### PR TITLE
feat(chat-models): Add streaming support to ChatOpenAI

### DIFF
--- a/packages/langchain_openai/lib/src/chains/qa_with_sources.dart
+++ b/packages/langchain_openai/lib/src/chains/qa_with_sources.dart
@@ -53,7 +53,7 @@ class OpenAIQAWithSourcesChain extends OpenAIQAWithStructureChain {
               'required': ['answer', 'sources'],
             },
           ),
-          outputParser: const QAWithSourcesOutputParser(),
+          outputParser: QAWithSourcesOutputParser(),
         );
 }
 
@@ -90,12 +90,12 @@ class QAWithSources {
 /// {@endtemplate}
 class QAWithSourcesOutputParser<CallOptions extends BaseLangChainOptions>
     extends BaseOutputFunctionsParser<CallOptions, QAWithSources> {
-  const QAWithSourcesOutputParser();
+  QAWithSourcesOutputParser();
 
   @override
   Future<QAWithSources> parseFunctionCall(
-    final AIChatMessageFunctionCall functionCall,
+    final AIChatMessageFunctionCall? functionCall,
   ) async {
-    return QAWithSources.fromMap(functionCall.arguments);
+    return QAWithSources.fromMap(functionCall?.arguments ?? const {});
   }
 }


### PR DESCRIPTION
Relates to #4 

Example:
```dart
final promptTemplate = ChatPromptTemplate.fromPromptMessages([
  SystemChatMessagePromptTemplate.fromTemplate(
    'You are a helpful assistant that replies only with numbers '
    'in order without any spaces or commas',
  ),
  HumanChatMessagePromptTemplate.fromTemplate(
    'List the numbers from 1 to {max_num}',
  ),
]);

final chat = ChatOpenAI(apiKey: openaiApiKey);
const stringOutputParser = StringOutputParser<ChatMessage>();
final chain = promptTemplate.pipe(chat).pipe(stringOutputParser);

final stream = chain.stream({'max_num': '9'});

String content = '';
await for (final res in stream) {
  content += res;
  print(content);
}
```

will print:
```

123
123456
123456789
```