### PR TITLE
fix(storage): Conditionally import dart:io in LocalFileStore

### DIFF
--- a/packages/langchain/lib/src/storage/file_system_io.dart
+++ b/packages/langchain/lib/src/storage/file_system_io.dart
@@ -4,10 +4,12 @@ import 'dart:typed_data';
 
 import 'base.dart';
 
-/// {@template local_file_store}
+/// {@template local_file_store_io}
 /// A simple file system implementation of a [BaseStore].
 ///
 /// Given a [rootPath], each key is mapped to a file relative to that path.
+///
+/// Note: [LocalFileStore] is not supported for web.
 ///
 /// Example:
 /// ```dart
@@ -15,7 +17,7 @@ import 'base.dart';
 /// ```
 /// {@endtemplate}
 class LocalFileStore implements BaseStore<String, Uint8List> {
-  /// {@macro local_file_store}
+  /// {@macro local_file_store_io}
   LocalFileStore(this.rootPath);
 
   /// The root path of the store.

--- a/packages/langchain/lib/src/storage/file_system_stub.dart
+++ b/packages/langchain/lib/src/storage/file_system_stub.dart
@@ -1,0 +1,49 @@
+import 'dart:typed_data';
+
+import 'base.dart';
+
+/// {@template local_file_store_stub}
+/// A simple file system implementation of a [BaseStore].
+///
+/// Given a [rootPath], each key is mapped to a file relative to that path.
+///
+/// Note: [LocalFileStore] is not supported for web.
+///
+/// Example:
+/// ```dart
+/// final store = LocalFileStore('/tmp');
+/// ```
+/// {@endtemplate}
+class LocalFileStore implements BaseStore<String, Uint8List> {
+  /// {@macro local_file_store_stub}
+  LocalFileStore(this.rootPath) {
+    throw _unimplementedError;
+  }
+
+  /// The root path of the store.
+  final String rootPath;
+
+  @override
+  Future<void> delete(final List<String> keys) {
+    throw _unimplementedError;
+  }
+
+  @override
+  Future<List<Uint8List?>> get(final List<String> keys) {
+    throw _unimplementedError;
+  }
+
+  @override
+  Future<void> set(final List<(String, Uint8List)> keyValuePairs) {
+    throw _unimplementedError;
+  }
+
+  @override
+  Stream<String> yieldKeys({final String? prefix}) {
+    throw _unimplementedError;
+  }
+
+  UnimplementedError get _unimplementedError => throw UnimplementedError(
+        'LocalFileStore is not supported for web.',
+      );
+}

--- a/packages/langchain/lib/src/storage/storage.dart
+++ b/packages/langchain/lib/src/storage/storage.dart
@@ -1,4 +1,4 @@
 export 'base.dart';
 export 'encoder_backed.dart';
-export 'file_system.dart';
+export 'file_system_stub.dart' if (dart.library.io) 'file_system_io.dart';
 export 'in_memory.dart';


### PR DESCRIPTION
Currently, pub.dev doesn't show web as a supported platform because `LocalFileStore` depends on `dart:io`.

This PR implements a stub of `LocalFileStore` for web and conditionally exports it.
