### PR TITLE
feat(vertex_ai): Add support for stopSequence and candidateCount

### DIFF
--- a/packages/vertex_ai/lib/src/gen_ai/models/text.dart
+++ b/packages/vertex_ai/lib/src/gen_ai/models/text.dart
@@ -52,6 +52,8 @@ class VertexAITextModelRequestParams {
     this.maxOutputTokens = 1024,
     this.topP = 0.95,
     this.topK = 40,
+    this.stopSequence = const [],
+    this.candidateCount = 1,
   });
 
   /// The temperature is used for sampling during response generation, which
@@ -108,6 +110,15 @@ class VertexAITextModelRequestParams {
   /// Range: `[1, 40]`
   final int topK;
 
+  /// Specifies a list of strings that tells the model to stop generating text
+  /// if one of the strings is encountered in the response. If a string appears
+  /// multiple times in the response, then the response truncates where it's
+  /// first encountered. The strings are case-sensitive.
+  final List<String> stopSequence;
+
+  /// The number of response variations to return.
+  final int candidateCount;
+
   /// Converts this object to a [Map].
   Map<String, dynamic> toMap() {
     return {
@@ -115,6 +126,8 @@ class VertexAITextModelRequestParams {
       'maxOutputTokens': maxOutputTokens,
       'topP': topP,
       'topK': topK,
+      'stopSequence': stopSequence,
+      'candidateCount': candidateCount,
     };
   }
 
@@ -125,14 +138,21 @@ class VertexAITextModelRequestParams {
           temperature == other.temperature &&
           maxOutputTokens == other.maxOutputTokens &&
           topP == other.topP &&
-          topK == other.topK;
+          topK == other.topK &&
+          const ListEquality<String>().equals(
+            stopSequence,
+            other.stopSequence,
+          ) &&
+          candidateCount == other.candidateCount;
 
   @override
   int get hashCode =>
       temperature.hashCode ^
       maxOutputTokens.hashCode ^
       topP.hashCode ^
-      topK.hashCode;
+      topK.hashCode ^
+      const ListEquality<String>().hash(stopSequence) ^
+      candidateCount.hashCode;
 
   @override
   String toString() {
@@ -140,7 +160,9 @@ class VertexAITextModelRequestParams {
         'temperature: $temperature, '
         'maxOutputTokens: $maxOutputTokens, '
         'topP: $topP, '
-        'topK: $topK}';
+        'topK: $topK, '
+        'stopSequence: $stopSequence, '
+        'candidateCount: $candidateCount}';
   }
 }
 

--- a/packages/vertex_ai/lib/src/gen_ai/models/text_chat.dart
+++ b/packages/vertex_ai/lib/src/gen_ai/models/text_chat.dart
@@ -98,6 +98,8 @@ class VertexAITextChatModelRequestParams {
     this.maxOutputTokens = 1024,
     this.topP = 0.95,
     this.topK = 40,
+    this.stopSequence = const [],
+    this.candidateCount = 1,
   });
 
   /// The temperature is used for sampling during response generation, which
@@ -154,6 +156,15 @@ class VertexAITextChatModelRequestParams {
   /// Range: `[1, 40]`
   final int topK;
 
+  /// Specifies a list of strings that tells the model to stop generating text
+  /// if one of the strings is encountered in the response. If a string appears
+  /// multiple times in the response, then the response truncates where it's
+  /// first encountered. The strings are case-sensitive.
+  final List<String> stopSequence;
+
+  /// The number of response variations to return.
+  final int candidateCount;
+
   /// Converts this object to a [Map].
   Map<String, dynamic> toMap() {
     return {
@@ -161,6 +172,8 @@ class VertexAITextChatModelRequestParams {
       'maxOutputTokens': maxOutputTokens,
       'topP': topP,
       'topK': topK,
+      'stopSequence': stopSequence,
+      'candidateCount': candidateCount,
     };
   }
 
@@ -171,14 +184,21 @@ class VertexAITextChatModelRequestParams {
           temperature == other.temperature &&
           maxOutputTokens == other.maxOutputTokens &&
           topP == other.topP &&
-          topK == other.topK;
+          topK == other.topK &&
+          const ListEquality<String>().equals(
+            stopSequence,
+            other.stopSequence,
+          ) &&
+          candidateCount == other.candidateCount;
 
   @override
   int get hashCode =>
       temperature.hashCode ^
       maxOutputTokens.hashCode ^
       topP.hashCode ^
-      topK.hashCode;
+      topK.hashCode ^
+      const ListEquality<String>().hash(stopSequence) ^
+      candidateCount.hashCode;
 
   @override
   String toString() {
@@ -186,7 +206,9 @@ class VertexAITextChatModelRequestParams {
         'temperature: $temperature, '
         'maxOutputTokens: $maxOutputTokens, '
         'topP: $topP, '
-        'topK: $topK}';
+        'topK: $topK, '
+        'stopSequence: $stopSequence, '
+        'candidateCount: $candidateCount}';
   }
 }
 

--- a/packages/vertex_ai/test/gen_ai/mappers/chat_test.dart
+++ b/packages/vertex_ai/test/gen_ai/mappers/chat_test.dart
@@ -31,6 +31,8 @@ void main() {
           maxOutputTokens: 256,
           topP: 0.1,
           topK: 30,
+          stopSequence: ['STOP'],
+          candidateCount: 10,
         ),
       );
       final expected = GoogleCloudAiplatformV1PredictRequest(
@@ -62,6 +64,8 @@ void main() {
           'maxOutputTokens': 256,
           'topP': 0.1,
           'topK': 30,
+          'stopSequence': ['STOP'],
+          'candidateCount': 10,
         },
       );
 

--- a/packages/vertex_ai/test/gen_ai/mappers/text_test.dart
+++ b/packages/vertex_ai/test/gen_ai/mappers/text_test.dart
@@ -13,6 +13,8 @@ void main() {
           maxOutputTokens: 256,
           topP: 0.1,
           topK: 30,
+          stopSequence: ['STOP'],
+          candidateCount: 10,
         ),
       );
       final expected = GoogleCloudAiplatformV1PredictRequest(
@@ -26,6 +28,8 @@ void main() {
           'maxOutputTokens': 256,
           'topP': 0.1,
           'topK': 30,
+          'stopSequence': ['STOP'],
+          'candidateCount': 10,
         },
       );
 


### PR DESCRIPTION
Ref:
- https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text
- https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-chat

(Although the don't seem to be taken into account by the current models yet)