### PR TITLE
feat(chat-models)!: Move all model config options to ChatOpenAIOptions

### DIFF
--- a/docs/expression_language/cookbook/tools.md
+++ b/docs/expression_language/cookbook/tools.md
@@ -4,7 +4,10 @@ Tools are also runnables, and can therefore be used within a chain:
 
 ```dart
 final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
-final model = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final model = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(temperature: 0),
+);
 const stringOutputParser = StringOutputParser();
 
 final promptTemplate = ChatPromptTemplate.fromTemplate('''

--- a/docs/get_started/quickstart.md
+++ b/docs/get_started/quickstart.md
@@ -126,7 +126,10 @@ However, the advantages of using these over raw string formatting are several. Y
 `PromptTemplates` can also be used to produce a list of messages. In this case, the prompt not only contains information about the content, but also each message (its role, its position in the list, etc) Here, what happens most often is a `ChatPromptTemplate` is a list of `ChatMessagePromptTemplates`. Each `ChatMessagePromptTemplate` contains instructions for how to format that `ChatMessage` - its role, and then also its content. Let's take a look at this below:
 
 ```dart
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final chat = final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(temperature: 0),
+);
 
 const systemTemplate = 'You are a helpful assistant that translates {input_language} to {output_language}.';
 final systemMessagePrompt = SystemChatMessagePromptTemplate.fromTemplate(systemTemplate);

--- a/docs/modules/agents/agent_types/openai_functions_agent.md
+++ b/docs/modules/agents/agent_types/openai_functions_agent.md
@@ -15,8 +15,10 @@ The OpenAI Functions Agent is designed to work with these models.
 ```dart
 final llm = ChatOpenAI(
   apiKey: openaiApiKey,
-  model: 'gpt-4',
-  temperature: 0,
+  defaultOptions: const ChatOpenAIOptions(
+    model: 'gpt-4',
+    temperature: 0,
+  ),
 );
 final tool = CalculatorTool();
 final agent = OpenAIFunctionsAgent.fromLLMAndTools(llm: llm, tools: [tool]);
@@ -32,7 +34,7 @@ Let's see an example of how to do this:
 ```dart
 final llm = ChatOpenAI(
   apiKey: openaiApiKey,
-  temperature: 0,
+  defaultOptions: const ChatOpenAIOptions(temperature: 0),
 );
 
 final tool = BaseTool.fromFunction(
@@ -91,8 +93,11 @@ final tool = CalculatorTool();
 
 final model = ChatOpenAI(
   apiKey: openaiApiKey,
-  temperature: 0,
-).bind(ChatOpenAIOptions(functions: [tool.toChatFunction()]));
+  defaultOptions: ChatOpenAIOptions(
+    temperature: 0,
+    functions: [tool.toChatFunction()],
+  ),
+);
 
 const outputParser = OpenAIFunctionsAgentOutputParser();
 

--- a/docs/modules/agents/agents.md
+++ b/docs/modules/agents/agents.md
@@ -73,11 +73,9 @@ and the executor be an action agent.
 First, let's load the language model we're going to use to control the agent.
 
 ```dart
-
 final llm = ChatOpenAI(
-  apiKey: openaiApiKey,
-  model: 'gpt-3.5-turbo-0613',
-  temperature: 0,
+  apiKey: openAiKey,
+  defaultOptions: const ChatOpenAIOptions(temperature: 0),
 );
 ```
 
@@ -85,7 +83,6 @@ Next, let's load some tools to use. In this case, we're going to use a
 calculator.
 
 ```dart
-
 final tool = CalculatorTool();
 final tools = [tool];
 ```

--- a/docs/modules/agents/tools/calculator.md
+++ b/docs/modules/agents/tools/calculator.md
@@ -8,7 +8,10 @@ Example:
 final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
 final llm = ChatOpenAI(
   apiKey: openaiApiKey,
-  temperature: 0,
+  defaultOptions: const ChatOpenAIOptions(
+    model: 'gpt-4',
+    temperature: 0,
+  ),
 );
 final tool = CalculatorTool();
 final agent = OpenAIFunctionsAgent.fromLLMAndTools(llm: llm, tools: [tool]);

--- a/docs/modules/agents/tools/openai_dall_e.md
+++ b/docs/modules/agents/tools/openai_dall_e.md
@@ -9,8 +9,10 @@ Example:
 ```dart
 final llm = ChatOpenAI(
   apiKey: openAiKey,
-  model: 'gpt-4',
-  temperature: 0,
+  defaultOptions: const ChatOpenAIOptions(
+    model: 'gpt-4',
+    temperature: 0,
+  ),
 );
 final tools = [
   CalculatorTool(),

--- a/docs/modules/chains/chains.md
+++ b/docs/modules/chains/chains.md
@@ -74,7 +74,12 @@ print(res);
 You can use a chat model in an LLMChain as well:
 
 ```dart
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final chat = final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+);
 
 const template = 'What is a good name for a company that makes {product}?';
 final humanMessagePrompt = HumanChatMessagePromptTemplate.fromTemplate(template);

