### PR TITLE
feat(output-parsers): Add streaming support to OutputFunctionsParsers

### DIFF
--- a/docs/expression_language/cookbook/prompt_llm_parser.md
+++ b/docs/expression_language/cookbook/prompt_llm_parser.md
@@ -195,7 +195,7 @@ final chain = promptTemplate |
         functionCall: ChatFunctionCall.forced(functionName: function.name),
       ),
     ) |
-    const JsonOutputFunctionsParser();
+    JsonOutputFunctionsParser();
 
 final res = await chain.invoke({'foo': 'bears'});
 print(res);
@@ -212,7 +212,7 @@ final chain = promptTemplate |
         functionCall: ChatFunctionCall.forced(functionName: function.name),
       ),
     ) |
-    const JsonKeyOutputFunctionsParser(keyName: 'setup');
+    JsonKeyOutputFunctionsParser(keyName: 'setup');
 
 final res = await chain.invoke({'foo': 'bears'});
 print(res);

--- a/examples/docs_examples/bin/expression_language/cookbook/prompt_llm_parser.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/prompt_llm_parser.dart
@@ -171,7 +171,7 @@ Future<void> _promptTemplateLLMJsonOutputFunctionsParser() async {
           functionCall: ChatFunctionCall.forced(functionName: function.name),
         ),
       ) |
-      const JsonOutputFunctionsParser();
+      JsonOutputFunctionsParser();
 
   final res = await chain.invoke({'foo': 'bears'});
   print(res);
@@ -215,7 +215,7 @@ Future<void> _promptTemplateLLMJsonKeyOutputFunctionsParser() async {
           functionCall: ChatFunctionCall.forced(functionName: function.name),
         ),
       ) |
-      const JsonKeyOutputFunctionsParser(keyName: 'setup');
+      JsonKeyOutputFunctionsParser(keyName: 'setup');
 
   final res = await chain.invoke({'foo': 'bears'});
   print(res);

--- a/packages/langchain/lib/src/core/runnable/base.dart
+++ b/packages/langchain/lib/src/core/runnable/base.dart
@@ -41,8 +41,8 @@ import 'sequence.dart';
 ///   as output. You can create a [RunnablePassthrough] using the
 ///   [Runnable.passthrough] static method.
 /// {@endtemplate}
