### PR TITLE
refactor(memory)!: Rename VectorStoreRetrieverMemory

### DIFF
--- a/packages/langchain/lib/src/memory/vector_store.dart
+++ b/packages/langchain/lib/src/memory/vector_store.dart
@@ -2,12 +2,13 @@ import '../../langchain.dart';
 import 'utils.dart';
 
 /// {@template vector_store_retriever_memory}
-/// VectorStoreRetriever-backed memory.
+/// Memory backed by a vector store.
 /// {@endtemplate}
-class VectorStoreRetrieverMemory implements BaseMemory {
+class VectorStoreMemory implements BaseMemory {
   /// {@macro vector_store_retriever_memory}
-  VectorStoreRetrieverMemory({
-    required this.retriever,
+  VectorStoreMemory({
+    required this.vectorStore,
+    this.searchType = const VectorStoreSimilaritySearch(),
     this.memoryKey = defaultMemoryKey,
     this.inputKey,
     this.excludeInputKeys = const {},
@@ -15,7 +16,10 @@ class VectorStoreRetrieverMemory implements BaseMemory {
   });
 
   /// VectorStoreRetriever object to connect to.
-  final VectorStoreRetriever retriever;
+  final VectorStore vectorStore;
+
+  /// The type of search to perform.
+  final VectorStoreSearchType searchType;
 
   /// Name of the key where the memories are in the map returned by
   /// [loadMemoryVariables].
@@ -48,7 +52,7 @@ class VectorStoreRetrieverMemory implements BaseMemory {
   ]) async {
     final promptInputKey = inputKey ?? getPromptInputKey(values, memoryKeys);
     final query = values[promptInputKey];
-    final docs = await retriever.getRelevantDocuments(query);
+    final docs = await vectorStore.search(query: query, searchType: searchType);
     return {
       memoryKey: returnDocs
           ? docs
@@ -62,7 +66,7 @@ class VectorStoreRetrieverMemory implements BaseMemory {
     required final MemoryOutputValues outputValues,
   }) async {
     final docs = _buildDocuments(inputValues, outputValues);
-    await retriever.addDocuments(docs);
+    await vectorStore.addDocuments(documents: docs);
   }
 
   /// Builds the documents to save to the vector store from the given

--- a/packages/langchain/test/memory/vector_store_test.dart
+++ b/packages/langchain/test/memory/vector_store_test.dart
@@ -2,16 +2,16 @@ import 'package:langchain/langchain.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('VectorStoreRetrieverMemory tests', () {
+  group('VectorStoreMemory tests', () {
     test('Test vector store memory', () async {
       final embeddings = _FakeEmbeddings();
       final vectorStore = MemoryVectorStore(embeddings: embeddings);
-      final memory = VectorStoreRetrieverMemory(
-        retriever: vectorStore.asRetriever(),
+      final memory = VectorStoreMemory(
+        vectorStore: vectorStore,
       );
 
       final result1 = await memory.loadMemoryVariables({'input': 'foo'});
-      expect(result1[VectorStoreRetrieverMemory.defaultMemoryKey], '');
+      expect(result1[VectorStoreMemory.defaultMemoryKey], '');
 
       await memory.saveContext(
         inputValues: {
@@ -23,7 +23,7 @@ void main() {
       );
       final result2 = await memory.loadMemoryVariables({'input': 'foo'});
       expect(
-        result2[VectorStoreRetrieverMemory.defaultMemoryKey],
+        result2[VectorStoreMemory.defaultMemoryKey],
         'foo: bar\nbar: foo',
       );
     });
@@ -31,8 +31,8 @@ void main() {
     test('Test returnDocs', () async {
       final embeddings = _FakeEmbeddings();
       final vectorStore = MemoryVectorStore(embeddings: embeddings);
-      final memory = VectorStoreRetrieverMemory(
-        retriever: vectorStore.asRetriever(),
+      final memory = VectorStoreMemory(
+        vectorStore: vectorStore,
         returnDocs: true,
       );
 
@@ -47,7 +47,7 @@ void main() {
       final result = await memory.loadMemoryVariables({'input': 'foo'});
       const expectedDoc = Document(pageContent: 'foo: bar\nbar: foo');
       expect(
-        result[VectorStoreRetrieverMemory.defaultMemoryKey],
+        result[VectorStoreMemory.defaultMemoryKey],
         [expectedDoc],
       );
     });
@@ -55,13 +55,13 @@ void main() {
     test('Test excludeInputKeys', () async {
       final embeddings = _FakeEmbeddings();
       final vectorStore = MemoryVectorStore(embeddings: embeddings);
-      final memory = VectorStoreRetrieverMemory(
-        retriever: vectorStore.asRetriever(),
+      final memory = VectorStoreMemory(
+        vectorStore: vectorStore,
         excludeInputKeys: {'foo'},
       );
 
       final result1 = await memory.loadMemoryVariables({'input': 'foo'});
-      expect(result1[VectorStoreRetrieverMemory.defaultMemoryKey], '');
+      expect(result1[VectorStoreMemory.defaultMemoryKey], '');
 
       await memory.saveContext(
         inputValues: {
@@ -73,7 +73,7 @@ void main() {
       );
       final result2 = await memory.loadMemoryVariables({'input': 'foo'});
       expect(
-        result2[VectorStoreRetrieverMemory.defaultMemoryKey],
+        result2[VectorStoreMemory.defaultMemoryKey],
         'bar: foo',
       );
     });


### PR DESCRIPTION
VectorStoreRetrieverMemory is now called VectorStoreMemory and it takes a vector store instead of a VectorStoreRetriever.

Reason: I'm going to remove the `VectorStoreRetriever.addDocuments` method, as a retriever should only be able to fetch data, not write data as well.
