### PR TITLE
fix(agent): openai function agent infinite loop issue

### DIFF
--- a/packages/langchain_openai/lib/src/agents/functions.dart
+++ b/packages/langchain_openai/lib/src/agents/functions.dart
@@ -247,13 +247,13 @@ class OpenAIFunctionsAgent extends BaseSingleActionAgent {
     return ChatPromptTemplate.fromPromptMessages([
       systemChatMessage,
       ...?extraPromptMessages,
+      for (final memoryKey in memory?.memoryKeys ?? {})
+        MessagesPlaceholder(variableName: memoryKey),
+      const MessagePlaceholder(variableName: agentInputKey),
       if (memory == null)
         const MessagesPlaceholder(
           variableName: BaseActionAgent.agentScratchpadInputKey,
         ),
-      for (final memoryKey in memory?.memoryKeys ?? {})
-        MessagesPlaceholder(variableName: memoryKey),
-      const MessagePlaceholder(variableName: agentInputKey),
     ]);
   }
 }


### PR DESCRIPTION
**Description**: The prompt of the default LLMChain(`OpenAIFunctionsAgent.fromLLMAndTools`) has a wrong order when no memory and causing infinite loop of function call.

**Issue**: infinite loop of function call with OpenAIFunctionsAgent

**Tag maintainer**:  @davidmigloz

**Background**:
When using `OpenAIFunctionsAgent.fromLLMAndTools` and `memory == null`, `createPrompt` will create prompt with the following order:
```
System
AgentScratchPad
Human
```
Even when the agent finishes the task, GPT appears to trigger the function repeatedly because the last message is a Human message.

Example of `promptValue` that calling infinite loop:
![Screenshot 2023-08-19 at 10 09 37 AM](https://github.com/davidmigloz/langchain_dart/assets/6364170/cba730db-c673-446e-8d0a-6e435520b4ef)

**Solution**:
I change the default order of `createPrompt` when no memory to the following and the issue is gone.
```
System
Human
AgentScratchPad
```
