### PR TITLE
refactor(retrievers)!: Remove addDocuments from VectorStoreRetriever

### DIFF
--- a/packages/langchain/lib/src/documents/retrievers/vector_store.dart
+++ b/packages/langchain/lib/src/documents/retrievers/vector_store.dart
@@ -22,13 +22,4 @@ class VectorStoreRetriever<V extends VectorStore> implements BaseRetriever {
   Future<List<Document>> getRelevantDocuments(final String query) {
     return vectorStore.search(query: query, searchType: searchType);
   }
-
-  /// Runs more documents through the embeddings and add to the vector store.
-  ///
-  /// - [documents] is a list of documents to add to the vector store.
-  ///
-  /// Returns a list of ids from adding the documents into the vector store.
-  Future<List<String>> addDocuments(final List<Document> documents) {
-    return vectorStore.addDocuments(documents: documents);
-  }
 }

--- a/packages/langchain/lib/src/documents/vector_stores/base.dart
+++ b/packages/langchain/lib/src/documents/vector_stores/base.dart
@@ -16,34 +16,6 @@ abstract class VectorStore {
   /// The embeddings model used to embed documents.
   final Embeddings embeddings;
 
-  /// Creates a vector store from a list of texts.
-  ///
-  /// - [texts] is a list of texts to add to the vector store.
-  /// - [metadatas] is a list of metadata to add to the vector store.
-  /// - [embeddings] is the embeddings model to use to embed the texts.
-  factory VectorStore.fromText({
-    required final List<String> texts,
-    required final List<Map<String, dynamic>> metadatas,
-    required final Embeddings embeddings,
-  }) {
-    throw UnimplementedError(
-      'Use the fromText method on a specific vector store.',
-    );
-  }
-
-  /// Creates a vector store from a list of documents.
-  ///
-  /// - [documents] is a list of documents to add to the vector store.
-  /// - [embeddings] is the embeddings model to use to embed the documents.
-  factory VectorStore.fromDocuments({
-    required final List<Document> documents,
-    required final Embeddings embeddings,
-  }) {
-    throw UnimplementedError(
-      'Use the fromDocuments method on a specific vector store.',
-    );
-  }
-
   /// Runs more documents through the embeddings and add to the vector store.
   ///
   /// - [documents] is a list of documents to add to the vector store.


### PR DESCRIPTION
A retriever should only be able to fetch data, not write data as well.