### PR TITLE
feat: add ConversationSummaryMemory

### DIFF
--- a/packages/langchain/lib/src/memory/summary.dart
+++ b/packages/langchain/lib/src/memory/summary.dart
@@ -1,0 +1,208 @@
+import '../chains/chains.dart';
+import '../model_io/chat_models/models/models.dart';
+import '../model_io/chat_models/utils.dart';
+import '../model_io/language_models/language_models.dart';
+import '../model_io/prompts/prompts.dart';
+import 'base.dart';
+import 'chat.dart';
+import 'models/models.dart';
+import 'stores/message/history.dart';
+import 'stores/message/in_memory.dart';
+
+/// {@template conversation_summary_memory}
+/// Summarizer memory to store a conversation and then retrieving the messages
+/// the summary of the conversation at a later time.
+///
+/// It requires a language model to summarize the conversation.
+///
+/// It uses [ChatMessageHistory] as in-memory storage by default.
+///
+/// Example:
+/// ```dart
+/// final memory = ConversationSummaryMemory(llm: OpenAI(apiKey: '...'));
+/// await memory.saveContext({'foo': 'bar'}, {'bar': 'foo'});
+/// final res = await memory.loadMemoryVariables();
+/// // {'history': 'System: Human said bar'}
+/// ```
+/// {@endtemplate}
+final class ConversationSummaryMemory<
+    LLMInput extends Object,
+    LLMOptions extends LanguageModelOptions,
+    LLMOutput extends Object> extends BaseChatMemory {
+  /// {@macro conversation_summary_memory}
+  ConversationSummaryMemory({
+    super.chatHistory,
+    super.inputKey,
+    super.outputKey,
+    super.returnMessages = false,
+    required this.llm,
+    this.prompt = summaryPrompt,
+    this.memoryKey = BaseMemory.defaultMemoryKey,
+    this.systemPrefix = SystemChatMessage.defaultPrefix,
+    this.humanPrefix = HumanChatMessage.defaultPrefix,
+    this.aiPrefix = AIChatMessage.defaultPrefix,
+    this.functionPrefix = FunctionChatMessage.defaultPrefix,
+  });
+
+  /// Language model to use for counting tokens.
+  final BaseLanguageModel<LLMInput, LLMOptions, LLMOutput> llm;
+
+  /// [PromptTemplate] to use for summarizing previous conversations.
+  /// This currently expect two input variables: `summary` and `new_lines`.
+  /// summary is the previous summary and new_lines are the new messages
+  /// formated to add.
+  final BasePromptTemplate prompt;
+
+  /// Store the summarized chat history in memory.
+  /// This does not concatenate, changes every new [ChatMessage] are added.
+  String buffer = '';
+
+  /// The memory key to use for the chat history.
+  /// This will be passed as input variable to the prompt.
+  final String memoryKey;
+
+  /// The prefix to use for system messages.
+  final String systemPrefix;
+
+  /// The prefix to use for human messages.
+  final String humanPrefix;
+
+  /// The prefix to use for AI messages.
+  final String aiPrefix;
+
+  /// The prefix to use for function messages.
+  final String functionPrefix;
+
+  /// Default summarizer template to use for [ConversationSummaryMemory].
+  static const defaultSummarizerTemplate = '''
+Progressively summarize the lines of conversation provided, adding onto the previous summary returning a new summary.
+
+EXAMPLE
+Current summary:
+The human asks what the AI thinks of artificial intelligence. The AI thinks artificial intelligence is a force for good.
+
+New lines of conversation:
+Human: Why do you think artificial intelligence is a force for good?
+AI: Because artificial intelligence will help humans reach their full potential.
+
+New summary:
+The human asks what the AI thinks of artificial intelligence. The AI thinks artificial intelligence is a force for good because it will help humans reach their full potential.
+END OF EXAMPLE
+
+Current summary:
+{summary}
+
+New lines of conversation:
+{new_lines}
+
+New summary:''';
+
+  /// Default summarizer prompt to use for [ConversationSummaryMemory].
+  static const summaryPrompt = PromptTemplate(
+    inputVariables: {'summary', 'new_lines'},
+    template: defaultSummarizerTemplate,
+  );
+
+  @override
+  Set<String> get memoryKeys => {memoryKey};
+
+  /// Instantiate a [ConversationSummaryMemory] from a list of [ChatMessage]s.
+  /// Use this factory method if you want to generate a [ConversationSummaryMemory]
+  /// with pre-loaded history and don't have the summari of the messages.
+  /// Required a [BaseLanguageModel] to use for summarizing.
+  static Future<ConversationSummaryMemory> fromMessages({
+    required final BaseLanguageModel llm,
+    required final BaseChatMessageHistory chatHistory,
+    final String? inputKey,
+    final String? outputKey,
+    final bool returnMessages = false,
+    final PromptTemplate prompt = summaryPrompt,
+    final String memoryKey = BaseMemory.defaultMemoryKey,
+    final String systemPrefix = SystemChatMessage.defaultPrefix,
+    final String humanPrefix = HumanChatMessage.defaultPrefix,
+    final String aiPrefix = AIChatMessage.defaultPrefix,
+    final String functionPrefix = FunctionChatMessage.defaultPrefix,
+    final int summaryStep = 2,
+  }) async {
+    final memory = ConversationSummaryMemory(
+      chatHistory: chatHistory,
+      llm: llm,
+      inputKey: inputKey,
+      outputKey: outputKey,
+      returnMessages: returnMessages,
+      prompt: prompt,
+      memoryKey: memoryKey,
+      systemPrefix: systemPrefix,
+      humanPrefix: humanPrefix,
+      aiPrefix: aiPrefix,
+      functionPrefix: functionPrefix,
+    );
+    final messages = await chatHistory.getChatMessages();
+    for (var i = 0; i < messages.length; i += summaryStep) {
+      final summary = await memory.summarize(
+        messages.sublist(i, i + summaryStep),
+        memory.buffer,
+      );
+      memory.buffer = summary;
+    }
+    return memory;
+  }
+
+  Future<String> summarize(
+    final List<ChatMessage> messages,
+    final String currentSummary,
+  ) async {
+    final input = messages.toBufferString(
+      systemPrefix: systemPrefix,
+      humanPrefix: humanPrefix,
+      aiPrefix: aiPrefix,
+      functionPrefix: functionPrefix,
+    );
+    return LLMChain(llm: llm, prompt: prompt).run({
+      'new_lines': input,
+      'summary': currentSummary,
+    });
+  }
+
+  @override
+  Future<MemoryVariables> loadMemoryVariables([
+    final MemoryInputValues values = const {},
+  ]) async {
+    final messages = <ChatMessage>[];
+    if (buffer.isNotEmpty) {
+      messages.add(SystemChatMessage(content: buffer));
+    }
+
+    if (returnMessages) {
+      return {memoryKey: messages};
+    }
+    return {
+      memoryKey: messages.toBufferString(
+        systemPrefix: systemPrefix,
+        humanPrefix: humanPrefix,
+        aiPrefix: aiPrefix,
+        functionPrefix: functionPrefix,
+      ),
+    };
+  }
+
+  @override
+  Future<void> saveContext({
+    required final MemoryInputValues inputValues,
+    required final MemoryOutputValues outputValues,
+  }) async {
+    await super
+        .saveContext(inputValues: inputValues, outputValues: outputValues);
+    final messages = await chatHistory.getChatMessages();
+    buffer = await summarize(
+      messages.sublist(messages.length - 2),
+      buffer,
+    );
+  }
+
+  @override
+  Future<void> clear() async {
+    await super.clear();
+    buffer = '';
+  }
+}

