### PR TITLE
feat(vector-stores): Upgrade pinecone client to v0.6.0

### DIFF
--- a/packages/langchain_pinecone/lib/src/vector_stores/pinecone.dart
+++ b/packages/langchain_pinecone/lib/src/vector_stores/pinecone.dart
@@ -74,17 +74,17 @@ import 'models/models.dart';
 class Pinecone extends VectorStore {
   /// {@macro pinecone}
   Pinecone({
-    required final String apiKey,
-    final String? host,
+    final String? apiKey,
+    final String? baseUrl,
+    final http.Client? client,
     required this.indexName,
     this.environment = 'gcp-starter',
     this.namespace,
     this.docPageContentKey = 'page_content',
     required super.embeddings,
-    final http.Client? client,
   }) : _client = PineconeClient(
-          apiKey: apiKey,
-          host: host,
+          apiKey: apiKey ?? '',
+          baseUrl: baseUrl,
           client: client,
         );
 

--- a/packages/langchain_pinecone/pubspec.yaml
+++ b/packages/langchain_pinecone/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   http: ^1.1.0
   langchain: ^0.0.14
   meta: ^1.9.1
-  pinecone: ^0.5.3
+  pinecone: ^0.6.0
   uuid: ^4.0.0
 
 dev_dependencies:


### PR DESCRIPTION
pinecone v0.6.0 had a breaking change that was breaking langchain_pinecone implementation (`host` renamed to `baseUrl`)