### PR TITLE
fix(openai_dart): Fetch requests with big payloads dropping connection

### DIFF
--- a/packages/openai_dart/lib/src/client.dart
+++ b/packages/openai_dart/lib/src/client.dart
@@ -99,6 +99,11 @@ class OpenAIClient extends g.OpenAIClient {
               CreateChatCompletionStreamResponse.fromJson(json.decode(d)),
         );
   }
+
+  @override
+  Future<http.BaseRequest> onRequest(final http.BaseRequest request) {
+    return onRequestHandler(request);
+  }
 }
 
 class _OpenAIStreamTransformer

--- a/packages/openai_dart/lib/src/http_client/http_client_html.dart
+++ b/packages/openai_dart/lib/src/http_client/http_client_html.dart
@@ -6,3 +6,13 @@ import 'package:http/retry.dart';
 http.Client createDefaultHttpClient() {
   return RetryClient(fetch.FetchClient(mode: fetch.RequestMode.cors));
 }
+
+/// Middleware for HTTP requests.
+Future<http.BaseRequest> onRequestHandler(final http.BaseRequest request) {
+  // If the request if bigger than 60KiB set persistentConnection to false
+  // Ref: https://github.com/Zekfad/fetch_client#large-payload
+  if ((request.contentLength ?? 0) > 61440) {
+    request.persistentConnection = false;
+  }
+  return Future.value(request);
+}

--- a/packages/openai_dart/lib/src/http_client/http_client_io.dart
+++ b/packages/openai_dart/lib/src/http_client/http_client_io.dart
@@ -5,3 +5,8 @@ import 'package:http/retry.dart';
 http.Client createDefaultHttpClient() {
   return RetryClient(http.Client());
 }
+
+/// Middleware for HTTP requests.
+Future<http.BaseRequest> onRequestHandler(final http.BaseRequest request) {
+  return Future.value(request);
+}

--- a/packages/openai_dart/lib/src/http_client/http_client_stub.dart
+++ b/packages/openai_dart/lib/src/http_client/http_client_stub.dart
@@ -4,3 +4,7 @@ import 'package:http/http.dart' as http;
 http.Client createDefaultHttpClient() => throw UnsupportedError(
       'Cannot create a client without dart:html or dart:io.',
     );
+
+/// Middleware for HTTP requests.
+Future<http.BaseRequest> onRequestHandler(final http.BaseRequest request) =>
+    throw UnsupportedError('stub');


### PR DESCRIPTION
The `fetch_client` that `openai_dart` uses when targeting web maps `keepalive` to [`BaseRequest.persistentConnection`](https://pub.dev/documentation/http/latest/http/BaseRequest/persistentConnection.html)
which is **`true`** by default.

Fetch spec says that maximum request size with `keepalive` flag is 64KiB:

> __4.5. HTTP-network-or-cache fetch__
>
> > 8.10.5: If the sum of _contentLength_ and _inflightKeepaliveBytes_ is greater
> > than 64 kibibytes, then return a [network error](https://fetch.spec.whatwg.org/#concept-network-error).
> 
> _Source: [Fetch. Living Standard — Last Updated 19 June 2023](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch)_

Therefore if the request is larger than 64KiB (this includes some other data, so effectively recommended check is _60KiB_) we must **explicitly** set [`BaseRequest.persistentConnection`](https://pub.dev/documentation/http/latest/http/BaseRequest/persistentConnection.html)
to `false`, otherwise request will fail.