### PR TITLE
fix(stores): variable k was not getting passed

### DIFF
--- a/packages/langchain/lib/src/documents/vector_stores/base.dart
+++ b/packages/langchain/lib/src/documents/vector_stores/base.dart
@@ -89,8 +89,8 @@ abstract class VectorStore {
     final int k = 4,
   }) {
     return switch (searchType) {
-      VectorStoreSearchType.similarity => similaritySearch(query: query),
-      VectorStoreSearchType.mmr => maxMarginalRelevanceSearch(query: query),
+      VectorStoreSearchType.similarity => similaritySearch(query: query, k: k),
+      VectorStoreSearchType.mmr => maxMarginalRelevanceSearch(query: query, k: k),
     };
   }
 


### PR DESCRIPTION
  - Description: I noticed always 4 documents were returned from search. Seems like it wasn't get passed to similaritySearch, maxMarginalRelevanceSearch.
  - Tag maintainer: @davidmigloz

Maintainer responsibilities:
  - General: @davidmigloz

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/davidmigloz/langchain_dart/blob/main/CONTRIBUTING.md

