### PR TITLE
feat(embeddings): Support task type in VertexAI embeddings models

### DIFF
--- a/packages/langchain_google/lib/src/chat_models/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai.dart
@@ -67,6 +67,22 @@ import 'models/models.dart';
 ///   constant `ChatVertexAI.cloudPlatformScope`)
 ///
 /// See: https://cloud.google.com/vertex-ai/docs/generative-ai/access-control
+///
+/// ## Available models
+///
+/// - `chat-bison`
+///   * Max input token: 4096
+///   * Max output tokens: 1024
+///   * Training data: Up to Feb 2023
+///   * Max turns: 2500
+/// - `chat-bison-32k`
+///   * Max input and output tokens combined: 32k
+///   * Training data: Up to Aug 2023
+///   * Max turns: 2500
+///
+/// The previous list of models may not be exhaustive or up-to-date. Check out
+/// the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models)
+/// for the latest list of available models.
 /// {@endtemplate}
 class ChatVertexAI extends BaseChatModel<ChatVertexAIOptions> {
   /// {@macro chat_vertex_ai}

--- a/packages/langchain_google/lib/src/llms/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai.dart
@@ -67,6 +67,20 @@ import 'models/models.dart';
 ///   constant `VertexAI.cloudPlatformScope`)
 ///
 /// See: https://cloud.google.com/vertex-ai/docs/generative-ai/access-control
+///
+/// ## Available models
+///
+/// - `text-bison`
+///   * Max input token: 8192
+///   * Max output tokens: 1024
+///   * Training data: Up to Feb 2023
+/// - `text-bison-32k`
+///   * Max input and output tokens combined: 32k
+///   * Training data: Up to Aug 2023
+///
+/// The previous list of models may not be exhaustive or up-to-date. Check out
+/// the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models)
+/// for the latest list of available models.
 /// {@endtemplate}
 class VertexAI extends BaseLLM<VertexAIOptions> {
   /// {@macro vertex_ai}


### PR DESCRIPTION
VertexAI embeddings models released in August support a new "task type" parameter that indicates the kind of task the embeddings is going to be used for, this helps the model produce better quality embeddings.

If you are using a model that supports it, LangChain.dart will use 'RETRIEVAL_DOCUMENT' when embedding a document and 'RETRIEVAL_QUERY' when embedding a query.

Docs:
https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings#api_changes_to_models_released_in_or_after_august_2023