### PR TITLE
Update pinecone dependency - regression resolved

### DIFF
--- a/packages/langchain_pinecone/pubspec.yaml
+++ b/packages/langchain_pinecone/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   http: ^1.1.0
   langchain: ^0.0.12
   meta: ^1.9.1
-  pinecone: 0.5.1 # 0.5.2 has issues
+  pinecone: ^0.5.3
   uuid: ^3.0.7
 
 dev_dependencies:


### PR DESCRIPTION
@davidmigloz This should resolve the regression you note in the `pubspec.yaml` file for `v0.5.2`.

The relevant changes to the the [pinecone](https://pub.dev/packages/pinecone) package are linked below. An accidental regression leaked where the security scheme for the client generation was not getting populated. In turn, it was defaulting to `http` instead of `https`. 

Performed a manual end-to-end test on Pinecone production servers to ensure this is now working as expected. Applying the patch update here to `langchain_pinecone`.

https://github.com/tazatechnology/pinecone/commit/dcbcdf5a427626f9037b9117b82246a9742e3b14
