### PR TITLE
feat(chat-models)!: Add multi-modal messages support with OpenAI Vision

### DIFF
--- a/docs/expression_language/cookbook/retrieval.md
+++ b/docs/expression_language/cookbook/retrieval.md
@@ -200,7 +200,8 @@ String formatChatHistory(final List<ChatMessage> chatHistory) {
       .map(
         (final msg) => switch (msg) {
           HumanChatMessage _ => 'Human: ${msg.content}',
-          _ => 'AI: ${msg.content}',
+          AIChatMessage _ => 'AI: ${msg.content}',
+          _ => '',
         },
       )
       .toList();
@@ -268,7 +269,7 @@ final conversationalQaChain = loadedMemory |
 // they will be used in the next invocation
 await memory.saveContext(
   inputValues: {
-    'question': ChatMessage.human('How much does my order cost?')
+    'question': ChatMessage.humanText('How much does my order cost?')
   },
   outputValues: {'answer': ChatMessage.ai('You have to pay 100€')},
 );

--- a/docs/get_started/quickstart.md
+++ b/docs/get_started/quickstart.md
@@ -94,7 +94,7 @@ Finally, let's use the `predictMessages` method to run over a list of messages.
 
 ```dart
 const text = 'What would be a good company name for a company that makes colorful socks?';
-final messages = [ChatMessage.human(text)];
+final messages = [ChatMessage.humanText(text)];
 
 final res1 = await llm.predictMessages(messages);
 print(res1); // AIChatMessage(content=Feetful of Fun)

--- a/docs/modules/model_io/models/chat_models/chat_models.md
+++ b/docs/modules/model_io/models/chat_models/chat_models.md
@@ -50,7 +50,7 @@ The response will be a message.
 
 ```dart
 final messages = [
-  ChatMessage.human(
+  ChatMessage.humanText(
     'Translate this sentence from English to French. I love programming.',
   ),
 ];
@@ -65,7 +65,7 @@ information. Here is an example of sending a system and user message to the chat
 ```dart
 final messages = [
   ChatMessage.system('You are a helpful assistant that translates English to French.'),
-  ChatMessage.human('I love programming.')
+  ChatMessage.humanText('I love programming.')
 ];
 final chatRes = await chat(messages);
 print(chatRes);

--- a/docs/modules/model_io/models/chat_models/how_to/streaming.md
+++ b/docs/modules/model_io/models/chat_models/how_to/streaming.md
@@ -20,7 +20,7 @@ final promptTemplate = ChatPromptTemplate.fromPromptMessages([
   ),
 ]);
 final chat = ChatOpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser<ChatMessage>();
+const stringOutputParser = StringOutputParser<AIChatMessage>();
 
 final chain = promptTemplate.pipe(chat).pipe(stringOutputParser);
 

--- a/docs/modules/model_io/models/chat_models/integrations/gcp_vertex_ai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/gcp_vertex_ai.md
@@ -71,7 +71,7 @@ final chatModel = ChatVertexAI(
   ),
 );
 final result = await chatModel(
-  [ChatMessage.human('Hello')],
+  [ChatMessage.humanText('Hello')],
   options: ChatVertexAIOptions(
     temperature: 0.5,
    ),
@@ -94,7 +94,7 @@ void main() async {
   );
   while (true) {
     stdout.write('> ');
-    final usrMsg = ChatMessage.human(stdin.readLineSync() ?? '');
+    final usrMsg = ChatMessage.humanText(stdin.readLineSync() ?? '');
     final aiMsg = await chat([usrMsg]);
     print(aiMsg.content);
   }

--- a/docs/modules/model_io/models/chat_models/integrations/openai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/openai.md
@@ -43,7 +43,7 @@ final promptTemplate = ChatPromptTemplate.fromPromptMessages([
   ),
 ]);
 final chat = ChatOpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser<ChatMessage>();
+const stringOutputParser = StringOutputParser<AIChatMessage>();
 
 final chain = promptTemplate.pipe(chat).pipe(stringOutputParser);
 
@@ -121,7 +121,7 @@ final prompt = PromptValue.chat([
     "Extract the 'name' and 'origin' of any companies mentioned in the "
         'following statement. Return a JSON list.',
   ),
-  ChatMessage.human(
+  ChatMessage.humanText(
     'Google was founded in the USA, while Deepmind was founded in the UK',
   ),
 ]);

--- a/docs/modules/model_io/models/getting_started.md
+++ b/docs/modules/model_io/models/getting_started.md
@@ -52,17 +52,17 @@ print(llmRes);
 ### `messages` -> `messages` interface
 
 ```dart
-final llmRes = await llm.generatePrompt(ChatPromptValue([ChatMessage.human('say hi!')]));
+final llmRes = await llm.generatePrompt(ChatPromptValue([ChatMessage.humanText('say hi!')]));
 print(llmRes.generations.first.first.output);
 // -> 'Robot: Hi there!'
 
-final chatRes = await chatModel.generatePrompt(ChatPromptValue([ChatMessage.human('say hi!')]));
+final chatRes = await chatModel.generatePrompt(ChatPromptValue([ChatMessage.humanText('say hi!')]));
 print(chatRes.generations.first.output);
 // -> AIChatMessage{content: 'Hello there! How may I assist you today?'}
 ```
 
 As it is the main functionality of the Chat model, we also provide a shorthand:
 ```dart
-final chatRes = await chatModel([ChatMessage.human('say hi!')]);
+final chatRes = await chatModel([ChatMessage.humanText('say hi!')]);
 print(chatRes); // [ChatMessage.ai(content: '\n\nHi there! How can I help you?')]
 ```

--- a/docs/modules/model_io/prompts/prompt_templates/msg_prompt_templates.md
+++ b/docs/modules/model_io/prompts/prompt_templates/msg_prompt_templates.md
@@ -34,7 +34,7 @@ final chatPromptTemplate = ChatPromptTemplate.fromPromptMessages([
   humanMessageTemplate,
 ]);
 
-final humanMessage = ChatMessage.human(
+final humanMessage = ChatMessage.humanText(
   'What is the best way to learn programming?',
 );
 final aiMessage = ChatMessage.ai('''

--- a/examples/docs_examples/bin/expression_language/cookbook/retrieval.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/retrieval.dart
@@ -226,7 +226,8 @@ Question: {question}''');
         .map(
           (final msg) => switch (msg) {
             HumanChatMessage _ => 'Human: ${msg.content}',
-            _ => 'AI: ${msg.content}',
+            AIChatMessage _ => 'AI: ${msg.content}',
+            _ => '',
           },
         )
         .toList();
@@ -298,7 +299,7 @@ Question: {question}''');
   // they will be used in the next invocation
   await memory.saveContext(
     inputValues: {
-      'question': ChatMessage.human('How much does my order cost?'),
+      'question': ChatMessage.humanText('How much does my order cost?'),
     },
     outputValues: {'answer': ChatMessage.ai('You have to pay 100€')},
   );

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/how_to/streaming.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/how_to/streaming.dart
@@ -21,7 +21,7 @@ Future<void> _chatOpenAIStreaming() async {
   ]);
 
   final chat = ChatOpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser<ChatMessage>();
+  const stringOutputParser = StringOutputParser<AIChatMessage>();
   final chain = promptTemplate.pipe(chat).pipe(stringOutputParser);
 
   final stream = chain.stream({'max_num': '9'});

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/openai.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/openai.dart
@@ -51,7 +51,7 @@ Future<void> _chatOpenAIStreaming() async {
     ),
   ]);
   final chat = ChatOpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser<ChatMessage>();
+  const stringOutputParser = StringOutputParser<AIChatMessage>();
 
   final chain = promptTemplate.pipe(chat).pipe(stringOutputParser);
 
@@ -125,7 +125,7 @@ Future<void> _chatOpenAIJsonMode() async {
       "Extract the 'name' and 'origin' of any companies mentioned in the "
       'following statement. Return a JSON list.',
     ),
-    ChatMessage.human(
+    ChatMessage.humanText(
       'Google was founded in the USA, while Deepmind was founded in the UK',
     ),
   ]);

--- a/examples/hello_world_cli/bin/hello_world_cli.dart
+++ b/examples/hello_world_cli/bin/hello_world_cli.dart
@@ -19,7 +19,7 @@ void main(final List<String> arguments) async {
   while (true) {
     stdout.write('> ');
     final query = stdin.readLineSync() ?? '';
-    final humanMessage = ChatMessage.human(query);
+    final humanMessage = ChatMessage.humanText(query);
     final aiMessage = await llm.call([humanMessage]);
     stdout.writeln(aiMessage.content.trim());
   }

--- a/examples/hello_world_flutter/lib/home/bloc/home_screen_cubit.dart
+++ b/examples/hello_world_flutter/lib/home/bloc/home_screen_cubit.dart
@@ -50,7 +50,7 @@ class HomeScreenCubit extends Cubit<HomeScreenState> {
       baseUrl: baseUrl,
     );
 
-    final result = await llm([ChatMessage.human(query)]);
+    final result = await llm([ChatMessage.humanText(query)]);
     emit(
       state.copyWith(
         status: HomeScreenStatus.idle,

--- a/packages/langchain/lib/src/chains/combine_documents/map_reduce.dart
+++ b/packages/langchain/lib/src/chains/combine_documents/map_reduce.dart
@@ -182,7 +182,7 @@ class MapReduceDocumentsChain extends BaseCombineDocumentsChain {
   }
 
   String _getContent(final dynamic content) => switch (content) {
-        final ChatMessage resultMsg => resultMsg.content,
+        final AIChatMessage resultMsg => resultMsg.content,
         _ => content,
       };
 }

--- a/packages/langchain/lib/src/chains/combine_documents/stuff.dart
+++ b/packages/langchain/lib/src/chains/combine_documents/stuff.dart
@@ -141,7 +141,7 @@ class StuffDocumentsChain extends BaseCombineDocumentsChain {
     final llmOutput = await llmChain.call(llmInputs);
     final content = llmOutput[llmChain.outputKey];
     final output = switch (content) {
-      final ChatMessage resultMsg => resultMsg.content,
+      final AIChatMessage resultMsg => resultMsg.content,
       _ => content,
     };
     return {

--- a/packages/langchain/lib/src/memory/chat_message_history/base.dart
+++ b/packages/langchain/lib/src/memory/chat_message_history/base.dart
@@ -17,7 +17,7 @@ abstract base class BaseChatMessageHistory {
 
   /// Add a human message to the history.
   Future<void> addHumanChatMessage(final String message) {
-    return addChatMessage(ChatMessage.human(message));
+    return addChatMessage(ChatMessage.humanText(message));
   }
 
   /// Add an AI message to the history.

--- a/packages/langchain/lib/src/model_io/chat_models/base.dart
+++ b/packages/langchain/lib/src/model_io/chat_models/base.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../language_models/base.dart';
-import '../language_models/models/models.dart';
 import '../prompts/models/models.dart';
 import 'models/models.dart';
 
@@ -10,7 +9,7 @@ import 'models/models.dart';
 /// It should take in chat messages and return a chat message.
 /// {@endtemplate}
 abstract class BaseChatModel<Options extends ChatModelOptions>
-    extends BaseLanguageModel<List<ChatMessage>, Options, ChatMessage> {
+    extends BaseLanguageModel<List<ChatMessage>, Options, AIChatMessage> {
   /// {@macro base_chat_model}
   const BaseChatModel();
 
@@ -22,11 +21,11 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
   /// Example:
   /// ```dart
   /// final result = await chat.invoke(
-  ///   PromptValue.chat([ChatMessage.human('say hi!')]),
+  ///   PromptValue.chat([ChatMessage.humanText('say hi!')]),
   /// );
   /// ```
   @override
-  Future<LanguageModelResult<ChatMessage>> invoke(
+  Future<ChatResult> invoke(
     final PromptValue input, {
     final Options? options,
   }) async {
@@ -40,7 +39,7 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
   ///
   /// Example:
   /// ```dart
-  /// final result = await chat.generate([ChatMessage.human('say hi!')]);
+  /// final result = await chat.generate([ChatMessage.humanText('say hi!')]);
   /// ```
   @override
   Future<ChatResult> generate(
@@ -56,7 +55,7 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
   /// Example:
   /// ```dart
   /// final result = await chat.generatePrompt(
-  ///   PromptValue.chat([ChatMessage.human('say hi!')]),
+  ///   PromptValue.chat([ChatMessage.humanText('say hi!')]),
   /// );
   /// ```
   @override
@@ -74,10 +73,10 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
   ///
   /// Example:
   /// ```dart
-  /// final result = await chat([ChatMessage.human('say hi!')]);
+  /// final result = await chat([ChatMessage.humanText('say hi!')]);
   /// ```
   @override
-  Future<ChatMessage> call(
+  Future<AIChatMessage> call(
     final List<ChatMessage> messages, {
     final Options? options,
   }) async {
@@ -100,7 +99,10 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
     final String text, {
     final Options? options,
   }) async {
-    final res = await call([ChatMessage.human(text)], options: options);
+    final res = await call(
+      [ChatMessage.humanText(text)],
+      options: options,
+    );
     return res.content;
   }
 
@@ -111,7 +113,7 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
   ///
   /// Example:
   /// ```dart
-  /// final result = await chat.predictMessages([ChatMessage.human('say hi!')]);
+  /// final result = await chat.predictMessages([ChatMessage.humanText('say hi!')]);
   /// );
   @override
   Future<ChatMessage> predictMessages(
@@ -138,7 +140,7 @@ abstract class SimpleChatModel<Options extends ChatModelOptions>
     final Options? options,
   }) async {
     final text = await callInternal(messages, options: options);
-    final message = ChatMessage.ai(text);
+    final message = AIChatMessage(content: text);
     return ChatResult(
       generations: [ChatGeneration(message)],
     );

--- a/packages/langchain/lib/src/model_io/chat_models/fake.dart
+++ b/packages/langchain/lib/src/model_io/chat_models/fake.dart
@@ -55,7 +55,7 @@ class FakeEchoChatModel extends SimpleChatModel {
     final List<ChatMessage> messages, {
     final ChatModelOptions? options,
   }) {
-    return Future<String>.value(messages.last.content);
+    return Future<String>.value(messages.last.contentAsString);
   }
 
   @override
@@ -65,10 +65,10 @@ class FakeEchoChatModel extends SimpleChatModel {
   }) {
     return inputStream.asyncExpand(
       (final input) {
-        final prompt = input.toChatMessages().first.content.split('');
+        final prompt = input.toChatMessages().first.contentAsString.split('');
         return Stream.fromIterable(prompt).map(
           (final char) => ChatResult(
-            generations: [ChatGeneration(ChatMessage.ai(char))],
+            generations: [ChatGeneration(AIChatMessage(content: char))],
             streaming: true,
           ),
         );

--- a/packages/langchain/lib/src/model_io/chat_models/utils.dart
+++ b/packages/langchain/lib/src/model_io/chat_models/utils.dart
@@ -13,14 +13,14 @@ extension ChatMessagesX on List<ChatMessage> {
     return map(
       (final m) {
         return switch (m) {
-          SystemChatMessage _ => '$systemPrefix: ${m.content}',
-          HumanChatMessage _ => '$humanPrefix: ${m.content}',
+          SystemChatMessage _ => '$systemPrefix: ${m.contentAsString}',
+          HumanChatMessage _ => '$humanPrefix: ${m.contentAsString}',
           AIChatMessage _ => m.functionCall == null
-              ? '$aiPrefix: ${m.content}'
+              ? '$aiPrefix: ${m.contentAsString}'
               : '$aiPrefix: ${m.functionCall!.name}(${m.functionCall!.arguments})',
           FunctionChatMessage(name: final n, content: final c) =>
             '$functionPrefix: $n=$c',
-          final CustomChatMessage m => '${m.role}: ${m.content}',
+          final CustomChatMessage m => '${m.role}: ${m.contentAsString}',
         };
       },
     ).join('\n');

--- a/packages/langchain/lib/src/model_io/output_parsers/functions.dart
+++ b/packages/langchain/lib/src/model_io/output_parsers/functions.dart
@@ -15,7 +15,7 @@ import 'utils/json.dart';
 /// {@endtemplate}
 abstract class BaseOutputFunctionsParser<
         CallOptions extends BaseLangChainOptions, O extends Object?>
-    extends BaseLLMOutputParser<ChatMessage, CallOptions, O> {
+    extends BaseLLMOutputParser<AIChatMessage, CallOptions, O> {
   /// {@macro base_output_functions_parser}
   BaseOutputFunctionsParser();
 

--- a/packages/langchain/lib/src/model_io/prompts/chat_prompt.dart
+++ b/packages/langchain/lib/src/model_io/prompts/chat_prompt.dart
@@ -423,7 +423,7 @@ final class HumanChatMessagePromptTemplate
 
   @override
   ChatMessage format([final InputValues values = const {}]) {
-    return ChatMessage.human(prompt.format(values));
+    return ChatMessage.humanText(prompt.format(values));
   }
 
   @override

--- a/packages/langchain/lib/src/model_io/prompts/models/models.dart
+++ b/packages/langchain/lib/src/model_io/prompts/models/models.dart
@@ -56,7 +56,7 @@ class StringPromptValue implements PromptValue {
 
   @override
   List<ChatMessage> toChatMessages() {
-    return [ChatMessage.human(value)];
+    return [ChatMessage.humanText(value)];
   }
 
   @override

--- a/packages/langchain/test/core/runnable/binding_test.dart
+++ b/packages/langchain/test/core/runnable/binding_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('RunnableBinding from Runnable.bind', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}');
       const model = _FakeOptionsChatModel();
-      const outputParser = StringOutputParser<ChatMessage>();
+      const outputParser = StringOutputParser<AIChatMessage>();
       final chain = prompt |
           model.bind(const _FakeOptionsChatModelOptions('world')) |
           outputParser;
@@ -19,7 +19,7 @@ void main() {
     test('Streaming RunnableBinding', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}');
       const model = _FakeOptionsChatModel();
-      const outputParser = StringOutputParser<ChatMessage>();
+      const outputParser = StringOutputParser<AIChatMessage>();
 
       final chain = prompt
           .pipe(model.bind(const _FakeOptionsChatModelOptions('world')))
@@ -49,7 +49,7 @@ class _FakeOptionsChatModel
     final _FakeOptionsChatModelOptions? options,
   }) {
     return Future.value(
-      messages.first.content.replaceAll(options?.stop ?? '', ''),
+      messages.first.contentAsString.replaceAll(options?.stop ?? '', ''),
     );
   }
 
@@ -63,12 +63,12 @@ class _FakeOptionsChatModel
         final prompt = input
             .toChatMessages()
             .first
-            .content
+            .contentAsString
             .replaceAll(options?.stop ?? '', '')
             .split('');
         return Stream.fromIterable(prompt).map(
           (final char) => ChatResult(
-            generations: [ChatGeneration(ChatMessage.ai(char))],
+            generations: [ChatGeneration(AIChatMessage(content: char))],
           ),
         );
       },

--- a/packages/langchain/test/core/runnable/function_test.dart
+++ b/packages/langchain/test/core/runnable/function_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('RunnableFunction from Runnable.fromFunction', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<ChatMessage>();
+      const outputParser = StringOutputParser<AIChatMessage>();
       final chain = prompt |
           model |
           outputParser |

--- a/packages/langchain/test/core/runnable/invoke_test.dart
+++ b/packages/langchain/test/core/runnable/invoke_test.dart
@@ -22,7 +22,7 @@ void main() {
         res.toChatMessages(),
         equals([
           ChatMessage.system('You are a helpful chatbot'),
-          ChatMessage.human('test'),
+          ChatMessage.humanText('test'),
         ]),
       );
     });

--- a/packages/langchain/test/core/runnable/map_test.dart
+++ b/packages/langchain/test/core/runnable/map_test.dart
@@ -9,7 +9,7 @@ void main() {
       final prompt1 = PromptTemplate.fromTemplate('Hello {input}!');
       final prompt2 = PromptTemplate.fromTemplate('Bye {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<ChatMessage>();
+      const outputParser = StringOutputParser<AIChatMessage>();
       final chain = Runnable.fromMap({
         'left': prompt1 | model | outputParser,
         'right': prompt2 | model | outputParser,

--- a/packages/langchain/test/core/runnable/passthrough_test.dart
+++ b/packages/langchain/test/core/runnable/passthrough_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('RunnablePassthrough from Runnable.passthrough', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<ChatMessage>();
+      const outputParser = StringOutputParser<AIChatMessage>();
       final chain = Runnable.fromMap({
         'in': Runnable.passthrough(),
         'out': Runnable.getMapFromItem('input') | prompt | model | outputParser,

--- a/packages/langchain/test/core/runnable/sequence_test.dart
+++ b/packages/langchain/test/core/runnable/sequence_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('RunnableSequence from Runnable.pipe', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<ChatMessage>();
+      const outputParser = StringOutputParser<AIChatMessage>();
       final chain = prompt.pipe(model).pipe(outputParser);
 
       final res = await chain.invoke({'input': 'world'});
@@ -17,7 +17,7 @@ void main() {
     test('RunnableSequence from | operator', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<ChatMessage>();
+      const outputParser = StringOutputParser<AIChatMessage>();
       final chain = prompt | model | outputParser;
 
       final res = await chain.invoke({'input': 'world'});
@@ -27,7 +27,7 @@ void main() {
     test('RunnableSequence from Runnable.fromList', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<ChatMessage>();
+      const outputParser = StringOutputParser<AIChatMessage>();
       final chain = Runnable.fromList([prompt, model, outputParser]);
 
       final res = await chain.invoke({'input': 'world'});

--- a/packages/langchain/test/core/runnable/stream_test.dart
+++ b/packages/langchain/test/core/runnable/stream_test.dart
@@ -34,7 +34,7 @@ void main() {
         item.toChatMessages(),
         equals([
           ChatMessage.system('You are a helpful chatbot'),
-          ChatMessage.human('test'),
+          ChatMessage.humanText('test'),
         ]),
       );
     });

--- a/packages/langchain/test/memory/buffer_test.dart
+++ b/packages/langchain/test/memory/buffer_test.dart
@@ -29,7 +29,7 @@ void main() {
         outputValues: {'bar': 'foo'},
       );
       final expectedResult = [
-        ChatMessage.human('bar'),
+        ChatMessage.humanText('bar'),
         ChatMessage.ai('foo'),
       ];
       final result2 = await memory.loadMemoryVariables();
@@ -55,7 +55,7 @@ void main() {
 
     test('Test buffer memory with pre-loaded history', () async {
       final pastMessages = [
-        ChatMessage.human("My name's Jonas"),
+        ChatMessage.humanText("My name's Jonas"),
         ChatMessage.ai('Nice to meet you, Jonas!'),
       ];
       final memory = ConversationBufferMemory(
@@ -93,7 +93,7 @@ void main() {
         outputValues: {'bar': 'foo'},
       );
       final expectedResult = [
-        ChatMessage.human('bar'),
+        ChatMessage.humanText('bar'),
         ChatMessage.ai('foo'),
       ];
       final result1 = await memory.loadMemoryVariables();
@@ -114,7 +114,7 @@ void main() {
         outputValues: {'bar': 'foo'},
       );
       final expectedResult = [
-        ChatMessage.human('bar2'),
+        ChatMessage.humanText('bar2'),
         ChatMessage.ai('foo'),
       ];
       final result1 = await memory.loadMemoryVariables();

--- a/packages/langchain/test/memory/buffer_window_test.dart
+++ b/packages/langchain/test/memory/buffer_window_test.dart
@@ -28,7 +28,7 @@ void main() {
         outputValues: {'bar': 'foo'},
       );
       final expectedResult = [
-        ChatMessage.human('bar'),
+        ChatMessage.humanText('bar'),
         ChatMessage.ai('foo'),
       ];
       final result2 = await memory.loadMemoryVariables();
@@ -40,7 +40,7 @@ void main() {
       );
 
       final expectedResult2 = [
-        ChatMessage.human('bar1'),
+        ChatMessage.humanText('bar1'),
         ChatMessage.ai('foo1'),
       ];
       final result3 = await memory.loadMemoryVariables();
@@ -49,7 +49,7 @@ void main() {
 
     test('Test buffer memory with pre-loaded history', () async {
       final pastMessages = [
-        ChatMessage.human("My name's Jonas"),
+        ChatMessage.humanText("My name's Jonas"),
         ChatMessage.ai('Nice to meet you, Jonas!'),
       ];
       final memory = ConversationBufferMemory(

--- a/packages/langchain/test/memory/chat_message_history/in_memory_test.dart
+++ b/packages/langchain/test/memory/chat_message_history/in_memory_test.dart
@@ -5,7 +5,7 @@ void main() {
   group('ChatMessageHistory tests', () {
     test('Test addMessage and getMessages', () async {
       final history = ChatMessageHistory();
-      final message = ChatMessage.human('This is a test');
+      final message = ChatMessage.humanText('This is a test');
       await history.addChatMessage(message);
       expect(await history.getChatMessages(), [message]);
     });
@@ -15,7 +15,7 @@ void main() {
       await history.addHumanChatMessage('This is a human msg');
       final messages = await history.getChatMessages();
       expect(messages.first, isA<HumanChatMessage>());
-      expect(messages.first.content, 'This is a human msg');
+      expect(messages.first.contentAsString, 'This is a human msg');
     });
 
     test('Test addAIChatMessage', () async {
@@ -23,42 +23,42 @@ void main() {
       await history.addAIChatMessage('This is an AI msg');
       final messages = await history.getChatMessages();
       expect(messages.first, isA<AIChatMessage>());
-      expect(messages.first.content, 'This is an AI msg');
+      expect(messages.first.contentAsString, 'This is an AI msg');
     });
 
     test('Test removeLast', () async {
       final history = ChatMessageHistory();
-      final message = ChatMessage.human('This is a test');
+      final message = ChatMessage.humanText('This is a test');
       final message2 = ChatMessage.ai('This is an AI msg');
       await history.addChatMessage(message);
       await history.addChatMessage(message2);
       final oldestMessage = await history.removeLast();
       expect(oldestMessage, isA<AIChatMessage>());
-      expect(oldestMessage.content, 'This is an AI msg');
+      expect(oldestMessage.contentAsString, 'This is an AI msg');
       final messages = await history.getChatMessages();
       expect(messages.length, 1);
       expect(messages.first, isA<HumanChatMessage>());
-      expect(messages.first.content, 'This is a test');
+      expect(messages.first.contentAsString, 'This is a test');
     });
 
     test('Test removeFirst', () async {
       final history = ChatMessageHistory();
-      final message = ChatMessage.human('This is a test');
+      final message = ChatMessage.humanText('This is a test');
       final message2 = ChatMessage.ai('This is an AI msg');
       await history.addChatMessage(message);
       await history.addChatMessage(message2);
       final oldestMessage = await history.removeFirst();
       expect(oldestMessage, isA<HumanChatMessage>());
-      expect(oldestMessage.content, 'This is a test');
+      expect(oldestMessage.contentAsString, 'This is a test');
       final messages = await history.getChatMessages();
       expect(messages.length, 1);
       expect(messages.first, isA<AIChatMessage>());
-      expect(messages.first.content, 'This is an AI msg');
+      expect(messages.first.contentAsString, 'This is an AI msg');
     });
 
     test('Test clear', () async {
       final history = ChatMessageHistory();
-      final message = ChatMessage.human('This is a test');
+      final message = ChatMessage.humanText('This is a test');
       await history.addChatMessage(message);
       await history.clear();
       expect(await history.getChatMessages(), <ChatMessage>[]);

--- a/packages/langchain/test/memory/summary_test.dart
+++ b/packages/langchain/test/memory/summary_test.dart
@@ -140,7 +140,7 @@ void main() {
         },
       );
       final pastMessages = [
-        ChatMessage.human("My name's Jonas"),
+        ChatMessage.humanText("My name's Jonas"),
         ChatMessage.ai('Nice to meet you, Jonas!'),
       ];
       final memory = await ConversationSummaryMemory.fromMessages(

--- a/packages/langchain/test/memory/token_buffer_test.dart
+++ b/packages/langchain/test/memory/token_buffer_test.dart
@@ -36,7 +36,7 @@ void main() {
         outputValues: {'bar': 'foo'},
       );
       final expectedResult = [
-        ChatMessage.human('bar'),
+        ChatMessage.humanText('bar'),
         ChatMessage.ai('foo'),
       ];
       final result2 = await memory.loadMemoryVariables();
@@ -49,7 +49,7 @@ void main() {
 
       final expectedResult2 = [
         ChatMessage.ai('foo'),
-        ChatMessage.human('bar1'),
+        ChatMessage.humanText('bar1'),
         ChatMessage.ai('foo1'),
       ];
       final result3 = await memory.loadMemoryVariables();
@@ -58,7 +58,7 @@ void main() {
 
     test('Test buffer memory with pre-loaded history', () async {
       final pastMessages = [
-        ChatMessage.human("My name's Jonas"),
+        ChatMessage.humanText("My name's Jonas"),
         ChatMessage.ai('Nice to meet you, Jonas!'),
       ];
       const model = FakeEchoLLM();

--- a/packages/langchain/test/model_io/chat_models/fake_test.dart
+++ b/packages/langchain/test/model_io/chat_models/fake_test.dart
@@ -5,9 +5,9 @@ void main() {
   group('FakeChatModel tests', () {
     test('Test model returns given responses', () async {
       final chatModel = FakeChatModel(responses: ['foo', 'bar']);
-      final res1 = await chatModel.generate([ChatMessage.human('Hello')]);
+      final res1 = await chatModel.generate([ChatMessage.humanText('Hello')]);
       expect(res1.firstOutputAsString, 'foo');
-      final res2 = await chatModel.generate([ChatMessage.human('World')]);
+      final res2 = await chatModel.generate([ChatMessage.humanText('World')]);
       expect(res2.firstOutputAsString, 'bar');
     });
   });

--- a/packages/langchain/test/model_io/output_parsers/functions_test.dart
+++ b/packages/langchain/test/model_io/output_parsers/functions_test.dart
@@ -5,12 +5,12 @@ import 'package:langchain/langchain.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final result = ChatResult(
+  const result = ChatResult(
     generations: [
       ChatGeneration(
-        ChatMessage.ai(
-          '',
-          functionCall: const AIChatMessageFunctionCall(
+        AIChatMessage(
+          content: '',
+          functionCall: AIChatMessageFunctionCall(
             name: 'test',
             argumentsRaw: '{"foo":"bar","bar":"foo"}',
             arguments: {
@@ -23,13 +23,13 @@ void main() {
     ],
   );
 
-  final streamingResult = ChatResult(
+  const streamingResult = ChatResult(
     streaming: true,
     generations: [
       ChatGeneration(
-        ChatMessage.ai(
-          '',
-          functionCall: const AIChatMessageFunctionCall(
+        AIChatMessage(
+          content: '',
+          functionCall: AIChatMessageFunctionCall(
             name: 'test',
             argumentsRaw: '{"foo":"bar"',
             arguments: {},

--- a/packages/langchain/test/model_io/output_parsers/string_test.dart
+++ b/packages/langchain/test/model_io/output_parsers/string_test.dart
@@ -12,8 +12,8 @@ void main() {
     });
 
     test('StringOutputParser from ChatResult', () async {
-      final result = ChatResult(
-        generations: [ChatGeneration(ChatMessage.ai('Hello world!'))],
+      const result = ChatResult(
+        generations: [ChatGeneration(AIChatMessage(content: 'Hello world!'))],
       );
       final res =
           await const StringOutputParser().parseResult(result.generations);

--- a/packages/langchain/test/model_io/prompts/chat_prompt_test.dart
+++ b/packages/langchain/test/model_io/prompts/chat_prompt_test.dart
@@ -22,7 +22,7 @@ void main() {
       });
       expect(messages.toChatMessages(), [
         ChatMessage.system("Here's some context: This is a context"),
-        ChatMessage.human(
+        ChatMessage.humanText(
           "Hello Foo, I'm Bar. Thanks for the This is a context",
         ),
         ChatMessage.ai("I'm an AI. I'm Foo. I'm Bar."),
@@ -169,10 +169,22 @@ void main() {
       expect(prompt is ChatPromptValue, true);
       final messages = prompt.toChatMessages();
       expect(messages.length, 4);
-      expect(messages[0].content, "Here's some context: context");
-      expect(messages[1].content, "Hello foo, I'm bar. Thanks for the context");
-      expect(messages[2].content, "I'm an AI. I'm foo. I'm bar.");
-      expect(messages[3].content, "I'm a generic message. I'm foo. I'm bar.");
+      expect(
+        messages[0].contentAsString,
+        "Here's some context: context",
+      );
+      expect(
+        messages[1].contentAsString,
+        "Hello foo, I'm bar. Thanks for the context",
+      );
+      expect(
+        messages[2].contentAsString,
+        "I'm an AI. I'm foo. I'm bar.",
+      );
+      expect(
+        messages[3].contentAsString,
+        "I'm a generic message. I'm foo. I'm bar.",
+      );
 
       final string = prompt.toString();
       const expected =
@@ -222,17 +234,17 @@ void main() {
       });
       expect(messages.toChatMessages(), [
         ChatMessage.system("Here's some context: This is a context"),
-        ChatMessage.human("Hello Foo, I'm Bar"),
+        ChatMessage.humanText("Hello Foo, I'm Bar"),
       ]);
     });
 
     test('Test SimpleMessagePromptTemplate', () {
       const prompt = MessagesPlaceholder(variableName: 'foo');
       final values = {
-        'foo': [ChatMessage.human("Hello Foo, I'm Bar")],
+        'foo': [ChatMessage.humanText("Hello Foo, I'm Bar")],
       };
       final messages = prompt.formatMessages(values);
-      expect(messages, [ChatMessage.human("Hello Foo, I'm Bar")]);
+      expect(messages, [ChatMessage.humanText("Hello Foo, I'm Bar")]);
     });
 
     test('Test MessagesPlaceholder', () {
@@ -248,7 +260,7 @@ void main() {
         {'conversation', 'word_count'},
       );
 
-      final humanMessage = ChatMessage.human(
+      final humanMessage = ChatMessage.humanText(
         'What is the best way to learn programming?',
       );
       final aiMessage = ChatMessage.ai('''
@@ -272,17 +284,17 @@ void main() {
       expect(chatPromptValue.messages.length, 3);
       expect(chatPromptValue.messages[0], isA<HumanChatMessage>());
       expect(
-        chatPromptValue.messages[0].content,
+        chatPromptValue.messages[0].contentAsString,
         startsWith('What is the best way to learn programming?'),
       );
       expect(chatPromptValue.messages[1], isA<AIChatMessage>());
       expect(
-        chatPromptValue.messages[1].content,
+        chatPromptValue.messages[1].contentAsString,
         startsWith('1. Choose a programming language:'),
       );
       expect(chatPromptValue.messages[2], isA<HumanChatMessage>());
       expect(
-        chatPromptValue.messages[2].content,
+        chatPromptValue.messages[2].contentAsString,
         startsWith('Summarize our conversation so far in 10 words.'),
       );
     });

--- a/packages/langchain/test/model_io/prompts/pipeline_test.dart
+++ b/packages/langchain/test/model_io/prompts/pipeline_test.dart
@@ -47,7 +47,7 @@ void main() {
       );
       expect(pipelinePrompt.inputVariables, ['bar']);
       final output = pipelinePrompt.formatPrompt({'bar': 'okay'});
-      expect(output.toChatMessages()[0].content, 'jim okay');
+      expect(output.toChatMessages()[0].contentAsString, 'jim okay');
     });
   });
 }

--- a/packages/langchain_google/example/langchain_google_example.dart
+++ b/packages/langchain_google/example/langchain_google_example.dart
@@ -38,7 +38,7 @@ Future<void> _example2() async {
 
   while (true) {
     stdout.write('> ');
-    final usrMsg = ChatMessage.human(stdin.readLineSync() ?? '');
+    final usrMsg = ChatMessage.humanText(stdin.readLineSync() ?? '');
     final aiMsg = await chat([usrMsg]);
     print(aiMsg.content);
   }

--- a/packages/langchain_google/lib/src/chat_models/models/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/models/mappers.dart
@@ -10,7 +10,12 @@ extension ChatMessageMapper on ChatMessage {
     return switch (this) {
       final HumanChatMessage humanChatMessage => VertexAITextChatModelMessage(
           author: _authorUser,
-          content: humanChatMessage.content,
+          content: switch (humanChatMessage.content) {
+            final ChatMessageContentText c => c.text,
+            _ => throw UnsupportedError(
+                'VertexAI only support ChatMessageContentText',
+              ),
+          },
         ),
       final AIChatMessage aiChatMessage => VertexAITextChatModelMessage(
           author: _authorAI,
@@ -55,7 +60,7 @@ extension _VertexAITextModelPredictionMapper
     on VertexAITextChatModelPrediction {
   ChatGeneration toChatGeneration() {
     return ChatGeneration(
-      candidates.first.toChatMessage(),
+      candidates.first.toAIChatMessage(),
       generationInfo: {
         'citations': citations,
         'safety_attributes': safetyAttributes,
@@ -66,12 +71,8 @@ extension _VertexAITextModelPredictionMapper
 
 /// Mapper for [VertexAITextChatModelMessage] to [ChatMessage].
 extension _VertexAITextChatModelMessageMapper on VertexAITextChatModelMessage {
-  ChatMessage toChatMessage() {
-    return switch (author) {
-      _authorUser => ChatMessage.human(content),
-      _authorAI => ChatMessage.ai(content),
-      _ => ChatMessage.custom(content, role: author ?? 'unknown'),
-    };
+  AIChatMessage toAIChatMessage() {
+    return AIChatMessage(content: content);
   }
 }
 

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai.dart
@@ -16,7 +16,7 @@ import 'models/models.dart';
 ///   authHttpClient: authClient,
 ///   project: 'your-project-id',
 /// );
-/// final result = await chatModel([ChatMessage.human('Hello')]);
+/// final result = await chatModel([ChatMessage.humanText('Hello')]);
 /// ```
 ///
 /// Vertex AI documentation:
@@ -102,7 +102,7 @@ import 'models/models.dart';
 ///   ),
 /// );
 /// final result = await chatModel(
-///   [ChatMessage.human('Hello')],
+///   [ChatMessage.humanText('Hello')],
 ///   options: ChatVertexAIOptions(
 ///     temperature: 0.5,
 ///    ),

--- a/packages/langchain_google/test/chat_models/vertex_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai_test.dart
@@ -53,7 +53,7 @@ void main() async {
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
       );
-      final res = await chat([ChatMessage.human('Hello')]);
+      final res = await chat([ChatMessage.humanText('Hello')]);
       expect(res.content, isNotEmpty);
     });
 
@@ -65,9 +65,9 @@ void main() async {
       );
       final res = await chat.generate(
         [
-          ChatMessage.human('Hello, how are you?'),
+          ChatMessage.humanText('Hello, how are you?'),
           ChatMessage.ai('I am fine, thank you.'),
-          ChatMessage.human('Good, what is your name?'),
+          ChatMessage.humanText('Good, what is your name?'),
         ],
       );
       expect(res.generations.first.output.content, isNotEmpty);
@@ -80,7 +80,7 @@ void main() async {
         defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
       );
       final res = await chat.generate(
-        [ChatMessage.human('Hello, how are you?')],
+        [ChatMessage.humanText('Hello, how are you?')],
       );
       expect(res.modelOutput, isNotNull);
       expect(res.modelOutput!['model'], chat.model);
@@ -99,7 +99,7 @@ void main() async {
       final systemMessage =
           ChatMessage.system('You are to chat with the user.');
       final humanMessage =
-          ChatMessage.human('write an ordered list of five items');
+          ChatMessage.humanText('write an ordered list of five items');
       final res = await chat([systemMessage, humanMessage]);
       expect(res.content, isNotEmpty);
     });
@@ -113,7 +113,7 @@ void main() async {
         ),
       );
       final res = await chat.generate([
-        ChatMessage.human(
+        ChatMessage.humanText(
           'List the numbers from 1 to 9 in order without any spaces or commas',
         ),
       ]);
@@ -123,7 +123,7 @@ void main() async {
       // call options should override defaults
       final res2 = await chat.generate(
         [
-          ChatMessage.human(
+          ChatMessage.humanText(
             'List the numbers from 1 to 9 in order without any spaces or commas',
           ),
         ],
@@ -147,13 +147,13 @@ void main() async {
         ),
       );
       final res = await chat.generate(
-        [ChatMessage.human('Suggest a name for a LLM framework for Dart')],
+        [ChatMessage.humanText('Suggest a name for a LLM framework for Dart')],
       );
       expect(res.generations.length, 3);
 
       // call options should override defaults
       final res2 = await chat.generate(
-        [ChatMessage.human('Suggest a name for a LLM framework for Dart')],
+        [ChatMessage.humanText('Suggest a name for a LLM framework for Dart')],
         options: const ChatVertexAIOptions(
           temperature: 1,
           candidateCount: 5,
@@ -200,7 +200,7 @@ void main() async {
           'You are a helpful, pattern-following assistant that translates '
           'corporate jargon into plain English.',
         ),
-        ChatMessage.human(
+        ChatMessage.humanText(
           "This late pivot means we don't have time to boil the ocean for the "
           'client deliverable.',
         ),

--- a/packages/langchain_openai/example/langchain_openai_example.dart
+++ b/packages/langchain_openai/example/langchain_openai_example.dart
@@ -26,7 +26,7 @@ Future<void> _example2() async {
 
   while (true) {
     stdout.write('> ');
-    final usrMsg = ChatMessage.human(stdin.readLineSync() ?? '');
+    final usrMsg = ChatMessage.humanText(stdin.readLineSync() ?? '');
     final aiMsg = await chat([usrMsg]);
     print(aiMsg.content);
   }

--- a/packages/langchain_openai/lib/src/agents/functions.dart
+++ b/packages/langchain_openai/lib/src/agents/functions.dart
@@ -166,7 +166,7 @@ class OpenAIFunctionsAgent extends BaseSingleActionAgent {
       agentInput = functionMsg;
     } else {
       agentInput = switch (inputs[agentInputKey]) {
-        final String inputStr => ChatMessage.human(inputStr),
+        final String inputStr => ChatMessage.humanText(inputStr),
         final ChatMessage inputMsg => inputMsg,
         _ => throw LangChainException(
             message: 'Agent expected a String or ChatMessage as input,'

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -13,7 +13,7 @@ import 'models/models.dart';
 /// final chat = ChatOpenAI(apiKey: '...', temperature: 1);
 /// final messages = [
 ///   ChatMessage.system('You are a helpful assistant that translates English to French.'),
-///   ChatMessage.human('I love programming.')
+///   ChatMessage.humanText('I love programming.')
 /// ];
 /// final res = await chat(messages);
 /// ```
@@ -360,7 +360,7 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     int numTokens = 0;
     for (final message in messages) {
       numTokens += tokensPerMessage;
-      numTokens += tiktoken.encode(message.content).length;
+      numTokens += tiktoken.encode(message.contentAsString).length;
       numTokens += switch (message) {
         final SystemChatMessage _ => tiktoken.encode('system').length,
         final HumanChatMessage _ => tiktoken.encode('user').length,


### PR DESCRIPTION
## Breaking changes

### `ChatMessage`

- In order to support multi-modal prompts, `ChatMessage.human()` takes now a `ChatMessageContent` instead of a `String`.
- `ChatMessageContent` is a sealed class that supports the following types of content:
  * `ChatMessageContent.text()`: text content
  * `ChatMessageContent.image()`: image content
  * `ChatMessageContent.multiModal()`: multi-modal content that can contain text and images
- Chat models now returns a `AIChatMessage` instead of a `ChatMessage`

**Migration:**

Before:
```dart
ChatMessage.human('How much does my order cost?')
```

After:
```dart
ChatMessage.humanText('How much does my order cost?')
// Which is a convenient factory for:
ChatMessage.human(ChatMessageContent.text('How much does my order cost?''))
```

Before:
```dart
const outputParser = StringOutputParser<ChatMessage>();
```

After:
```
const outputParser = StringOutputParser<AIChatMessage>();
```



