### PR TITLE
refactor(vertex_ai): Require `http.Client` instead of `AuthClient`

### DIFF
--- a/examples/vertex_ai_matching_engine_setup/bin/vertex_ai_matching_engine_setup.dart
+++ b/examples/vertex_ai_matching_engine_setup/bin/vertex_ai_matching_engine_setup.dart
@@ -41,7 +41,7 @@ void main(final List<String> arguments) async {
   // Get Vertex AI client
   print('\n> Creating client...');
   final marchingEngine = VertexAIMatchingEngineClient(
-    authHttpClient: authClient,
+    httpClient: authClient,
     project: projectId,
     location: projectLocation,
   );
@@ -127,7 +127,7 @@ void main(final List<String> arguments) async {
   print('You can now use it in LangChain.dart:');
   print('''
 final vectorStore = VertexAIMatchingEngine(
-  authHttpClient: authClient,
+  httpClient: authClient,
   project: '$projectId',
   location: '$projectLocation',
   queryRootUrl: 'http://${indexEndpoint.publicEndpointDomainName}/',

--- a/packages/langchain_google/example/langchain_google_example.dart
+++ b/packages/langchain_google/example/langchain_google_example.dart
@@ -15,7 +15,7 @@ void main() async {
 /// The most basic building block of LangChain is calling an LLM on some input.
 Future<void> _example1() async {
   final openai = VertexAI(
-    authHttpClient: await _getAuthHttpClient(),
+    httpClient: await _getAuthHttpClient(),
     project: _getProjectId(),
     defaultOptions: const VertexAIOptions(
       temperature: 0.9,
@@ -29,7 +29,7 @@ Future<void> _example1() async {
 /// This is the most basic one.
 Future<void> _example2() async {
   final chat = ChatVertexAI(
-    authHttpClient: await _getAuthHttpClient(),
+    httpClient: await _getAuthHttpClient(),
     project: _getProjectId(),
     defaultOptions: const ChatVertexAIOptions(
       temperature: 0,

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai.dart
@@ -1,4 +1,4 @@
-import 'package:googleapis_auth/googleapis_auth.dart';
+import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:tiktoken/tiktoken.dart';
 import 'package:vertex_ai/vertex_ai.dart';
@@ -30,12 +30,11 @@ import 'models/models.dart';
 ///
 /// ### Authentication
 ///
-/// The `ChatVertexAI` wrapper delegates authentication to the
-/// [googleapis_auth](https://pub.dev/packages/googleapis_auth) package.
-///
 /// To create an instance of `ChatVertexAI` you need to provide an
-/// [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
-/// instance.
+/// HTTP client that handles authentication. The easiest way to do this is to
+/// use [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
+/// from the [googleapis_auth](https://pub.dev/packages/googleapis_auth)
+/// package.
 ///
 /// There are several ways to obtain an `AuthClient` depending on your use case.
 /// Check out the [googleapis_auth](https://pub.dev/packages/googleapis_auth)
@@ -52,7 +51,7 @@ import 'models/models.dart';
 ///   [ChatVertexAI.cloudPlatformScope],
 /// );
 /// final chatVertexAi = ChatVertexAI(
-///   authHttpClient: authClient,
+///   httpClient: authClient,
 ///   project: 'your-project-id',
 /// );
 /// ```
@@ -95,7 +94,7 @@ import 'models/models.dart';
 /// Example:
 /// ```dart
 /// final chatModel = ChatVertexAI(
-///   authHttpClient: authClient,
+///   httpClient: authClient,
 ///   project: 'your-project-id',
 ///   defaultOptions: ChatVertexAIOptions(
 ///     temperature: 0.9,
@@ -112,18 +111,18 @@ import 'models/models.dart';
 class ChatVertexAI extends BaseChatModel<ChatVertexAIOptions> {
   /// {@macro chat_vertex_ai}
   ChatVertexAI({
-    required final AuthClient authHttpClient,
+    required final http.Client httpClient,
     required final String project,
     final String location = 'us-central1',
-    final String rootUrl = 'https://us-central1-aiplatform.googleapis.com/',
+    final String? rootUrl,
     this.publisher = 'google',
     this.model = 'chat-bison',
     this.defaultOptions = const ChatVertexAIOptions(),
   }) : client = VertexAIGenAIClient(
-          authHttpClient: authHttpClient,
+          httpClient: httpClient,
           project: project,
           location: location,
-          rootUrl: rootUrl,
+          rootUrl: rootUrl ?? 'https://$location-aiplatform.googleapis.com/',
         );
 
   /// A client for interacting with Vertex AI API.

--- a/packages/langchain_google/lib/src/embeddings/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/embeddings/vertex_ai.dart
@@ -1,4 +1,4 @@
-import 'package:googleapis_auth/googleapis_auth.dart';
+import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:vertex_ai/vertex_ai.dart';
 
@@ -8,7 +8,7 @@ import 'package:vertex_ai/vertex_ai.dart';
 /// Example:
 /// ```dart
 /// final embeddings = VertexAIEmbeddings(
-///   authHttpClient: authClient,
+///   httpClient: authClient,
 ///   project: 'your-project-id',
 /// );
 /// final result = await embeddings.embedQuery('Hello world');
@@ -26,8 +26,11 @@ import 'package:vertex_ai/vertex_ai.dart';
 ///
 /// ### Authentication
 ///
-/// The `VertexAIEmbeddings` wrapper delegates authentication to the
-/// [googleapis_auth](https://pub.dev/packages/googleapis_auth) package.
+/// To create an instance of `VertexAIEmbeddings` you need to provide an
+/// HTTP client that handles authentication. The easiest way to do this is to
+/// use [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
+/// from the [googleapis_auth](https://pub.dev/packages/googleapis_auth)
+/// package.
 ///
 /// To create an instance of `VertexAIEmbeddings` you need to provide an
 /// [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
@@ -48,7 +51,7 @@ import 'package:vertex_ai/vertex_ai.dart';
 ///   [VertexAIEmbeddings.cloudPlatformScope],
 /// );
 /// final vertexAi = VertexAIEmbeddings(
-///   authHttpClient: authClient,
+///   httpClient: authClient,
 ///   project: 'your-project-id',
 /// );
 /// ```
@@ -99,7 +102,7 @@ import 'package:vertex_ai/vertex_ai.dart';
 /// Example:
 /// ```dart
 /// final embeddings = VertexAIEmbeddings(
-///   authHttpClient: authClient,
+///   httpClient: authClient,
 ///   project: 'your-project-id',
 ///   docTitleKey: 'title',
 /// );
@@ -114,19 +117,19 @@ import 'package:vertex_ai/vertex_ai.dart';
 class VertexAIEmbeddings implements Embeddings {
   /// {@macro vertex_ai_embeddings}
   VertexAIEmbeddings({
-    required final AuthClient authHttpClient,
+    required final http.Client httpClient,
     required final String project,
     final String location = 'us-central1',
-    final String rootUrl = 'https://us-central1-aiplatform.googleapis.com/',
+    final String? rootUrl,
     this.publisher = 'google',
     this.model = 'textembedding-gecko',
     this.batchSize = 5,
     this.docTitleKey = 'title',
   }) : client = VertexAIGenAIClient(
-          authHttpClient: authHttpClient,
+          httpClient: httpClient,
           project: project,
           location: location,
-          rootUrl: rootUrl,
+          rootUrl: rootUrl ?? 'https://$location-aiplatform.googleapis.com/',
         );
 
   /// A client for interacting with Vertex AI API.

--- a/packages/langchain_google/lib/src/llms/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai.dart
@@ -1,4 +1,4 @@
-import 'package:googleapis_auth/googleapis_auth.dart';
+import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:tiktoken/tiktoken.dart';
 import 'package:vertex_ai/vertex_ai.dart';
@@ -30,8 +30,11 @@ import 'models/models.dart';
 ///
 /// ### Authentication
 ///
-/// The `VertexAI` wrapper delegates authentication to the
-/// [googleapis_auth](https://pub.dev/packages/googleapis_auth) package.
+/// To create an instance of `VertexAI` you need to provide an
+/// HTTP client that handles authentication. The easiest way to do this is to
+/// use [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
+/// from the [googleapis_auth](https://pub.dev/packages/googleapis_auth)
+/// package.
 ///
 /// To create an instance of `VertexAI` you need to provide an
 /// [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
@@ -52,7 +55,7 @@ import 'models/models.dart';
 ///   [VertexAI.cloudPlatformScope],
 /// );
 /// final vertexAi = VertexAI(
-///   authHttpClient: authClient,
+///   httpClient: authClient,
 ///   project: 'your-project-id',
 /// );
 /// ```
@@ -93,7 +96,7 @@ import 'models/models.dart';
 /// Example:
 /// ```dart
 /// final llm = VertexAI(
-///   authHttpClient: authClient,
+///   httpClient: authClient,
 ///   project: 'your-project-id',
 ///   defaultOptions: VertexAIOptions(
 ///     temperature: 0.9,
@@ -110,7 +113,7 @@ import 'models/models.dart';
 class VertexAI extends BaseLLM<VertexAIOptions> {
   /// {@macro vertex_ai}
   VertexAI({
-    required final AuthClient authHttpClient,
+    required final http.Client httpClient,
     required final String project,
     final String location = 'us-central1',
     final String? rootUrl,
@@ -118,7 +121,7 @@ class VertexAI extends BaseLLM<VertexAIOptions> {
     this.model = 'text-bison',
     this.defaultOptions = const VertexAIOptions(),
   }) : client = VertexAIGenAIClient(
-          authHttpClient: authHttpClient,
+          httpClient: httpClient,
           project: project,
           location: location,
           rootUrl: rootUrl ?? 'https://$location-aiplatform.googleapis.com/',

--- a/packages/langchain_google/test/chat_models/vertex_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai_test.dart
@@ -15,7 +15,7 @@ void main() async {
   group('ChatVertexAI tests', () {
     test('Test ChatVertexAI parameters', () async {
       final llm = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         location: 'us-central1',
         rootUrl: 'https://us-central1-aiplatform.googleapis.com/',
@@ -49,7 +49,7 @@ void main() async {
 
     test('Test call to ChatVertexAI', () async {
       final chat = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
       );
@@ -59,7 +59,7 @@ void main() async {
 
     test('Test generate to ChatVertexAI', () async {
       final chat = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
       );
@@ -75,7 +75,7 @@ void main() async {
 
     test('Test model output contains metadata', () async {
       final chat = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
       );
@@ -92,7 +92,7 @@ void main() async {
 
     test('Test ChatVertexAI wrapper with system message', () async {
       final chat = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
       );
@@ -106,7 +106,7 @@ void main() async {
 
     test('Test model stop sequence', () async {
       final chat = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const ChatVertexAIOptions(
           stopSequences: ['4'],
@@ -139,7 +139,7 @@ void main() async {
       // It seems that the Vertex AI Chat API ignores the candidateCount
       // parameter at the moment
       final chat = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const ChatVertexAIOptions(
           temperature: 1,
@@ -164,7 +164,7 @@ void main() async {
 
     test('Test tokenize', () async {
       final chat = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
       );
       const text = 'Hello, how are you?';
@@ -175,7 +175,7 @@ void main() async {
 
     test('Test countTokens string', () async {
       final chat = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
       );
       final prompt = PromptValue.string('Hello, how are you?');
@@ -187,7 +187,7 @@ void main() async {
 
     test('Test countTokens messages', () async {
       final chat = ChatVertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const ChatVertexAIOptions(
           maxOutputTokens: 1,

--- a/packages/langchain_google/test/embeddings/vertex_ai_test.dart
+++ b/packages/langchain_google/test/embeddings/vertex_ai_test.dart
@@ -14,7 +14,7 @@ void main() async {
   group('VertexAIEmbeddings tests', () {
     test('Test VertexAIEmbeddings.embedQuery', () async {
       final embeddings = VertexAIEmbeddings(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
       );
       final res = await embeddings.embedQuery('Hello world');
@@ -23,7 +23,7 @@ void main() async {
 
     test('Test VertexAIEmbeddings.embedDocuments', () async {
       final embeddings = VertexAIEmbeddings(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         batchSize: 1,
       );

--- a/packages/langchain_google/test/llms/vertex_ai_test.dart
+++ b/packages/langchain_google/test/llms/vertex_ai_test.dart
@@ -15,7 +15,7 @@ Future<void> main() async {
   group('VertexAI tests', () {
     test('Test VertexAI parameters', () async {
       final llm = VertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         location: 'us-central1',
         rootUrl: 'https://us-central1-aiplatform.googleapis.com/',
@@ -49,7 +49,7 @@ Future<void> main() async {
 
     test('Test call to VertexAI', () async {
       final llm = VertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
       );
       final output = await llm('Say foo:');
@@ -58,7 +58,7 @@ Future<void> main() async {
 
     test('Test generate to VertexAI', () async {
       final llm = VertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const VertexAIOptions(maxOutputTokens: 10),
       );
@@ -68,7 +68,7 @@ Future<void> main() async {
 
     test('Test model output contains metadata', () async {
       final llm = VertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const VertexAIOptions(maxOutputTokens: 10),
       );
@@ -83,7 +83,7 @@ Future<void> main() async {
 
     test('Test model stop sequence', () async {
       final llm = VertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const VertexAIOptions(
           stopSequences: ['4'],
@@ -108,7 +108,7 @@ Future<void> main() async {
 
     test('Test model candidates count', () async {
       final llm = VertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const VertexAIOptions(
           temperature: 1,
@@ -133,7 +133,7 @@ Future<void> main() async {
 
     test('Test tokenize', () async {
       final llm = VertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
       );
       const text = 'Hello, how are you?';
@@ -144,7 +144,7 @@ Future<void> main() async {
 
     test('Test countTokens', () async {
       final llm = VertexAI(
-        authHttpClient: authHttpClient,
+        httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
       );
       const text = 'Hello, how are you?';

--- a/packages/langchain_google/test/vector_stores/matching_engine_test.dart
+++ b/packages/langchain_google/test/vector_stores/matching_engine_test.dart
@@ -12,12 +12,12 @@ import '../utils/auth.dart';
 void main() async {
   final authHttpClient = await getAuthHttpClient();
   final embeddings = VertexAIEmbeddings(
-    authHttpClient: authHttpClient,
+    httpClient: authHttpClient,
     project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
     model: 'textembedding-gecko-multilingual',
   );
   final vectorStore = VertexAIMatchingEngine(
-    authHttpClient: authHttpClient,
+    httpClient: authHttpClient,
     project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
     location: 'europe-west1',
     indexId: '6394355006866194432',
@@ -53,7 +53,7 @@ void main() async {
       expect(res.length, 1);
       expect(
         res.first.id,
-        'education_61dd8b84bbd3af82960777a6',
+        'faq_621656c96b5ff317d867d019',
       );
     });
 

--- a/packages/langchain_pinecone/pubspec.yaml
+++ b/packages/langchain_pinecone/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   http: ^1.1.0
   langchain: ^0.0.12
   meta: ^1.9.1
-  pinecone: ^0.5.1
+  pinecone: 0.5.1 # 0.5.2 has issues
   uuid: ^3.0.7
 
 dev_dependencies:

--- a/packages/langchain_pinecone/pubspec_overrides.yaml
+++ b/packages/langchain_pinecone/pubspec_overrides.yaml
@@ -1,4 +1,6 @@
-# melos_managed_dependency_overrides: langchain
+# melos_managed_dependency_overrides: langchain,langchain_openai
 dependency_overrides:
   langchain:
     path: ../langchain
+  langchain_openai:
+    path: ../langchain_openai

--- a/packages/langchain_pinecone/test/vector_stores/pinecone_test.dart
+++ b/packages/langchain_pinecone/test/vector_stores/pinecone_test.dart
@@ -9,7 +9,7 @@ import 'package:langchain_pinecone/langchain_pinecone.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  group('Pinecone tests', () {
+  group('Pinecone tests', timeout: const Timeout(Duration(minutes: 1)), () {
     final openaiApiKey = Platform.environment['OPENAI_API_KEY']!;
     final pineconeApiKey = Platform.environment['PINECONE_API_KEY']!;
     final embeddings = OpenAIEmbeddings(apiKey: openaiApiKey);

--- a/packages/vertex_ai/example/vertex_ai_example.dart
+++ b/packages/vertex_ai/example/vertex_ai_example.dart
@@ -7,7 +7,7 @@ import 'package:vertex_ai/vertex_ai.dart';
 
 void main() async {
   final vertexAi = VertexAIGenAIClient(
-    authHttpClient: await _getAuthHttpClient(),
+    httpClient: await _getAuthHttpClient(),
     project: _getProjectId(),
   );
 

--- a/packages/vertex_ai/lib/src/gen_ai/gen_ai_client.dart
+++ b/packages/vertex_ai/lib/src/gen_ai/gen_ai_client.dart
@@ -1,5 +1,5 @@
 import 'package:googleapis/aiplatform/v1.dart';
-import 'package:googleapis_auth/googleapis_auth.dart';
+import 'package:http/http.dart' as http;
 
 import 'apis/apis.dart';
 
@@ -29,12 +29,11 @@ import 'apis/apis.dart';
 ///
 /// ### Authentication
 ///
-/// The `VertexAIGenAIClient` delegates authentication to the
-/// [googleapis_auth](https://pub.dev/packages/googleapis_auth) package.
-///
 /// To create an instance of `VertexAIGenAIClient` you need to provide an
-/// [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
-/// instance.
+/// HTTP client that handles authentication. The easiest way to do this is to
+/// use [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
+/// from the [googleapis_auth](https://pub.dev/packages/googleapis_auth)
+/// package.
 ///
 /// There are several ways to obtain an `AuthClient` depending on your use case.
 /// Check out the [googleapis_auth](https://pub.dev/packages/googleapis_auth)
@@ -51,7 +50,7 @@ import 'apis/apis.dart';
 ///   [VertexAIGenAIClient.cloudPlatformScope],
 /// );
 /// final vertexAi = VertexAIGenAIClient(
-///   authHttpClient: authClient,
+///   httpClient: authClient,
 ///   project: 'your-project-id',
 /// );
 /// ```
@@ -75,12 +74,12 @@ import 'apis/apis.dart';
 class VertexAIGenAIClient {
   /// {@macro vertex_ai_gen_ai_client}
   VertexAIGenAIClient({
-    required final AuthClient authHttpClient,
+    required final http.Client httpClient,
     required this.project,
     this.location = 'us-central1',
     final String? rootUrl,
   }) : _vertexAiApi = AiplatformApi(
-          authHttpClient,
+          httpClient,
           rootUrl: rootUrl ?? 'https://$location-aiplatform.googleapis.com/',
         );
 

--- a/packages/vertex_ai/lib/src/matching_engine/matching_engine_client.dart
+++ b/packages/vertex_ai/lib/src/matching_engine/matching_engine_client.dart
@@ -1,5 +1,5 @@
 import 'package:googleapis/aiplatform/v1.dart';
-import 'package:googleapis_auth/googleapis_auth.dart';
+import 'package:http/http.dart' as http;
 
 import 'apis/apis.dart';
 
@@ -22,12 +22,11 @@ import 'apis/apis.dart';
 ///
 /// ### Authentication
 ///
-/// The `VertexAIMatchingEngineClient` delegates authentication to the
-/// [googleapis_auth](https://pub.dev/packages/googleapis_auth) package.
-///
 /// To create an instance of `VertexAIMatchingEngineClient` you need to provide
-/// an [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
-/// instance.
+/// an HTTP client that handles authentication. The easiest way to do this is
+/// to use [`AuthClient`](https://pub.dev/documentation/googleapis_auth/latest/googleapis_auth/AuthClient-class.html)
+/// from the [googleapis_auth](https://pub.dev/packages/googleapis_auth)
+/// package.
 ///
 /// There are several ways to obtain an `AuthClient` depending on your use case.
 /// Check out the [googleapis_auth](https://pub.dev/packages/googleapis_auth)
@@ -44,7 +43,7 @@ import 'apis/apis.dart';
 ///   [VertexAIGenAIClient.cloudPlatformScope],
 /// );
 /// final vertexAi = VertexAIMatchingEngineClient(
-///   authHttpClient: authClient,
+///   httpClient: authClient,
 ///   project: 'your-project-id',
 /// );
 /// ```
@@ -76,12 +75,12 @@ import 'apis/apis.dart';
 /// {@endtemplate}
 class VertexAIMatchingEngineClient {
   VertexAIMatchingEngineClient({
-    required final AuthClient authHttpClient,
+    required final http.Client httpClient,
     required this.project,
     this.location = 'us-central1',
     final String? rootUrl,
   }) : _vertexAiApi = AiplatformApi(
-          authHttpClient,
+          httpClient,
           rootUrl: rootUrl ?? 'https://$location-aiplatform.googleapis.com/',
         );
 

--- a/packages/vertex_ai/test/gen_ai/gen_ai_client_test.dart
+++ b/packages/vertex_ai/test/gen_ai/gen_ai_client_test.dart
@@ -11,7 +11,7 @@ import 'package:vertex_ai/vertex_ai.dart';
 void main() async {
   final client = await _getAuthenticatedClient();
   final vertexAi = VertexAIGenAIClient(
-    authHttpClient: client,
+    httpClient: client,
     project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
   );
 

--- a/packages/vertex_ai/test/matching_engine/maching_engine_client_test.dart
+++ b/packages/vertex_ai/test/matching_engine/maching_engine_client_test.dart
@@ -12,7 +12,7 @@ import 'package:vertex_ai/vertex_ai.dart';
 void main() async {
   final authClient = await _getAuthenticatedClient();
   final marchingEngine = VertexAIMatchingEngineClient(
-    authHttpClient: authClient,
+    httpClient: authClient,
     project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
     location: 'europe-west1',
   );
@@ -144,7 +144,7 @@ void main() async {
   group('VertexAIMatchingEngineClient query tests', () {
     test('Test query index', () async {
       final machineEngineQuery = VertexAIMatchingEngineClient(
-        authHttpClient: authClient,
+        httpClient: authClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         rootUrl:
             'https://455238120.europe-west1-706285145183.vdb.vertexai.goog/',


### PR DESCRIPTION
Currently all VertexAI wrapper require a `AuthHttp` instance from `googleapis_auth` package. However, you may want to use a proxy server instead of calling directly VertexAI. Requiring an `http.Client` instead of  `AuthClient` gives you the flexibility to do that. As you can create your own wrapper of `http.Client` to handle the authentication of your proxy.
