### PR TITLE
feat(vertex_ai): Support task type and title in embeddings models

### DIFF
--- a/packages/vertex_ai/README.md
+++ b/packages/vertex_ai/README.md
@@ -99,7 +99,12 @@ like semantic search, recommendation, classification, and outlier detection.
 
 ```dart
 final res = await vertexAi.textEmbeddings.predict(
-  content: ['The only true wisdom is in knowing you know nothing.'],
+  content: [
+    const VertexAITextEmbeddingsModelContent(
+      taskType: VertexAITextEmbeddingsModelTaskType.retrievalDocument,
+      title: 'The Paradox of Wisdom',
+      content: 'The only true wisdom is in knowing you know nothing',
+    ),
 );
 ```
 

--- a/packages/vertex_ai/lib/src/gen_ai/apis/text.dart
+++ b/packages/vertex_ai/lib/src/gen_ai/apis/text.dart
@@ -8,6 +8,19 @@ import '../models/models.dart';
 ///
 /// Documentation:
 /// https://cloud.google.com/vertex-ai/docs/generative-ai/text/text-overview
+///
+/// Supported models:
+/// - `text-bison`
+///   * Max input token: 8192
+///   * Max output tokens: 1024
+///   * Training data: Up to Feb 2023
+/// - `text-bison-32k`
+///   * Max input and output tokens combined: 32k
+///   * Training data: Up to Aug 2023
+///
+/// The previous list of models may not be exhaustive or up-to-date. Check out
+/// the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models)
+/// for the latest list of available models.
 /// {@endtemplate}
 class VertexAITextModelApi {
   /// {@macro vertex_ai_text_model_api}

--- a/packages/vertex_ai/lib/src/gen_ai/apis/text_chat.dart
+++ b/packages/vertex_ai/lib/src/gen_ai/apis/text_chat.dart
@@ -8,6 +8,21 @@ import '../models/models.dart';
 ///
 /// Documentation:
 /// https://cloud.google.com/vertex-ai/docs/generative-ai/chat/test-chat-prompts
+///
+/// Supported models:
+/// - `chat-bison`
+///   * Max input token: 4096
+///   * Max output tokens: 1024
+///   * Training data: Up to Feb 2023
+///   * Max turns: 2500
+/// - `chat-bison-32k`
+///   * Max input and output tokens combined: 32k
+///   * Training data: Up to Aug 2023
+///   * Max turns: 2500
+///
+/// The previous list of models may not be exhaustive or up-to-date. Check out
+/// the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models)
+/// for the latest list of available models.
 /// {@endtemplate}
 class VertexAITextChatModelApi {
   /// {@macro vertex_ai_text_chat_model_api}

--- a/packages/vertex_ai/lib/src/gen_ai/apis/text_embeddings.dart
+++ b/packages/vertex_ai/lib/src/gen_ai/apis/text_embeddings.dart
@@ -8,6 +8,18 @@ import '../models/models.dart';
 ///
 /// Documentation:
 /// https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings
+///
+/// Supported models:
+/// - `textembedding-gecko`
+///   * Max input token: 3072
+///   * Output: 768-dimensional vector embeddings
+/// - `textembedding-gecko-multilingual`
+///   * Max input token: 3072
+///   * Output: 768-dimensional vector embeddings
+///
+/// The previous list of models may not be exhaustive or up-to-date. Check out
+/// the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models)
+/// for the latest list of available models.
 /// {@endtemplate}
 class VertexAITextEmbeddingsModelApi {
   /// {@macro vertex_ai_text_embeddings_model_api}
@@ -40,7 +52,7 @@ class VertexAITextEmbeddingsModelApi {
   /// API documentation:
   /// https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.publishers.models/predict
   Future<VertexAITextEmbeddingsModelResponse> predict({
-    required final List<String> content,
+    required final List<VertexAITextEmbeddingsModelContent> content,
     final String publisher = 'google',
     final String model = 'textembedding-gecko',
   }) async {

--- a/packages/vertex_ai/lib/src/gen_ai/mappers/text_embeddings.dart
+++ b/packages/vertex_ai/lib/src/gen_ai/mappers/text_embeddings.dart
@@ -9,7 +9,7 @@ class VertexAITextEmbeddingsModelGoogleApisMapper {
   ) {
     return GoogleCloudAiplatformV1PredictRequest(
       instances: [
-        for (final c in request.content) {'content': c},
+        for (final c in request.content) c.toMap(),
       ],
     );
   }

--- a/packages/vertex_ai/lib/src/gen_ai/models/text_embeddings.dart
+++ b/packages/vertex_ai/lib/src/gen_ai/models/text_embeddings.dart
@@ -11,25 +11,124 @@ class VertexAITextEmbeddingsModelRequest {
     required this.content,
   });
 
-  /// The text that you want to generate embeddings for.
+  /// The content you want to generate embeddings for.
   ///
-  /// There is a limit of up to 5 input texts per request.
-  final List<String> content;
+  /// There is a limit of up to 5 items per request.
+  final List<VertexAITextEmbeddingsModelContent> content;
 
   @override
   bool operator ==(covariant final VertexAITextEmbeddingsModelRequest other) =>
       identical(this, other) ||
       runtimeType == other.runtimeType &&
-          const ListEquality<String>().equals(content, other.content);
+          const ListEquality<VertexAITextEmbeddingsModelContent>().equals(
+            content,
+            other.content,
+          );
 
   @override
-  int get hashCode => const ListEquality<String>().hash(content);
+  int get hashCode =>
+      const ListEquality<VertexAITextEmbeddingsModelContent>().hash(content);
 
   @override
   String toString() {
     return 'VertexAITextEmbeddingsModelRequest{'
         'content: $content}';
   }
+}
+
+/// {@template vertex_ai_text_embeddings_model_content}
+/// The content to embed.
+/// {@endtemplate}
+@immutable
+class VertexAITextEmbeddingsModelContent {
+  /// {@macro vertex_ai_text_embeddings_model_content}
+  const VertexAITextEmbeddingsModelContent({
+    this.taskType,
+    this.title,
+    required this.content,
+  }) : assert(
+          title == null ||
+              taskType == VertexAITextEmbeddingsModelTaskType.retrievalDocument,
+          'title can only be used with retrievalDocument taskType',
+        );
+
+  /// Type of task where the embeddings will be used.
+  /// It helps the model produce better quality embeddings.
+  ///
+  /// Note: only supported in models released in or after August 2023. Check
+  /// out [Models versions and lifecycle](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/model-versioning)
+  /// for more information.
+  final VertexAITextEmbeddingsModelTaskType? taskType;
+
+  /// Optional title of the document to embed.
+  ///
+  /// Only valid with [taskType] set to [VertexAITextEmbeddingsModelTaskType.retrievalDocument].
+  ///
+  /// Note: only supported in models released in or after August 2023. Check
+  /// out [Models versions and lifecycle](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/model-versioning)
+  /// for more information.
+  final String? title;
+
+  /// The text that you want to generate embeddings for.
+  final String content;
+
+  /// Converts this content to a JSON map.
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      if (taskType != null)
+        'task_type': switch (taskType!) {
+          VertexAITextEmbeddingsModelTaskType.retrievalQuery =>
+            'RETRIEVAL_QUERY',
+          VertexAITextEmbeddingsModelTaskType.retrievalDocument =>
+            'RETRIEVAL_DOCUMENT',
+          VertexAITextEmbeddingsModelTaskType.semanticSimilarity =>
+            'SEMANTIC_SIMILARITY',
+          VertexAITextEmbeddingsModelTaskType.classification =>
+            'CLASSIFICATION',
+          VertexAITextEmbeddingsModelTaskType.clustering => 'CLUSTERING',
+        },
+      if (title != null) 'title': title,
+      'content': content,
+    };
+  }
+
+  @override
+  bool operator ==(covariant final VertexAITextEmbeddingsModelContent other) =>
+      identical(this, other) ||
+      runtimeType == other.runtimeType &&
+          taskType == other.taskType &&
+          title == other.title &&
+          content == other.content;
+
+  @override
+  int get hashCode => taskType.hashCode ^ title.hashCode ^ content.hashCode;
+
+  @override
+  String toString() {
+    return 'VertexAITextEmbeddingsModelContent{'
+        'taskType: $taskType, '
+        'title: $title, '
+        'content: $content}';
+  }
+}
+
+/// Type of task where the embeddings will be used.
+/// It helps the model produce better quality embeddings.
+enum VertexAITextEmbeddingsModelTaskType {
+  /// Specifies the given text is a query in a search/retrieval setting.
+  retrievalQuery,
+
+  /// Specifies the given text is a document in a search/retrieval setting.
+  retrievalDocument,
+
+  /// Specifies the given text will be used for Semantic Textual Similarity.
+  semanticSimilarity,
+
+  /// Specifies that the embeddings will be used for classification.
+  classification,
+
+  /// Specifies that the embeddings will be used for clustering.
+  clustering,
 }
 
 /// {@template vertex_ai_text_embeddings_model_response}

--- a/packages/vertex_ai/test/gen_ai/gen_ai_client_test.dart
+++ b/packages/vertex_ai/test/gen_ai/gen_ai_client_test.dart
@@ -17,55 +17,79 @@ void main() async {
 
   group('VertexAIGenAIClient tests', () {
     test('Test VertexAITextModelApi', () async {
-      final res = await vertexAi.text.predict(
-        prompt:
-            'List the numbers from 1 to 9 in order without any spaces or commas.',
-      );
-      expect(res.predictions.first.content, contains('123456789'));
-      expect(res.predictions.first.safetyAttributes.blocked, isFalse);
-      expect(res.metadata.token.inputTotalTokens, greaterThan(0));
-      expect(res.metadata.token.outputTotalTokens, greaterThan(0));
+      final models = ['text-bison', 'text-bison-32k'];
+
+      for (final model in models) {
+        final res = await vertexAi.text.predict(
+          model: model,
+          prompt:
+              'List the numbers from 1 to 9 in order without any spaces or commas.',
+        );
+        expect(res.predictions.first.content, contains('123456789'));
+        expect(res.predictions.first.safetyAttributes.blocked, isFalse);
+        expect(res.metadata.token.inputTotalTokens, greaterThan(0));
+        expect(res.metadata.token.outputTotalTokens, greaterThan(0));
+      }
     });
 
     test('Test VertexAIChatModelApi', () async {
-      final res = await vertexAi.chat.predict(
-        context: 'Only output numeric characters.',
-        examples: const [
-          VertexAITextChatModelExample(
-            input: VertexAITextChatModelMessage(
+      final models = ['chat-bison', 'chat-bison-32k'];
+
+      for (final model in models) {
+        final res = await vertexAi.chat.predict(
+          model: model,
+          context: 'Only output numeric characters.',
+          examples: const [
+            VertexAITextChatModelExample(
+              input: VertexAITextChatModelMessage(
+                author: 'USER',
+                content: 'List the numbers from 1 to 3',
+              ),
+              output: VertexAITextChatModelMessage(
+                author: 'AI',
+                content: '123',
+              ),
+            ),
+          ],
+          messages: const [
+            VertexAITextChatModelMessage(
               author: 'USER',
-              content: 'List the numbers from 1 to 3',
+              content: 'List the numbers from 1 to 9',
             ),
-            output: VertexAITextChatModelMessage(
-              author: 'AI',
-              content: '123',
-            ),
-          ),
-        ],
-        messages: const [
-          VertexAITextChatModelMessage(
-            author: 'USER',
-            content: 'List the numbers from 1 to 9',
-          ),
-        ],
-      );
-      expect(
-        res.predictions.first.candidates.first.content,
-        contains('123456789'),
-      );
-      expect(res.predictions.first.safetyAttributes.first.blocked, isFalse);
-      expect(res.metadata.token.inputTotalTokens, greaterThan(0));
-      expect(res.metadata.token.outputTotalTokens, greaterThan(0));
+          ],
+        );
+        expect(
+          res.predictions.first.candidates.first.content,
+          contains('123456789'),
+        );
+        expect(res.predictions.first.safetyAttributes.first.blocked, isFalse);
+        expect(res.metadata.token.inputTotalTokens, greaterThan(0));
+        expect(res.metadata.token.outputTotalTokens, greaterThan(0));
+      }
     });
 
     test('Test VertexAITextEmbeddingsModelApi', () async {
-      final res = await vertexAi.textEmbeddings.predict(
-        content: ['Embedding text'],
-      );
-      expect(res.predictions.first.values, hasLength(768));
-      expect(res.predictions.first.statistics.truncated, isFalse);
-      expect(res.predictions.first.statistics.tokenCount, greaterThan(1));
-      expect(res.metadata.billableCharacterCount, greaterThan(1));
+      final models = [
+        'textembedding-gecko@latest',
+        'textembedding-gecko-multilingual@latest',
+      ];
+
+      for (final model in models) {
+        final res = await vertexAi.textEmbeddings.predict(
+          model: model,
+          content: [
+            const VertexAITextEmbeddingsModelContent(
+              taskType: VertexAITextEmbeddingsModelTaskType.retrievalDocument,
+              title: 'Embedding title',
+              content: 'Embedding text',
+            ),
+          ],
+        );
+        expect(res.predictions.first.values, hasLength(768));
+        expect(res.predictions.first.statistics.truncated, isFalse);
+        expect(res.predictions.first.statistics.tokenCount, greaterThan(1));
+        expect(res.metadata.billableCharacterCount, greaterThan(1));
+      }
     });
   });
 }

--- a/packages/vertex_ai/test/gen_ai/mappers/text_embeddings_test.dart
+++ b/packages/vertex_ai/test/gen_ai/mappers/text_embeddings_test.dart
@@ -8,20 +8,52 @@ void main() {
     test('VertexAITextEmbeddingsModelGoogleApisMapper.mapRequest', () {
       const request = VertexAITextEmbeddingsModelRequest(
         content: [
-          'CONTENT 1',
-          'CONTENT 2',
-          'CONTENT 3',
-          'CONTENT 4',
-          'CONTENT 5',
+          VertexAITextEmbeddingsModelContent(
+            taskType: VertexAITextEmbeddingsModelTaskType.retrievalDocument,
+            title: 'TITLE 1',
+            content: 'CONTENT 1',
+          ),
+          VertexAITextEmbeddingsModelContent(
+            taskType: VertexAITextEmbeddingsModelTaskType.retrievalQuery,
+            content: 'CONTENT 2',
+          ),
+          VertexAITextEmbeddingsModelContent(
+            taskType: VertexAITextEmbeddingsModelTaskType.semanticSimilarity,
+            content: 'CONTENT 3',
+          ),
+          VertexAITextEmbeddingsModelContent(
+            taskType: VertexAITextEmbeddingsModelTaskType.classification,
+            content: 'CONTENT 4',
+          ),
+          VertexAITextEmbeddingsModelContent(
+            taskType: VertexAITextEmbeddingsModelTaskType.clustering,
+            content: 'CONTENT 5',
+          ),
         ],
       );
       final expected = GoogleCloudAiplatformV1PredictRequest(
         instances: [
-          {'content': 'CONTENT 1'},
-          {'content': 'CONTENT 2'},
-          {'content': 'CONTENT 3'},
-          {'content': 'CONTENT 4'},
-          {'content': 'CONTENT 5'},
+          {
+            'task_type': 'RETRIEVAL_DOCUMENT',
+            'title': 'TITLE 1',
+            'content': 'CONTENT 1',
+          },
+          {
+            'task_type': 'RETRIEVAL_QUERY',
+            'content': 'CONTENT 2',
+          },
+          {
+            'task_type': 'SEMANTIC_SIMILARITY',
+            'content': 'CONTENT 3',
+          },
+          {
+            'task_type': 'CLASSIFICATION',
+            'content': 'CONTENT 4',
+          },
+          {
+            'task_type': 'CLUSTERING',
+            'content': 'CONTENT 5',
+          },
         ],
       );
 


### PR DESCRIPTION
The embeddings API now support a "task type" parameter to define the kind of task the embedding will be used for to help the model produce better quality embeddings.

- RETRIEVAL_QUERY: Specifies the given text is a query in a search/retrieval setting.
- RETRIEVAL_DOCUMENT: Specifies the given text is a document in a search/retrieval setting.
- SEMANTIC_SIMILARITY: Specifies the given text will be used for Semantic Textual Similarity (STS).
- CLASSIFICATION: Specifies that the embeddings will be used for classification.
- CLUSTERING: Specifies that the embeddings will be used for clustering.

For RETRIEVAL_DOCUMENT task, a "title" parameter can also be attached.

These two new parameters are only supported in models released in or after August 2023.

Docs:
https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings#api_changes_to_models_released_in_or_after_august_2023