-abstract class Runnable<RunInput extends Object,
-    CallOptions extends BaseLangChainOptions, RunOutput extends Object> {
+abstract class Runnable<RunInput extends Object?,
+    CallOptions extends BaseLangChainOptions, RunOutput extends Object?> {
   const Runnable();
 
   /// Creates a [RunnableSequence] from a list of [Runnable] objects.
@@ -137,7 +137,7 @@ abstract class Runnable<RunInput extends Object,
   /// Pipes the output of this [Runnable] into another [Runnable].
   ///
   /// - [next] - the [Runnable] to pipe the output into.
-  RunnableSequence<RunInput, NewRunOutput> pipe<NewRunOutput extends Object,
+  RunnableSequence<RunInput, NewRunOutput> pipe<NewRunOutput extends Object?,
       NewCallOptions extends BaseLangChainOptions>(
     final Runnable<RunOutput, NewCallOptions, NewRunOutput> next,
   ) {

--- a/packages/langchain/lib/src/core/runnable/binding.dart
+++ b/packages/langchain/lib/src/core/runnable/binding.dart
@@ -36,8 +36,8 @@ import 'base.dart';
 /// // }
 /// ```
 /// {@endtemplate}
-class RunnableBinding<RunInput extends Object,
-        CallOptions extends BaseLangChainOptions, RunOutput extends Object>
+class RunnableBinding<RunInput extends Object?,
+        CallOptions extends BaseLangChainOptions, RunOutput extends Object?>
     extends Runnable<RunInput, CallOptions, RunOutput> {
   /// {@macro runnable_binding}
   const RunnableBinding({
@@ -68,6 +68,7 @@ class RunnableBinding<RunInput extends Object,
     final Stream<RunInput> inputStream, {
     final CallOptions? options,
   }) {
-    return bound.streamFromInputStream(inputStream, options: options ?? this.options);
+    return bound.streamFromInputStream(inputStream,
+        options: options ?? this.options);
   }
 }

--- a/packages/langchain/lib/src/core/runnable/map.dart
+++ b/packages/langchain/lib/src/core/runnable/map.dart
@@ -74,7 +74,9 @@ class RunnableMap<RunInput extends Object>
   }) {
     return StreamGroup.merge(
       steps.entries.map((final entry) {
-        return entry.value.streamFromInputStream(inputStream, options: options).map(
+        return entry.value
+            .streamFromInputStream(inputStream, options: options)
+            .map(
               (final output) => {entry.key: output},
             );
       }),

--- a/packages/langchain/lib/src/core/runnable/sequence.dart
+++ b/packages/langchain/lib/src/core/runnable/sequence.dart
@@ -59,7 +59,7 @@ import 'base.dart';
 /// // Why don't bears wear shoes? Because they have bear feet!
 /// ```
 /// {@endtemplate}
-class RunnableSequence<RunInput extends Object, RunOutput extends Object>
+class RunnableSequence<RunInput extends Object?, RunOutput extends Object?>
     extends Runnable<RunInput, BaseLangChainOptions, RunOutput> {
   /// {@macro runnable_sequence}
   const RunnableSequence({
@@ -69,13 +69,13 @@ class RunnableSequence<RunInput extends Object, RunOutput extends Object>
   });
 
   /// The first [Runnable] in the [RunnableSequence].
-  final Runnable<RunInput, BaseLangChainOptions, Object> first;
+  final Runnable<RunInput, BaseLangChainOptions, Object?> first;
 
   /// The middle [Runnable]s in the [RunnableSequence].
   final List<Runnable> middle;
 
   /// The last [Runnable] in the [RunnableSequence].
-  final Runnable<Object, BaseLangChainOptions, RunOutput> last;
+  final Runnable<Object?, BaseLangChainOptions, RunOutput> last;
 
   /// Returns a list of all the [Runnable]s in the [RunnableSequence].
   List<Runnable> get steps => [first, ...middle, last];
@@ -100,7 +100,7 @@ class RunnableSequence<RunInput extends Object, RunOutput extends Object>
     final RunInput input, {
     final BaseLangChainOptions? options,
   }) async {
-    Object nextStepInput = input;
+    Object? nextStepInput = input;
 
     for (final step in [first, ...middle]) {
       nextStepInput = await step.invoke(nextStepInput, options: options);
@@ -127,7 +127,8 @@ class RunnableSequence<RunInput extends Object, RunOutput extends Object>
   ///
   /// - [next] - the [Runnable] to pipe the output into.
   @override
-  RunnableSequence<RunInput, NewRunOutput> pipe<NewRunOutput extends Object, NewCallOptions extends BaseLangChainOptions>(
+  RunnableSequence<RunInput, NewRunOutput> pipe<NewRunOutput extends Object?,
+      NewCallOptions extends BaseLangChainOptions>(
     final Runnable<RunOutput, NewCallOptions, NewRunOutput> next,
   ) {
     if (next is RunnableSequence<RunOutput, NewRunOutput>) {

--- a/packages/langchain/lib/src/model_io/chat_models/models/models.dart
+++ b/packages/langchain/lib/src/model_io/chat_models/models/models.dart
@@ -287,6 +287,7 @@ class AIChatMessageFunctionCall {
   Map<String, dynamic> toMap() {
     return {
       'name': name,
+      'argumentsRaw': argumentsRaw,
       'arguments': arguments,
     };
   }

--- a/packages/langchain/lib/src/model_io/output_parsers/output_parser.dart
+++ b/packages/langchain/lib/src/model_io/output_parsers/output_parser.dart
@@ -6,10 +6,10 @@ import '../prompts/models/models.dart';
 interface class FormatInstructionsOptions {}
 
 /// {@template base_llm_output_parser}
-/// Class to parse the output of an LLM call.
+/// Class to parse the output of an model call.
 /// {@endtemplate}
 abstract class BaseLLMOutputParser<LLMOutput extends Object,
-        CallOptions extends BaseLangChainOptions, ParserOutput extends Object>
+        CallOptions extends BaseLangChainOptions, ParserOutput extends Object?>
     extends Runnable<LanguageModelResult<LLMOutput>, CallOptions,
         ParserOutput> {
   /// {@macro base_llm_output_parser}
@@ -96,16 +96,4 @@ abstract class BaseOutputParser<LLMOutput extends Object,
   String getFormatInstructions([final FormatInstructionsOptions? options]) {
     return ''; // Override this method to provide instructions.
   }
-}
-
-/// {@template base_transform_output_parser}
-/// Class to parse the output of an LLM call that also allows streaming inputs.
-/// {@endtemplate}
-abstract class BaseTransformOutputParser<LLMOutput extends Object,
-        CallOptions extends BaseLangChainOptions, ParserOutput extends Object>
-    extends BaseOutputParser<LLMOutput, CallOptions, ParserOutput> {
-  /// {@macro base_transform_output_parser}
-  const BaseTransformOutputParser();
-
-// TODO add streaming methods
 }

--- a/packages/langchain/lib/src/model_io/output_parsers/utils/json.dart
+++ b/packages/langchain/lib/src/model_io/output_parsers/utils/json.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+/// Parses a JSON string that may be missing some closing characters.
+///
+/// This function is useful for parsing an incomplete JSON string that is
+/// being streamed from an API.
+///
+/// For example:
+/// ```dart
+/// parsePartialJson('{"foo":"bar"'); // Returns {"foo":"bar"}
+/// ```
+dynamic parsePartialJson(final String s) {
+  // Attempt to parse the string as-is
+  try {
+    return jsonDecode(s);
+  } on Exception {
+    // Pass
+  }
+
+  // Initialize variables
+  String newStr = '';
+  final stack = <String>[];
+  bool isInsideString = false;
+  bool escaped = false;
+
+  // Process each character in the string one at a time
+  for (int i = 0; i < s.length; i++) {
+    var char = s[i];
+    if (isInsideString) {
+      if (char == '"' && !escaped) {
+        isInsideString = false;
+      } else if (char == '\n' && !escaped) {
+        char = r'\n'; // Replace the newline character with the escape sequence
+      } else if (char == r'\') {
+        escaped = !escaped;
+      } else {
+        escaped = false;
+      }
+    } else {
+      if (char == '"') {
+        isInsideString = true;
+        escaped = false;
+      } else if (char == '{') {
+        stack.add('}');
+      } else if (char == '[') {
+        stack.add(']');
+      } else if (char == '}' || char == ']') {
+        if (stack.isNotEmpty && stack.last == char) {
+          stack.removeLast();
+        } else {
+          // Mismatched closing character; the input is malformed
+          return null;
+        }
+      }
+    }
+
+    // Append the processed character to the new string
+    newStr += char;
+  }
+
+  // If we're still inside a string at the end of processing,
+  // we need to close the string
+  if (isInsideString) {
+    newStr += '"';
+  }
+
+  // Close any remaining open structures in the reverse order
+  // that they were opened
+  while (stack.isNotEmpty) {
+    newStr += stack.removeLast();
+  }
+
+  // Attempt to parse the modified string as JSON
+  try {
+    return jsonDecode(newStr);
+  } on Exception {
+    // If we still can't parse the string as JSON,
+    // return null to indicate failure
+    return null;
+  }
+}

--- a/packages/langchain/test/core/runnable/stream_test.dart
+++ b/packages/langchain/test/core/runnable/stream_test.dart
@@ -105,7 +105,6 @@ void main() {
       expect(res, 'Hello world!');
     });
 
-
     test('Streaming Chain', () async {
       final model = FakeListLLM(responses: ['Hello world!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo}');

--- a/packages/langchain/test/model_io/output_parsers/functions_test.dart
+++ b/packages/langchain/test/model_io/output_parsers/functions_test.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: unused_element
+import 'dart:convert';
+
 import 'package:langchain/langchain.dart';
 import 'package:test/test.dart';
 
@@ -21,26 +23,90 @@ void main() {
     ],
   );
 
+  final streamingResult = ChatResult(
+    streaming: true,
+    generations: [
+      ChatGeneration(
+        ChatMessage.ai(
+          '',
+          functionCall: const AIChatMessageFunctionCall(
+            name: 'test',
+            argumentsRaw: '{"foo":"bar"',
+            arguments: {},
+          ),
+        ),
+      ),
+    ],
+  );
+
   group('OutputFunctionsParser tests', () {
     test('OutputFunctionsParser from ChatResult', () async {
-      final res =
-          await const OutputFunctionsParser().parseResult(result.generations);
+      final res = await OutputFunctionsParser().parseResult(result.generations);
       expect(res, '{"foo":"bar","bar":"foo"}');
+    });
+
+    test('OutputFunctionsParser from ChatResult streaming', () async {
+      final res = await OutputFunctionsParser().stream(streamingResult).first;
+      expect(res, '{"foo":"bar"');
+    });
+
+    test('OutputFunctionsParser from ChatResult argsOnly=false', () async {
+      final res = await OutputFunctionsParser(argsOnly: false)
+          .parseResult(result.generations);
+      expect(
+        res,
+        json.encode({
+          'name': 'test',
+          'argumentsRaw': '{"foo":"bar","bar":"foo"}',
+          'arguments': {
+            'foo': 'bar',
+            'bar': 'foo',
+          },
+        }),
+      );
+    });
+
+    test('OutputFunctionsParser from ChatResult streaming argsOnly=false',
+        () async {
+      final res = await OutputFunctionsParser(argsOnly: false)
+          .stream(streamingResult)
+          .first;
+      expect(
+        res,
+        json.encode({
+          'name': 'test',
+          'argumentsRaw': '{"foo":"bar"',
+          'arguments': <String, dynamic>{},
+        }),
+      );
     });
   });
 
   group('JsonOutputFunctionsParser tests', () {
     test('JsonOutputFunctionsParser from ChatResult', () async {
-      final res = await const JsonOutputFunctionsParser()
-          .parseResult(result.generations);
+      final res =
+          await JsonOutputFunctionsParser().parseResult(result.generations);
       expect(res, {'foo': 'bar', 'bar': 'foo'});
+    });
+
+    test('JsonOutputFunctionsParser from ChatResult streaming', () async {
+      final res =
+          await JsonOutputFunctionsParser().stream(streamingResult).first;
+      expect(res, {'foo': 'bar'});
     });
   });
 
   group('JsonKeyOutputFunctionsParser tests', () {
     test('JsonKeyOutputFunctionsParser from ChatResult', () async {
-      final res = await const JsonKeyOutputFunctionsParser(keyName: 'foo')
+      final res = await JsonKeyOutputFunctionsParser(keyName: 'foo')
           .parseResult(result.generations);
+      expect(res, 'bar');
+    });
+
+    test('JsonKeyOutputFunctionsParser from ChatResult streaming', () async {
+      final res = await JsonKeyOutputFunctionsParser(keyName: 'foo')
+          .stream(streamingResult)
+          .first;
       expect(res, 'bar');
     });
   });

--- a/packages/langchain/test/model_io/output_parsers/utils/json_test.dart
+++ b/packages/langchain/test/model_io/output_parsers/utils/json_test.dart
@@ -1,0 +1,37 @@
+import 'package:langchain/src/model_io/output_parsers/utils/json.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parsePartialJson tests', () {
+    test('Valid JSON input should be parsed correctly', () {
+      const jsonString = '{"name": "John", "age": 30}';
+      final result = parsePartialJson(jsonString) as Map<String, dynamic>;
+      expect(result['name'], equals('John'));
+      expect(result['age'], equals(30));
+    });
+
+    test('Missing closing brace should be parsed correctly', () {
+      const jsonString = '{"name": "John", "age": 30';
+      final result = parsePartialJson(jsonString) as Map<String, dynamic>;
+      expect(result, equals({'name': 'John', 'age': 30}));
+    });
+
+    test('Missing value should return null', () {
+      const jsonString = '{"name": "John", "age":';
+      final result = parsePartialJson(jsonString);
+      expect(result, isNull);
+    });
+
+    test('Invalid JSON should return null', () {
+      const jsonString = '{"name": "John, "age": 30}';
+      final result = parsePartialJson(jsonString);
+      expect(result, isNull);
+    });
+
+    test('should handle strings with whitespace', () {
+      const jsonString = '  {"name": "John Doe"}  ';
+      final result = parsePartialJson(jsonString) as Map<String, dynamic>;
+      expect(result['name'], equals('John Doe'));
+    });
+  });
+}


### PR DESCRIPTION
Example:
```dart
const function = ChatFunction(
  name: 'joke',
  description: 'A joke',
  parameters: {
    'type': 'object',
    'properties': {
      'setup': {
        'type': 'string',
        'description': 'The setup for the joke',
      },
      'punchline': {
        'type': 'string',
        'description': 'The punchline to the joke',
      },
    },
    'required': ['location', 'punchline'],
  },
);
final promptTemplate = ChatPromptTemplate.fromTemplate(
  'tell me a long joke about {foo}',
);
final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
  ChatOpenAIOptions(
    functions: const [function],
    functionCall: ChatFunctionCall.forced(functionName: 'joke'),
  ),
);
final jsonOutputParser = JsonOutputFunctionsParser();
final chain = promptTemplate.pipe(chat).pipe(jsonOutputParser);

final stream = chain.stream({'foo': 'bears'});

await for (final res in stream) {
  print(res);
}
```

will print:
```
{}
{setup: }
{setup: Why}
{setup: Why don}
{setup: Why don't}
{setup: Why don't bears}
{setup: Why don't bears like}
{setup: Why don't bears like fast}
{setup: Why don't bears like fast food}
{setup: Why don't bears like fast food?, punchline: }
{setup: Why don't bears like fast food?, punchline: Because}
{setup: Why don't bears like fast food?, punchline: Because they}
{setup: Why don't bears like fast food?, punchline: Because they can}
{setup: Why don't bears like fast food?, punchline: Because they can't}
{setup: Why don't bears like fast food?, punchline: Because they can't catch}
{setup: Why don't bears like fast food?, punchline: Because they can't catch it}
{setup: Why don't bears like fast food?, punchline: Because they can't catch it!}
```