### PR TITLE
feat(llms): Support seed and system_fingerprint in OpenAI wrapper

### DIFF
--- a/packages/langchain_openai/lib/src/llms/models/mappers.dart
+++ b/packages/langchain_openai/lib/src/llms/models/mappers.dart
@@ -12,6 +12,7 @@ extension CreateCompletionResponseMapper on CreateCompletionResponse {
         'id': id,
         'created': created,
         'model': model,
+        'systemFingerprint': systemFingerprint,
       },
       streaming: streaming,
     );

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -114,6 +114,7 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     this.maxTokens = 256,
     this.n = 1,
     this.presencePenalty = 0,
+    this.seed,
     this.suffix,
     this.temperature = 1,
     this.topP = 1,
@@ -181,6 +182,16 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
   /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-presence_penalty
   final double presencePenalty;
 
+  /// If specified, our system will make a best effort to sample
+  /// deterministically, such that repeated requests with the same seed and
+  /// parameters should return the same result.
+  ///
+  /// Determinism is not guaranteed, and you should refer to the
+  /// `system_fingerprint` response parameter to monitor changes in the backend.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-seed
+  final int? seed;
+
   /// The suffix that comes after a completion of inserted text.
   ///
   /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-suffix
@@ -245,6 +256,7 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
         maxTokens: maxTokens,
         n: n,
         presencePenalty: presencePenalty,
+        seed: seed,
         stop: options?.stop != null
             ? CompletionStop.arrayString(options!.stop!)
             : null,

--- a/packages/langchain_openai/test/llms/openai_test.dart
+++ b/packages/langchain_openai/test/llms/openai_test.dart
@@ -119,5 +119,28 @@ void main() {
       expect(count, greaterThan(1));
       expect(content, contains('123456789'));
     });
+
+    test('Test response seed', () async {
+      final prompt = PromptValue.string('How are you?');
+      final llm = OpenAI(
+        apiKey: openaiApiKey,
+        temperature: 0,
+        seed: 9999,
+      );
+
+      final res1 = await llm.invoke(prompt);
+      expect(res1.generations, hasLength(1));
+      final generation1 = res1.generations.first;
+
+      final res2 = await llm.invoke(prompt);
+      expect(res2.generations, hasLength(1));
+      final generation2 = res2.generations.first;
+
+      expect(
+        res1.modelOutput?['systemFingerprint'],
+        res2.modelOutput?['systemFingerprint'],
+      );
+      expect(generation1.output, generation2.output);
+    });
   });
 }


### PR DESCRIPTION
Example:
```dart
test('Test response seed', () async {
  final prompt = PromptValue.string('How are you?');
  final llm = OpenAI(
    apiKey: openaiApiKey,
    temperature: 0,
    seed: 9999,
  );
  final res1 = await llm.invoke(prompt);
  expect(res1.generations, hasLength(1));
  final generation1 = res1.generations.first;
  final res2 = await llm.invoke(prompt);
  expect(res2.generations, hasLength(1));
  final generation2 = res2.generations.first;
  expect(
    res1.modelOutput?['systemFingerprint'],
    res2.modelOutput?['systemFingerprint'],
  );
  expect(generation1.output, generation2.output);
});
```