--- a/packages/langchain/lib/src/memory/token_buffer.dart
+++ b/packages/langchain/lib/src/memory/token_buffer.dart
@@ -27,10 +27,8 @@ import 'stores/message/in_memory.dart';
 /// // {'history': 'Human: bar\nAI: foo'}
 /// ```
 /// {@endtemplate}
-final class ConversationTokenBufferMemory<
-    LLMInput extends Object,
-    LLMOptions extends LanguageModelOptions,
-    LLMOutput extends Object> extends BaseChatMemory {
+final class ConversationTokenBufferMemory<LLMType extends BaseLanguageModel>
+    extends BaseChatMemory {
   /// {@macro conversation_token_buffer_memory}
   ConversationTokenBufferMemory({
     super.chatHistory,
@@ -50,7 +48,7 @@ final class ConversationTokenBufferMemory<
   final int maxTokenLimit;
 
   /// Language model to use for counting tokens.
-  final BaseLanguageModel<LLMInput, LLMOptions, LLMOutput> llm;
+  final LLMType llm;
 
   /// The memory key to use for the chat history.
   /// This will be passed as input variable to the prompt.

--- a/packages/langchain/test/memory/summary_test.dart
+++ b/packages/langchain/test/memory/summary_test.dart
@@ -1,0 +1,189 @@
+import 'package:langchain/src/memory/memory.dart';
+import 'package:langchain/src/memory/summary.dart';
+import 'package:langchain/src/model_io/chat_models/chat_models.dart';
+import 'package:langchain/src/model_io/llms/fake.dart';
+import 'package:langchain/src/model_io/prompts/prompts.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ConversationSummaryMemory tests', () {
+    test('Test summary memory', () async {
+      final model = FakeHandlerLLM(
+        handler: (final prompt, final options, final callCount) {
+          switch (callCount) {
+            case 1:
+              expect(
+                prompt,
+                'Progressively summarize the lines of conversation provided, adding onto the previous summary returning a new summary.\n\n'
+                'EXAMPLE\n'
+                'Current summary:\n'
+                'The human asks what the AI thinks of artificial intelligence. The AI thinks artificial intelligence is a force for good.\n\n'
+                'New lines of conversation:\n'
+                'Human: Why do you think artificial intelligence is a force for good?\n'
+                'AI: Because artificial intelligence will help humans reach their full potential.\n\n'
+                'New summary:\n'
+                'The human asks what the AI thinks of artificial intelligence. The AI thinks artificial intelligence is a force for good because it will help humans reach their full potential.\n'
+                'END OF EXAMPLE\n\n'
+                'Current summary:\n\n'
+                '\n'
+                'New lines of conversation:\n'
+                'Human: bar\nAI: foo\n\n'
+                'New summary:',
+              );
+              return 'Human said foo';
+            default:
+              throw TestFailure('Unexpected call count: $callCount');
+          }
+        },
+      );
+      final memory = ConversationSummaryMemory(llm: model);
+      final result1 = await memory.loadMemoryVariables();
+      expect(result1, {'history': ''});
+
+      await memory.saveContext(
+        inputValues: {'foo': 'bar'},
+        outputValues: {'bar': 'foo'},
+      );
+      final result2 = await memory.loadMemoryVariables();
+      expect(result2, {'history': 'System: Human said foo'});
+    });
+
+    test('Test summary memory return system messages', () async {
+      final model = FakeHandlerLLM(
+        handler: (final prompt, final options, final callCount) {
+          switch (callCount) {
+            case 1:
+              expect(
+                prompt,
+                'Progressively summarize the lines of conversation provided, adding onto the previous summary returning a new summary.\n\n'
+                'EXAMPLE\n'
+                'Current summary:\n'
+                'The human asks what the AI thinks of artificial intelligence. The AI thinks artificial intelligence is a force for good.\n\n'
+                'New lines of conversation:\n'
+                'Human: Why do you think artificial intelligence is a force for good?\n'
+                'AI: Because artificial intelligence will help humans reach their full potential.\n\n'
+                'New summary:\n'
+                'The human asks what the AI thinks of artificial intelligence. The AI thinks artificial intelligence is a force for good because it will help humans reach their full potential.\n'
+                'END OF EXAMPLE\n\n'
+                'Current summary:\n\n'
+                '\n'
+                'New lines of conversation:\n'
+                'Human: bar\nAI: foo\n\n'
+                'New summary:',
+              );
+              return 'Human said foo';
+            case 2:
+              expect(
+                prompt,
+                'Progressively summarize the lines of conversation provided, adding onto the previous summary returning a new summary.\n\n'
+                'EXAMPLE\n'
+                'Current summary:\n'
+                'The human asks what the AI thinks of artificial intelligence. The AI thinks artificial intelligence is a force for good.\n\n'
+                'New lines of conversation:\n'
+                'Human: Why do you think artificial intelligence is a force for good?\n'
+                'AI: Because artificial intelligence will help humans reach their full potential.\n\n'
+                'New summary:\n'
+                'The human asks what the AI thinks of artificial intelligence. The AI thinks artificial intelligence is a force for good because it will help humans reach their full potential.\n'
+                'END OF EXAMPLE\n\n'
+                'Current summary:\nHuman said foo\n'
+                '\n'
+                'New lines of conversation:\n'
+                'Human: bar1\nAI: foo1\n\n'
+                'New summary:',
+              );
+              return 'Human said bar';
+            default:
+              throw TestFailure('Unexpected call count: $callCount');
+          }
+        },
+      );
+      final memory =
+          ConversationSummaryMemory(llm: model, returnMessages: true);
+      final result1 = await memory.loadMemoryVariables();
+      expect(result1, {'history': <ChatMessage>[]});
+
+      await memory.saveContext(
+        inputValues: {'foo': 'bar'},
+        outputValues: {'bar': 'foo'},
+      );
+      final expectedResult = [ChatMessage.system('Human said foo')];
+      final result2 = await memory.loadMemoryVariables();
+      expect(result2, {'history': expectedResult});
+
+      await memory.saveContext(
+        inputValues: {'foo': 'bar1'},
+        outputValues: {'bar': 'foo1'},
+      );
+
+      final expectedResult2 = [ChatMessage.system('Human said bar')];
+      final result3 = await memory.loadMemoryVariables();
+      expect(result3, {'history': expectedResult2});
+    });
+
+    test('Test buffer memory with pre-loaded history', () async {
+      const prompt = PromptTemplate(
+        inputVariables: {'summary', 'new_lines'},
+        template: 'Please summary {summary} with {new_lines}',
+      );
+      final model = FakeHandlerLLM(
+        handler: (final prompt, final options, final callCount) {
+          switch (callCount) {
+            case 1:
+              expect(
+                prompt,
+                "Please summary  with Human: My name's Jonas\nAI: Nice to meet you, Jonas!",
+              );
+              return 'Human said foo';
+            default:
+              throw TestFailure('Unexpected call count: $callCount');
+          }
+        },
+      );
+      final pastMessages = [
+        ChatMessage.human("My name's Jonas"),
+        ChatMessage.ai('Nice to meet you, Jonas!'),
+      ];
+      final memory = await ConversationSummaryMemory.fromMessages(
+        llm: model,
+        chatHistory: ChatMessageHistory(messages: pastMessages),
+        prompt: prompt,
+      );
+      final result = await memory.loadMemoryVariables();
+      expect(result, {'history': 'System: Human said foo'});
+    });
+
+    test('Test clear memory', () async {
+      const prompt = PromptTemplate(
+        inputVariables: {'summary', 'new_lines'},
+        template: 'Please summary {summary} with {new_lines}',
+      );
+      final model = FakeHandlerLLM(
+        handler: (final prompt, final options, final callCount) {
+          switch (callCount) {
+            case 1:
+              expect(
+                prompt,
+                'Please summary Human said bar with Human: bar\nAI: foo',
+              );
+              return 'Human said foo';
+            default:
+              throw TestFailure('Unexpected call count: $callCount');
+          }
+        },
+      );
+      final memory = ConversationSummaryMemory(llm: model, prompt: prompt)
+        ..buffer = 'Human said bar';
+      await memory.saveContext(
+        inputValues: {'foo': 'bar'},
+        outputValues: {'bar': 'foo'},
+      );
+      const expectedString = 'System: Human said foo';
+      final result1 = await memory.loadMemoryVariables();
+      expect(result1, {'history': expectedString});
+
+      await memory.clear();
+      final result2 = await memory.loadMemoryVariables();
+      expect(result2, {'history': ''});
+    });
+  });
+}


### PR DESCRIPTION
Adds support for ConversationSummaryMemory.
Some considerations:
- Store prompt text and the default prompt as a static default inside the memory class
- As the python package, it only support prompts using `summary` and `new_lines`. We could change this in the future ;)
- I did not use a factory to generate with previous messages as the the summarization is done async.

Issue: #27 
Dependencies: None
Maintainer @davidmigloz 