--- a/docs/modules/chains/getting_started.md
+++ b/docs/modules/chains/getting_started.md
@@ -1,14 +1,17 @@
 # Getting Started
 
-
-
 ## Different ways of calling chains
 
 All classes inherited from `BaseChain` offer a few ways of running chain logic. The most direct one 
 is by `call()` (a chain is a [callable object](https://dart.dev/language/callable-objects)):
 
 ```dart
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final chat = final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+);
 const template = 'Tell me a {adjective} joke';
 final prompt = PromptTemplate.fromTemplate(template);
 final chain = LLMChain(llm: chat, prompt: prompt);
@@ -58,7 +61,12 @@ Tips: You can easily integrate a Chain object as a Tool in your Agent via its ru
 persist data across multiple calls. In other words, it makes `Chain` a stateful object.
 
 ```dart
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final chat = final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+);
 final memory = ConversationBufferMemory(returnMessages: true);
 final conversation = ConversationChain(llm: chat, memory: memory);
 

--- a/docs/modules/chains/how_to/call_methods.md
+++ b/docs/modules/chains/how_to/call_methods.md
@@ -5,7 +5,12 @@ The most direct one is by `call()` (a chain is a
 [callable object](https://dart.dev/language/callable-objects)):
 
 ```dart
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final chat = final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+);
 const template = 'Tell me a {adjective} joke';
 final prompt = PromptTemplate.fromTemplate(template);
 final chain = LLMChain(llm: chat, prompt: prompt);
@@ -59,7 +64,12 @@ run method.
 `Chain` a stateful object.
 
 ```dart
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final chat = final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+);
 final memory = ConversationBufferMemory(returnMessages: true);
 final conversation = ConversationChain(llm: chat, memory: memory);
 

--- a/docs/modules/model_io/models/chat_models/chat_models.md
+++ b/docs/modules/model_io/models/chat_models/chat_models.md
@@ -31,7 +31,12 @@ import 'package:langchain_openai/langchain_openai.dart';
 
 We can then instantiate the chat model:
 ```dart
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final chat = final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+);
 ```
 
 ### Messages

--- a/docs/modules/model_io/models/chat_models/how_to/llm_chain.md
+++ b/docs/modules/model_io/models/chat_models/how_to/llm_chain.md
@@ -5,7 +5,12 @@ You can use the existing `LLMChain` in a very similar way as
 model.
 
 ```dart
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final chat = final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+);
 
 const template = 'You are a helpful assistant that translates {input_language} to {output_language}.';
 final systemMessagePrompt = SystemChatMessagePromptTemplate.fromTemplate(template);

--- a/docs/modules/model_io/models/chat_models/how_to/prompts.md
+++ b/docs/modules/model_io/models/chat_models/how_to/prompts.md
@@ -14,7 +14,7 @@ you were to use this template, this is what it would look like:
 ```dart
 const template = 'You are a helpful assistant that translates {input_language} to {output_language}.';
 final systemMessagePrompt = SystemChatMessagePromptTemplate.fromTemplate(template);
-const  humanTemplate = '{text}';
+const humanTemplate = '{text}';
 final humanMessagePrompt = HumanChatMessagePromptTemplate.fromTemplate(humanTemplate);
 
 final chatPrompt = ChatPromptTemplate.fromPromptMessages(

--- a/docs/modules/model_io/models/chat_models/integrations/openai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/openai.md
@@ -9,7 +9,12 @@ OpenAI [models](https://platform.openai.com/docs/models) using the Chat API.
 ```dart
 final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
 
-final chatModel = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+final chatModel = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+);
 
 const template = 'You are a helpful assistant that translates {input_language} to {output_language}.';
 final systemMessagePrompt = SystemChatMessagePromptTemplate.fromTemplate(template);
@@ -79,7 +84,12 @@ const function = ChatFunction(
 final promptTemplate = ChatPromptTemplate.fromTemplate(
   'tell me a long joke about {foo}',
 );
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
+final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+).bind(
   ChatOpenAIOptions(
     functions: const [function],
     functionCall: ChatFunctionCall.forced(functionName: 'joke'),
@@ -127,10 +137,12 @@ final prompt = PromptValue.chat([
 ]);
 final llm = ChatOpenAI(
   apiKey: openaiApiKey,
-  model: 'gpt-4-1106-preview',
-  temperature: 0,
-  responseFormat: const ChatOpenAIResponseFormat(
-    type: ChatOpenAIResponseFormatType.jsonObject,
+  defaultOptions: const ChatOpenAIOptions(
+    model: 'gpt-4-1106-preview',
+    temperature: 0,
+    responseFormat: ChatOpenAIResponseFormat(
+      type: ChatOpenAIResponseFormatType.jsonObject,
+    ),
   ),
 );
 final res = await llm.invoke(prompt);

--- a/docs/modules/model_io/models/chat_models/integrations/prem.md
+++ b/docs/modules/model_io/models/chat_models/integrations/prem.md
@@ -6,10 +6,7 @@ the OpenAI API.
 
 ```dart
 const localUrl = 'http://localhost:8000'; // Check Prem app for the actual URL
-final chat = ChatOpenAI(
-    baseUrl: localUrl,
-    temperature: 0,
-);
+final chat = ChatOpenAI(baseUrl: localUrl);
 
 const template = 'You are a helpful assistant that translates {input_language} to {output_language}.';
 final systemMessagePrompt = SystemChatMessagePromptTemplate.fromTemplate(template);

--- a/docs/modules/model_io/output_parsers/functions.md
+++ b/docs/modules/model_io/output_parsers/functions.md
@@ -27,7 +27,12 @@ const function = ChatFunction(
 final promptTemplate = ChatPromptTemplate.fromTemplate(
   'tell me a long joke about {foo}',
 );
-final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
+final chat = ChatOpenAI(
+  apiKey: openaiApiKey,
+  defaultOptions: const ChatOpenAIOptions(
+    temperature: 0,
+  ),
+).bind(
   ChatOpenAIOptions(
     functions: const [function],
     functionCall: ChatFunctionCall.forced(functionName: 'joke'),

--- a/docs/modules/retrieval/retrievers/retrievers.md
+++ b/docs/modules/retrieval/retrievers/retrievers.md
@@ -60,9 +60,8 @@ final docSearch = await MemoryVectorStore.fromDocuments(
   embeddings: embeddings,
 );
 final llm = ChatOpenAI(
-  apiKey: openaiApiKey,
-  model: 'gpt-3.5-turbo-0613',
-  temperature: 0,
+  apiKey: openAiKey,
+  defaultOptions: const ChatOpenAIOptions(temperature: 0),
 );
 final qaChain = OpenAIQAWithSourcesChain(llm: llm);
 final docPrompt = PromptTemplate.fromTemplate(

--- a/docs/modules/retrieval/vector_stores/integrations/memory.md
+++ b/docs/modules/retrieval/vector_stores/integrations/memory.md
@@ -29,9 +29,8 @@ final docSearch = await MemoryVectorStore.fromDocuments(
   embeddings: embeddings,
 );
 final llm = ChatOpenAI(
-  apiKey: openaiApiKey,
-  model: 'gpt-3.5-turbo-0613',
-  temperature: 0,
+  apiKey: openAiKey,
+  defaultOptions: const ChatOpenAIOptions(temperature: 0),
 );
 final qaChain = OpenAIQAWithSourcesChain(llm: llm);
 final docPrompt = PromptTemplate.fromTemplate(

--- a/examples/docs_examples/bin/expression_language/cookbook/tools.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/tools.dart
@@ -10,7 +10,12 @@ void main(final List<String> arguments) async {
 
 Future<void> _calculator() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
-  final model = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+  final model = ChatOpenAI(
+    apiKey: openaiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0,
+    ),
+  );
   const stringOutputParser = StringOutputParser();
 
   final promptTemplate = ChatPromptTemplate.fromTemplate('''

--- a/examples/docs_examples/bin/expression_language/interface.dart
+++ b/examples/docs_examples/bin/expression_language/interface.dart
@@ -267,7 +267,7 @@ Future<void> _runnableTypesRunnableMapInput() async {
 
   final model = ChatOpenAI(
     apiKey: openaiApiKey,
-    temperature: 0,
+    defaultOptions: const ChatOpenAIOptions(temperature: 0),
   ).bind(ChatOpenAIOptions(functions: [tool.toChatFunction()]));
 
   const outputParser = OpenAIFunctionsAgentOutputParser();

--- a/examples/docs_examples/bin/modules/agents/agent_types/openai_functions_agent.dart
+++ b/examples/docs_examples/bin/modules/agents/agent_types/openai_functions_agent.dart
@@ -14,8 +14,10 @@ Future<void> _openaiFunctionsAgent() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
   final llm = ChatOpenAI(
     apiKey: openaiApiKey,
-    model: 'gpt-4',
-    temperature: 0,
+    defaultOptions: const ChatOpenAIOptions(
+      model: 'gpt-4',
+      temperature: 0,
+    ),
   );
   final tool = CalculatorTool();
   final agent = OpenAIFunctionsAgent.fromLLMAndTools(llm: llm, tools: [tool]);
@@ -28,7 +30,7 @@ Future<void> _openaiFunctionsAgentCustomToolsMemory() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
   final llm = ChatOpenAI(
     apiKey: openaiApiKey,
-    temperature: 0,
+    defaultOptions: const ChatOpenAIOptions(temperature: 0),
   );
 
   final tool = BaseTool.fromFunction(
@@ -90,8 +92,11 @@ Future<void> _openaiFunctionsAgentLCEL() async {
 
   final model = ChatOpenAI(
     apiKey: openaiApiKey,
-    temperature: 0,
-  ).bind(ChatOpenAIOptions(functions: [tool.toChatFunction()]));
+    defaultOptions: ChatOpenAIOptions(
+      temperature: 0,
+      functions: [tool.toChatFunction()],
+    ),
+  );
 
   const outputParser = OpenAIFunctionsAgentOutputParser();
 

--- a/examples/docs_examples/bin/modules/agents/tools/calculator.dart
+++ b/examples/docs_examples/bin/modules/agents/tools/calculator.dart
@@ -8,8 +8,10 @@ void main() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
   final llm = ChatOpenAI(
     apiKey: openaiApiKey,
-    model: 'gpt-4',
-    temperature: 0,
+    defaultOptions: const ChatOpenAIOptions(
+      model: 'gpt-4',
+      temperature: 0,
+    ),
   );
   final tool = CalculatorTool();
   final agent = OpenAIFunctionsAgent.fromLLMAndTools(llm: llm, tools: [tool]);

--- a/examples/docs_examples/bin/modules/agents/tools/openai_dalle.dart
+++ b/examples/docs_examples/bin/modules/agents/tools/openai_dalle.dart
@@ -8,8 +8,10 @@ void main() async {
   final openAiKey = Platform.environment['OPENAI_API_KEY'];
   final llm = ChatOpenAI(
     apiKey: openAiKey,
-    model: 'gpt-4',
-    temperature: 0,
+    defaultOptions: const ChatOpenAIOptions(
+      model: 'gpt-4',
+      temperature: 0,
+    ),
   );
   final tools = [
     CalculatorTool(),

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/openai.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/openai.dart
@@ -14,7 +14,12 @@ void main(final List<String> arguments) async {
 Future<void> _chatOpenAI() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
 
-  final chatModel = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+  final chatModel = ChatOpenAI(
+    apiKey: openaiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0,
+    ),
+  );
 
   const template =
       'You are a helpful assistant that translates {input_language} to {output_language}.';
@@ -86,7 +91,12 @@ Future<void> _chatOpenAIStreamingFunctions() async {
   final promptTemplate = ChatPromptTemplate.fromTemplate(
     'tell me a long joke about {foo}',
   );
-  final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
+  final chat = ChatOpenAI(
+    apiKey: openaiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0,
+    ),
+  ).bind(
     ChatOpenAIOptions(
       functions: const [function],
       functionCall: ChatFunctionCall.forced(functionName: 'joke'),
@@ -131,10 +141,12 @@ Future<void> _chatOpenAIJsonMode() async {
   ]);
   final llm = ChatOpenAI(
     apiKey: openaiApiKey,
-    model: 'gpt-4-1106-preview',
-    temperature: 0,
-    responseFormat: const ChatOpenAIResponseFormat(
-      type: ChatOpenAIResponseFormatType.jsonObject,
+    defaultOptions: const ChatOpenAIOptions(
+      model: 'gpt-4-1106-preview',
+      temperature: 0,
+      responseFormat: ChatOpenAIResponseFormat(
+        type: ChatOpenAIResponseFormatType.jsonObject,
+      ),
     ),
   );
   final res = await llm.invoke(prompt);

--- a/examples/docs_examples/bin/modules/model_io/output_parsers/functions.dart
+++ b/examples/docs_examples/bin/modules/model_io/output_parsers/functions.dart
@@ -36,7 +36,12 @@ Future<void> _outputFunctionsParser() async {
   final promptTemplate = ChatPromptTemplate.fromTemplate(
     'tell me a long joke about {foo}',
   );
-  final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
+  final chat = ChatOpenAI(
+    apiKey: openaiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0,
+    ),
+  ).bind(
     ChatOpenAIOptions(
       functions: const [function],
       functionCall: ChatFunctionCall.forced(functionName: 'joke'),
@@ -73,7 +78,12 @@ Future<void> _jsonOutputFunctionsParser() async {
   final promptTemplate = ChatPromptTemplate.fromTemplate(
     'tell me a long joke about {foo}',
   );
-  final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
+  final chat = ChatOpenAI(
+    apiKey: openaiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0,
+    ),
+  ).bind(
     ChatOpenAIOptions(
       functions: const [function],
       functionCall: ChatFunctionCall.forced(functionName: 'joke'),
@@ -110,7 +120,12 @@ Future<void> _jsonOutputFunctionsParserStreaming() async {
   final promptTemplate = ChatPromptTemplate.fromTemplate(
     'tell me a long joke about {foo}',
   );
-  final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
+  final chat = ChatOpenAI(
+    apiKey: openaiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0,
+    ),
+  ).bind(
     ChatOpenAIOptions(
       functions: const [function],
       functionCall: ChatFunctionCall.forced(functionName: 'joke'),
@@ -165,7 +180,12 @@ Future<void> _jsonKeyOutputFunctionsParser() async {
   final promptTemplate = ChatPromptTemplate.fromTemplate(
     'tell me a long joke about {foo}',
   );
-  final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
+  final chat = ChatOpenAI(
+    apiKey: openaiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0,
+    ),
+  ).bind(
     ChatOpenAIOptions(
       functions: const [function],
       functionCall: ChatFunctionCall.forced(functionName: 'joke'),
@@ -202,7 +222,12 @@ Future<void> _jsonKeyOutputFunctionsParserStreaming() async {
   final promptTemplate = ChatPromptTemplate.fromTemplate(
     'tell me a long joke about {foo}',
   );
-  final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
+  final chat = ChatOpenAI(
+    apiKey: openaiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0,
+    ),
+  ).bind(
     ChatOpenAIOptions(
       functions: const [function],
       functionCall: ChatFunctionCall.forced(functionName: 'joke'),

--- a/examples/hello_world_backend/bin/sonnets.dart
+++ b/examples/hello_world_backend/bin/sonnets.dart
@@ -11,7 +11,12 @@ class SonnetsService {
           'OPENAI_API_KEY environment variable.');
       exit(64);
     }
-    _llm = ChatOpenAI(apiKey: openAiApiKey, temperature: 0.9);
+    _llm = ChatOpenAI(
+      apiKey: openAiApiKey,
+      defaultOptions: const ChatOpenAIOptions(
+        temperature: 0.9,
+      ),
+    );
   }
 
   late final ChatOpenAI _llm;

--- a/examples/hello_world_cli/bin/hello_world_cli.dart
+++ b/examples/hello_world_cli/bin/hello_world_cli.dart
@@ -12,7 +12,12 @@ void main(final List<String> arguments) async {
     exit(1);
   }
 
-  final llm = ChatOpenAI(apiKey: openAiApiKey, temperature: 0.9);
+  final llm = ChatOpenAI(
+    apiKey: openAiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0.9,
+    ),
+  );
 
   stdout.writeln('How can I help you?');
 

--- a/packages/langchain_openai/example/langchain_openai_example.dart
+++ b/packages/langchain_openai/example/langchain_openai_example.dart
@@ -25,7 +25,12 @@ Future<void> _example1() async {
 /// This is the most basic one.
 Future<void> _example2() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
-  final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+  final chat = ChatOpenAI(
+    apiKey: openaiApiKey,
+    defaultOptions: const ChatOpenAIOptions(
+      temperature: 0,
+    ),
+  );
 
   while (true) {
     stdout.write('> ');

--- a/packages/langchain_openai/lib/src/chat_models/models/models.dart
+++ b/packages/langchain_openai/lib/src/chat_models/models/models.dart
@@ -1,5 +1,4 @@
 import 'package:langchain/langchain.dart';
-import '../openai.dart';
 
 /// {@template chat_openai_options}
 /// Options to pass into the OpenAI Chat Model.
@@ -7,35 +6,112 @@ import '../openai.dart';
 class ChatOpenAIOptions extends ChatModelOptions {
   /// {@macro chat_openai_options}
   const ChatOpenAIOptions({
+    this.model = 'gpt-3.5-turbo',
+    this.frequencyPenalty = 0,
+    this.logitBias,
+    this.maxTokens,
+    this.n = 1,
+    this.presencePenalty = 0,
+    this.responseFormat,
+    this.seed,
     this.stop,
+    this.temperature = 1,
+    this.topP = 1,
     this.functions,
     this.functionCall,
     this.user,
   });
 
+  /// ID of the model to use (e.g. 'gpt-3.5-turbo').
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-model
+  final String model;
+
+  /// Number between -2.0 and 2.0. Positive values penalize new tokens based on
+  /// their existing frequency in the text so far, decreasing the model's
+  /// likelihood to repeat the same line verbatim.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-frequency_penalty
+  final double frequencyPenalty;
+
+  /// Modify the likelihood of specified tokens appearing in the completion.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-logit_bias
+  final Map<String, int>? logitBias;
+
+  /// The maximum number of tokens to generate in the chat completion.
+  /// Defaults to inf.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens
+  final int? maxTokens;
+
+  /// How many chat completion choices to generate for each input message.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-n
+  final int n;
+
+  /// Number between -2.0 and 2.0. Positive values penalize new tokens based on
+  /// whether they appear in the text so far, increasing the model's likelihood
+  /// to talk about new topics.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-presence_penalty
+  final double presencePenalty;
+
+  /// An object specifying the format that the model must output.
+  ///
+  /// Setting to [ChatOpenAIResponseFormatType.jsonObject] enables JSON mode,
+  /// which guarantees the message the model generates is valid JSON.
+  ///
+  /// Important: when using JSON mode you must still instruct the model to
+  /// produce JSON yourself via some conversation message, for example via your
+  /// system message. If you don't do this, the model may generate an unending
+  /// stream of whitespace until the generation reaches the token limit, which
+  /// may take a lot of time and give the appearance of a "stuck" request.
+  /// Also note that the message content may be partial (i.e. cut off) if
+  /// `finish_reason="length"`, which indicates the generation exceeded
+  /// `max_tokens` or the conversation exceeded the max context length.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format
+  final ChatOpenAIResponseFormat? responseFormat;
+
+  /// This feature is in Beta. If specified, our system will make a best effort
+  /// to sample deterministically, such that repeated requests with the same
+  /// seed and parameters should return the same result. Determinism is not
+  /// guaranteed, and you should refer to the system_fingerprint response
+  /// parameter to monitor changes in the backend.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed
+  final int? seed;
+
   /// Up to 4 sequences where the API will stop generating further tokens.
   ///
-  /// Ref: https://platform.openai.com/docs/api-reference/chat/create#chat/create-stop
+  /// Ref: https://platform.openai.com/docs/api-reference/chat/create#chat-create-stop
   final List<String>? stop;
+
+  /// What sampling temperature to use, between 0 and 2.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature
+  final double temperature;
+
+  /// An alternative to sampling with temperature, called nucleus sampling,
+  /// where the model considers the results of the tokens with top_p
+  /// probability mass.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p
+  final double topP;
 
   /// A list of functions the model may generate JSON inputs for.
   ///
-  /// Ref: https://platform.openai.com/docs/api-reference/chat/create#chat/create-functions
+  /// Ref: https://platform.openai.com/docs/api-reference/chat/create#chat-create-functions
   final List<ChatFunction>? functions;
 
   /// Controls how the model responds to function calls.
   ///
-  /// Ref: https://platform.openai.com/docs/api-reference/chat/create#chat/create-function_call
+  /// Ref: https://platform.openai.com/docs/api-reference/chat/create#chat-create-function_call
   final ChatFunctionCall? functionCall;
 
   /// A unique identifier representing your end-user, which can help OpenAI to
   /// monitor and detect abuse.
-  ///
-  /// If the user does not change between requests, you can set this field in
-  /// [ChatOpenAI.user] instead.
-  ///
-  /// If you specify it in both places, the value in [ChatOpenAIOptions.user]
-  /// will be used.
   ///
   /// Ref: https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids
   final String? user;

--- a/packages/langchain_openai/test/agents/functions_test.dart
+++ b/packages/langchain_openai/test/agents/functions_test.dart
@@ -14,8 +14,7 @@ void main() {
     test('Test OpenAIFunctionsAgent', () async {
       final llm = ChatOpenAI(
         apiKey: openaiApiKey,
-        model: 'gpt-3.5-turbo-0613',
-        temperature: 0,
+        defaultOptions: const ChatOpenAIOptions(temperature: 0),
       );
 
       final tool = CalculatorTool();
@@ -34,8 +33,7 @@ void main() {
     Future<void> testMemory({required final bool returnMessages}) async {
       final llm = ChatOpenAI(
         apiKey: openaiApiKey,
-        model: 'gpt-3.5-turbo-0613',
-        temperature: 0,
+        defaultOptions: const ChatOpenAIOptions(temperature: 0),
       );
 
       final tool = BaseTool.fromFunction(
@@ -120,7 +118,7 @@ void main() {
 
     final model = ChatOpenAI(
       apiKey: openaiApiKey,
-      temperature: 0,
+      defaultOptions: const ChatOpenAIOptions(temperature: 0),
     ).bind(ChatOpenAIOptions(functions: [tool.toChatFunction()]));
 
     final agent = Agent.fromRunnable(

--- a/packages/langchain_openai/test/agents/tools/dall_e_test.dart
+++ b/packages/langchain_openai/test/agents/tools/dall_e_test.dart
@@ -39,8 +39,10 @@ void main() {
         timeout: const Timeout(Duration(minutes: 2)), skip: true, () async {
       final llm = ChatOpenAI(
         apiKey: openAiKey,
-        model: 'gpt-4',
-        temperature: 0,
+        defaultOptions: const ChatOpenAIOptions(
+          model: 'gpt-4',
+          temperature: 0,
+        ),
       );
 
       final tools = [

--- a/packages/langchain_openai/test/chains/qa_with_sources_test.dart
+++ b/packages/langchain_openai/test/chains/qa_with_sources_test.dart
@@ -41,8 +41,10 @@ void main() {
 
       final llm = ChatOpenAI(
         apiKey: openaiApiKey,
-        model: 'gpt-3.5-turbo-0613',
-        temperature: 0,
+        defaultOptions: const ChatOpenAIOptions(
+          model: 'gpt-3.5-turbo-0613',
+          temperature: 0,
+        ),
       );
 
       final qaChain = OpenAIQAWithSourcesChain(llm: llm);

--- a/packages/langchain_openai/test/chat_models/openai_test.dart
+++ b/packages/langchain_openai/test/chat_models/openai_test.dart
@@ -15,29 +15,36 @@ void main() {
     test('Test ChatOpenAI parameters', () async {
       final chat = ChatOpenAI(
         apiKey: openaiApiKey,
-        model: 'foo',
-        temperature: 0.1,
-        topP: 0.1,
-        n: 10,
-        maxTokens: 10,
-        presencePenalty: 0.1,
-        frequencyPenalty: 0.1,
-        logitBias: {'foo': 1},
-        user: 'foo',
+        defaultOptions: const ChatOpenAIOptions(
+          model: 'foo',
+          temperature: 0.1,
+          topP: 0.1,
+          n: 10,
+          maxTokens: 10,
+          presencePenalty: 0.1,
+          frequencyPenalty: 0.1,
+          logitBias: {'foo': 1},
+          user: 'foo',
+        ),
       );
-      expect(chat.model, 'foo');
-      expect(chat.maxTokens, 10);
-      expect(chat.temperature, 0.1);
-      expect(chat.topP, 0.1);
-      expect(chat.n, 10);
-      expect(chat.presencePenalty, 0.1);
-      expect(chat.frequencyPenalty, 0.1);
-      expect(chat.logitBias, {'foo': 1.0});
-      expect(chat.user, 'foo');
+      expect(chat.defaultOptions.model, 'foo');
+      expect(chat.defaultOptions.maxTokens, 10);
+      expect(chat.defaultOptions.temperature, 0.1);
+      expect(chat.defaultOptions.topP, 0.1);
+      expect(chat.defaultOptions.n, 10);
+      expect(chat.defaultOptions.presencePenalty, 0.1);
+      expect(chat.defaultOptions.frequencyPenalty, 0.1);
+      expect(chat.defaultOptions.logitBias, {'foo': 1.0});
+      expect(chat.defaultOptions.user, 'foo');
     });
 
     test('Test call to ChatOpenAI', () async {
-      final chat = ChatOpenAI(apiKey: openaiApiKey, maxTokens: 10);
+      final chat = ChatOpenAI(
+        apiKey: openaiApiKey,
+        defaultOptions: const ChatOpenAIOptions(
+          maxTokens: 10,
+        ),
+      );
       final res = await chat([ChatMessage.humanText('Hello')]);
       expect(res.content, isNotEmpty);
     });
@@ -55,19 +62,29 @@ void main() {
     });
 
     test('Test model output contains metadata', () async {
-      final chat = ChatOpenAI(apiKey: openaiApiKey, maxTokens: 10);
+      final chat = ChatOpenAI(
+        apiKey: openaiApiKey,
+        defaultOptions: const ChatOpenAIOptions(
+          maxTokens: 10,
+        ),
+      );
       final res = await chat.generate(
         [ChatMessage.humanText('Hello, how are you?')],
       );
       expect(res.modelOutput, isNotNull);
       expect(res.modelOutput!['created'], isNotNull);
-      expect(res.modelOutput!['model'], startsWith(chat.model));
+      expect(res.modelOutput!['model'], startsWith(chat.defaultOptions.model));
     });
 
     test('Test stop logic on valid configuration', () async {
       final query =
           ChatMessage.humanText('write an ordered list of five items');
-      final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0);
+      final chat = ChatOpenAI(
+        apiKey: openaiApiKey,
+        defaultOptions: const ChatOpenAIOptions(
+          temperature: 0,
+        ),
+      );
       final res = await chat(
         [query],
         options: const ChatOpenAIOptions(stop: ['3']),
@@ -77,7 +94,12 @@ void main() {
     });
 
     test('Test ChatOpenAI wrapper with system message', () async {
-      final chat = ChatOpenAI(apiKey: openaiApiKey, maxTokens: 10);
+      final chat = ChatOpenAI(
+        apiKey: openaiApiKey,
+        defaultOptions: const ChatOpenAIOptions(
+          maxTokens: 10,
+        ),
+      );
       final systemMessage =
           ChatMessage.system('You are to chat with the user.');
       final humanMessage =
@@ -87,7 +109,13 @@ void main() {
     });
 
     test('Test ChatOpenAI wrapper with multiple completions', () async {
-      final chat = ChatOpenAI(apiKey: openaiApiKey, maxTokens: 10, n: 5);
+      final chat = ChatOpenAI(
+        apiKey: openaiApiKey,
+        defaultOptions: const ChatOpenAIOptions(
+          maxTokens: 10,
+          n: 5,
+        ),
+      );
       final humanMessage = ChatMessage.humanText('Hello');
       final res = await chat.generate([humanMessage]);
       expect(res.generations.length, 5);
@@ -199,9 +227,11 @@ void main() {
       for (final model in models) {
         final chat = ChatOpenAI(
           apiKey: openaiApiKey,
-          model: model,
-          temperature: 0,
-          maxTokens: 1,
+          defaultOptions: ChatOpenAIOptions(
+            model: model,
+            temperature: 0,
+            maxTokens: 1,
+          ),
         );
         final messages = [
           ChatMessage.system(
@@ -269,7 +299,10 @@ void main() {
       final promptTemplate = ChatPromptTemplate.fromTemplate(
         'tell me a long joke about {foo}',
       );
-      final chat = ChatOpenAI(apiKey: openaiApiKey, temperature: 0).bind(
+      final chat = ChatOpenAI(
+        apiKey: openaiApiKey,
+        defaultOptions: const ChatOpenAIOptions(temperature: 0),
+      ).bind(
         ChatOpenAIOptions(
           functions: const [function],
           functionCall: ChatFunctionCall.forced(functionName: 'joke'),
@@ -297,8 +330,10 @@ void main() {
       final prompt = PromptValue.string('How are you?');
       final llm = ChatOpenAI(
         apiKey: openaiApiKey,
-        temperature: 0,
-        seed: 9999,
+        defaultOptions: const ChatOpenAIOptions(
+          temperature: 0,
+          seed: 9999,
+        ),
       );
 
       final res1 = await llm.invoke(prompt);
@@ -328,11 +363,13 @@ void main() {
       ]);
       final llm = ChatOpenAI(
         apiKey: openaiApiKey,
-        model: 'gpt-4-1106-preview',
-        temperature: 0,
-        seed: 9999,
-        responseFormat: const ChatOpenAIResponseFormat(
-          type: ChatOpenAIResponseFormatType.jsonObject,
+        defaultOptions: const ChatOpenAIOptions(
+          model: 'gpt-4-1106-preview',
+          temperature: 0,
+          seed: 9999,
+          responseFormat: ChatOpenAIResponseFormat(
+            type: ChatOpenAIResponseFormatType.jsonObject,
+          ),
         ),
       );
 
@@ -368,7 +405,9 @@ void main() {
       ]);
       final chatModel = ChatOpenAI(
         apiKey: openaiApiKey,
-        model: 'gpt-4-vision-preview',
+        defaultOptions: const ChatOpenAIOptions(
+          model: 'gpt-4-vision-preview',
+        ),
       );
 
       final res = await chatModel.invoke(prompt);


### PR DESCRIPTION
Until now, `ChatOpenAI` completions wrapper used to accept the completions request parameters (e.g. `temperature`) in the constructor as parameters. Like:

```
final chatModel = ChatOpenAI(apiKey: openaiApiKey, temperature: 0.9);
```

This was not ideal, as it was not possible to change the parameters after the object was created. So, for example, if you wanted to change the temperature, you had to create a new instance.

Now, all the completions request parameters are part of the `ChatOpenAIOptions` class.

When you create an instance of `ChatOpenAI`, you can define the `defaultOptions` that will be used for all the completions requests.

If you want to change the parameters for a specific request, you can pass the desired `ChatOpenAIOptions` when making the request. The options passed in the request will override the `defaultOptions`.

## Migration

Move all the request parameters from the constructor to the `defaultOptions` parameter.

Before:

```dart
final chatModel = ChatOpenAI(
  apiKey: openaiApiKey,
  temperature: 0.9,
  maxTokens: 100,
);
```

Now:

```dart
final chatModel = ChatOpenAI(
  apiKey: openaiApiKey,
  defaultOptions: const ChatOpenAIOptions(
    temperature: 0.9,
    maxTokens: 100,
  ),
);
```

## Example of using different options for different requests

```dart
final prompt = PromptValue.string('How are you?');
final chatModel = ChatOpenAI(
  apiKey: openaiApiKey,
  defaultOptions: const ChatOpenAIOptions(
    temperature: 0,
    maxTokens: 50,
  ),
);

final res1 = await chatModel.invoke(prompt);

final res2 = await chatModel.invoke(
  prompt,
  options: const ChatOpenAIOptions(seed: 9999),
);
```

You can also change the options in a `Runnable` pipeline using the `bind` method. In this case, we are using two totally different models for each question:

```dart
final chatModel = ChatOpenAI(apiKey: openaiApiKey,);
const outputParser = StringOutputParser();
final prompt1 = PromptTemplate.fromTemplate('How are you {name}?');
final prompt2 = PromptTemplate.fromTemplate('How old are you {name}?');
final chain = Runnable.fromMap({
  'q1': prompt1 | chatModel.bind(const ChatOpenAIOptions(model: 'gpt-4')) | outputParser,
  'q2': prompt2| chatModel.bind(const ChatOpenAIOptions(model: 'gpt-3.5-turbo')) | outputParser,
});
final res = await chain.invoke({'name': 'David'});
```

## OpenAI Functions

Before, you can only defined the available functions when calling the moment. Now you can also define the functions when instantiating the `ChatOpenAI` wrapper.

Before:
```dart
final tool = CalculatorTool();
final model = ChatOpenAI(
  apiKey: openaiApiKey,
  temperature: 0,
).bind(ChatOpenAIOptions(functions: [tool.toChatFunction()]));
```

Now:
```dart
final tool = CalculatorTool();
final model = ChatOpenAI(
  apiKey: openaiApiKey,
  defaultOptions: ChatOpenAIOptions(
    temperature: 0,
    functions: [tool.toChatFunction()],
  ),
);
```