### PR TITLE
feat(llms): Add streaming support to OpenAI

### DIFF
--- a/packages/langchain_openai/lib/src/llms/models/mappers.dart
+++ b/packages/langchain_openai/lib/src/llms/models/mappers.dart
@@ -2,7 +2,7 @@ import 'package:langchain/langchain.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 extension CreateCompletionResponseMapper on CreateCompletionResponse {
-  LLMResult toLLMResult() {
+  LLMResult toLLMResult({final bool streaming = false}) {
     return LLMResult(
       generations: choices
           .map((final choice) => choice.toLLMGeneration())
@@ -13,6 +13,7 @@ extension CreateCompletionResponseMapper on CreateCompletionResponse {
         'created': created,
         'model': model,
       },
+      streaming: streaming,
     );
   }
 }

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -257,6 +257,45 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     return completion.toLLMResult();
   }
 
+  @override
+  Stream<LLMResult> stream(
+    final PromptValue input, {
+    final OpenAIOptions? options,
+  }) {
+    return _client
+        .createCompletionStream(
+          request: CreateCompletionRequest(
+            model: CompletionModel.string(model),
+            prompt: CompletionPrompt.string(input.toString()),
+            bestOf: bestOf,
+            frequencyPenalty: frequencyPenalty,
+            logitBias: logitBias,
+            logprobs: logprobs,
+            maxTokens: maxTokens,
+            n: n,
+            presencePenalty: presencePenalty,
+            stop: options?.stop != null
+                ? CompletionStop.arrayString(options!.stop!)
+                : null,
+            suffix: suffix,
+            temperature: temperature,
+            topP: topP,
+            user: options?.user ?? user,
+          ),
+        )
+        .map((final completion) => completion.toLLMResult(streaming: true));
+  }
+
+  @override
+  Stream<LLMResult> streamFromInputStream(
+    final Stream<PromptValue> inputStream, {
+    final OpenAIOptions? options,
+  }) {
+    return inputStream.asyncExpand((final input) {
+      return stream(input, options: options);
+    });
+  }
+
   /// Tokenizes the given prompt using tiktoken with the encoding used by the
   /// [model]. If an encoding model is specified in [encoding] field, that
   /// encoding is used instead.


### PR DESCRIPTION
Relates to #4 

Example:
```dart
final promptTemplate = PromptTemplate.fromTemplate(
  'List the numbers from 1 to {max_num} in order without any spaces or commas',
);
final llm = OpenAI(apiKey: openaiApiKey);
const stringOutputParser = StringOutputParser<String>();
final chain = promptTemplate.pipe(llm).pipe(stringOutputParser);

final stream = chain.stream({'max_num': '9'});

String content = '';
await for (final res in stream) {
  content += res;
  print(content);
}
```

will print:
```

123
12345
1234567
123456789
```