### PR TITLE
refactor(lcel): Rename RunnableMapFromItem to RunnableMapFromInput

### DIFF
--- a/docs/expression_language/cookbook/multiple_chains.md
+++ b/docs/expression_language/cookbook/multiple_chains.md
@@ -64,7 +64,7 @@ final promptTemplate4 = ChatPromptTemplate.fromTemplate(
 
 final modelParser = model | const StringOutputParser();
 
-final colorGenerator = Runnable.getMapFromItem('attribute') |
+final colorGenerator = Runnable.getMapFromInput('attribute') |
     promptTemplate1 |
     Runnable.fromMap({
       'color': modelParser,
@@ -104,11 +104,11 @@ final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
 final model = ChatOpenAI(apiKey: openaiApiKey);
 const stringOutputParser = StringOutputParser();
 
-final planner = Runnable.getMapFromItem('input') |
+final planner = Runnable.getMapFromInput() |
     ChatPromptTemplate.fromTemplate('Generate an argument about: {input}') |
     model |
     stringOutputParser |
-    Runnable.getMapFromItem('base_response');
+    Runnable.getMapFromInput('base_response');
 
 final argumentsFor = ChatPromptTemplate.fromTemplate(
       'List the pros or positive aspects of {base_response}',

--- a/docs/expression_language/cookbook/prompt_llm_parser.md
+++ b/docs/expression_language/cookbook/prompt_llm_parser.md
@@ -235,7 +235,7 @@ final chain = map | promptTemplate | model | const StringOutputParser();
 However, this is a bit verbose. We can simplify it by using `Runnable.getItemFromMap` which does the same under the hood:
 
 ```dart
-final chain = Runnable.getMapFromItem('foo') |
+final chain = Runnable.getMapFromInput('foo') |
     promptTemplate |
     model |
     const StringOutputParser();

--- a/docs/expression_language/cookbook/tools.md
+++ b/docs/expression_language/cookbook/tools.md
@@ -16,11 +16,11 @@ INPUT:
 
 MATH EXPRESSION:''');
 
-final chain = Runnable.getMapFromItem('input') |
+final chain = Runnable.getMapFromInput() |
     promptTemplate |
     model |
     stringOutputParser |
-    Runnable.getMapFromItem('input') |
+    Runnable.getMapFromInput() |
     CalculatorTool();
 
 final res = await chain.invoke(

--- a/docs/expression_language/interface.md
+++ b/docs/expression_language/interface.md
@@ -25,7 +25,7 @@ The type of the input and output varies by component:
 | `RunnableFunction`          | Runnable input type    | Runnable output type   |
 | `RunnablePassthrough`       | Runnable input type    | Runnable input type    |
 | `RunnableItemFromMap`       | `Map<String, dynamic>` | Runnable output type   |
-| `RunnableMapFromItem`       | Runnable input type    | `Map<String, dynamic>` |
+| `RunnableMapFromInput`       | Runnable input type    | `Map<String, dynamic>` |
 
 You can combine `Runnable` objects into sequences in three ways:
 
@@ -316,13 +316,13 @@ print(res);
 // Aceptamos los siguientes métodos de pago: iDEAL, PayPal y tarjeta de crédito.
 ```
 
-### RunnableMapFromItem
+### RunnableMapFromInput
 
-A `RunnableMapFromItem` allows you to output a map with the given key and the input as value.
+A `RunnableMapFromInput` allows you to output a map with the given key and the input as value.
 
-You can create a `RunnableMapFromItem` using the `Runnable.getMapFromItem` static method.
+You can create a `RunnableMapFromInput` using the `Runnable.getMapFromInput` static method.
 
-When you call `invoke` on a `RunnableMapFromItem`, it will take the input it receives and returns a map with the given key and the input as value.
+When you call `invoke` on a `RunnableMapFromInput`, it will take the input it receives and returns a map with the given key and the input as value.
 
 It is equivalent to:
 
@@ -342,7 +342,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
   'Tell me a joke about {foo}',
 );
 
-final chain = Runnable.getMapFromItem('foo') |
+final chain = Runnable.getMapFromInput('foo') |
     promptTemplate |
     model |
     const StringOutputParser();

--- a/examples/docs_examples/bin/expression_language/cookbook/multiple_chains.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/multiple_chains.dart
@@ -62,7 +62,7 @@ Future<void> _multipleChains2() async {
 
   final modelParser = model | const StringOutputParser();
 
-  final colorGenerator = Runnable.getMapFromItem('attribute') |
+  final colorGenerator = Runnable.getMapFromInput('attribute') |
       promptTemplate1 |
       Runnable.fromMap({
         'color': modelParser,
@@ -89,11 +89,11 @@ Future<void> _branchingAndMerging() async {
   final model = ChatOpenAI(apiKey: openaiApiKey);
   const stringOutputParser = StringOutputParser();
 
-  final planner = Runnable.getMapFromItem('input') |
+  final planner = Runnable.getMapFromInput() |
       ChatPromptTemplate.fromTemplate('Generate an argument about: {input}') |
       model |
       stringOutputParser |
-      Runnable.getMapFromItem('base_response');
+      Runnable.getMapFromInput('base_response');
 
   final argumentsFor = ChatPromptTemplate.fromTemplate(
         'List the pros or positive aspects of {base_response}',

--- a/examples/docs_examples/bin/expression_language/cookbook/prompt_llm_parser.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/prompt_llm_parser.dart
@@ -230,7 +230,7 @@ Future<void> _simplifyingInput() async {
     'Tell me a joke about {foo}',
   );
 
-  final chain = Runnable.getMapFromItem('foo') |
+  final chain = Runnable.getMapFromInput('foo') |
       promptTemplate |
       model |
       const StringOutputParser();

--- a/examples/docs_examples/bin/expression_language/cookbook/tools.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/tools.dart
@@ -22,11 +22,11 @@ INPUT:
 
 MATH EXPRESSION:''');
 
-  final chain = Runnable.getMapFromItem('input') |
+  final chain = Runnable.getMapFromInput() |
       promptTemplate |
       model |
       stringOutputParser |
-      Runnable.getMapFromItem('input') |
+      Runnable.getMapFromInput() |
       CalculatorTool();
 
   final res = await chain.invoke(

--- a/examples/docs_examples/bin/expression_language/interface.dart
+++ b/examples/docs_examples/bin/expression_language/interface.dart
@@ -17,7 +17,7 @@ void main(final List<String> arguments) async {
   await _runnableTypesRunnableFunction();
   await _runnableTypesRunnablePassthrough();
   await _runnableTypesRunnableItemFromMap();
-  await _runnableTypesRunnableMapFromItem();
+  await _runnableTypesRunnableMapFromInput();
 }
 
 Future<void> _runnableInterfaceInvoke() async {
@@ -233,7 +233,7 @@ Answer in the following language: {language}''');
   // crédito.
 }
 
-Future<void> _runnableTypesRunnableMapFromItem() async {
+Future<void> _runnableTypesRunnableMapFromInput() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
   final model = ChatOpenAI(apiKey: openaiApiKey);
 
@@ -241,7 +241,7 @@ Future<void> _runnableTypesRunnableMapFromItem() async {
     'Tell me a joke about {foo}',
   );
 
-  final chain = Runnable.getMapFromItem('foo') |
+  final chain = Runnable.getMapFromInput('foo') |
       promptTemplate |
       model |
       const StringOutputParser();

--- a/packages/langchain/lib/src/core/runnable/base.dart
+++ b/packages/langchain/lib/src/core/runnable/base.dart
@@ -86,13 +86,11 @@ abstract class Runnable<RunInput extends Object?,
     return RunnableItemFromMap<RunOutput>(key);
   }
 
-  /// Creates a [RunnableMapFromItem] which output a map with the given key and
+  /// Creates a [RunnableMapFromInput] which output a map with the given key and
   /// the input as value.
   static Runnable<RunInput, BaseLangChainOptions, Map<String, dynamic>>
-      getMapFromItem<RunInput extends Object>(
-    final String key,
-  ) {
-    return RunnableMapFromItem<RunInput>(key);
+      getMapFromInput<RunInput extends Object>([final String key = 'input']) {
+    return RunnableMapFromInput<RunInput>(key);
   }
 
   /// Invokes the [Runnable] on the given [input].

--- a/packages/langchain/lib/src/core/runnable/input_getter.dart
+++ b/packages/langchain/lib/src/core/runnable/input_getter.dart
@@ -60,14 +60,14 @@ class RunnableItemFromMap<RunOutput extends Object>
   }
 }
 
-/// {@template runnable_map_from_item}
-/// A [RunnableMapFromItem] allows you to output a map with the given key and
+/// {@template runnable_map_from_input}
+/// A [RunnableMapFromInput] allows you to output a map with the given key and
 /// the input as value.
 ///
-/// You can create a [RunnableMapFromItem] using the [Runnable.getMapFromItem]
+/// You can create a [RunnableMapFromInput] using the [Runnable.getMapFromInput]
 /// static method.
 ///
-/// When you call [invoke] on a [RunnableMapFromItem], it will take the input
+/// When you call [invoke] on a [RunnableMapFromInput], it will take the input
 /// it receives and returns a map with the given key and the input as value.
 ///
 /// It is equivalent to:
@@ -88,7 +88,7 @@ class RunnableItemFromMap<RunOutput extends Object>
 ///   'Tell me a joke about {foo}',
 /// );
 ///
-/// final chain = Runnable.getMapFromItem('foo') |
+/// final chain = Runnable.getMapFromInput('foo') |
 ///     promptTemplate |
 ///     model |
 ///     const StringOutputParser();
@@ -98,17 +98,17 @@ class RunnableItemFromMap<RunOutput extends Object>
 /// // Why don't bears wear shoes? Because they have bear feet!
 /// ```
 /// {@endtemplate}
-class RunnableMapFromItem<RunInput extends Object>
+class RunnableMapFromInput<RunInput extends Object>
     extends Runnable<RunInput, BaseLangChainOptions, Map<String, dynamic>> {
-  /// {@macro runnable_map_from_item}
-  const RunnableMapFromItem(this.key);
+  /// {@macro runnable_map_from_input}
+  const RunnableMapFromInput(this.key);
 
   /// The key where to place the input in the output map.
   final String key;
 
-  /// Invokes the [RunnableMapFromItem] on the given [input].
+  /// Invokes the [RunnableMapFromInput] on the given [input].
   ///
-  /// - [input] - the input to invoke the [RunnableMapFromItem] on.
+  /// - [input] - the input to invoke the [RunnableMapFromInput] on.
   /// - [options] - not used.
   @override
   Future<Map<String, dynamic>> invoke(

--- a/packages/langchain/test/core/runnable/input_getter_test.dart
+++ b/packages/langchain/test/core/runnable/input_getter_test.dart
@@ -11,8 +11,8 @@ void main() {
       expect(res, 'foo1');
     });
 
-    test('RunnableMapFromItem from Runnable.getMapFromItem', () async {
-      final chain = Runnable.getMapFromItem('foo');
+    test('RunnableMapFromInput from Runnable.getMapFromInput', () async {
+      final chain = Runnable.getMapFromInput('foo');
 
       final res = await chain.invoke('foo1');
       expect(res, {'foo': 'foo1'});
@@ -30,8 +30,8 @@ void main() {
       expect(item, 'foo1');
     });
 
-    test('Streaming RunnableMapFromItem', () async {
-      final chain = Runnable.getMapFromItem('foo');
+    test('Streaming RunnableMapFromInput', () async {
+      final chain = Runnable.getMapFromInput('foo');
       final stream = chain.stream('foo1');
 
       final streamList = await stream.toList();

--- a/packages/langchain/test/core/runnable/passthrough_test.dart
+++ b/packages/langchain/test/core/runnable/passthrough_test.dart
@@ -10,7 +10,7 @@ void main() {
       const outputParser = StringOutputParser<AIChatMessage>();
       final chain = Runnable.fromMap({
         'in': Runnable.passthrough(),
-        'out': Runnable.getMapFromItem('input') | prompt | model | outputParser,
+        'out': Runnable.getMapFromInput() | prompt | model | outputParser,
       });
 
       final res = await chain.invoke('world');


### PR DESCRIPTION
`RunnableMapFromItem` has been renamed to `RunnableMapFromInput`.
And its corresponding factory from `Runnable.getMapFromItem()` to `Runnable.getMapFromInput()`.
