### PR TITLE
feat(tools)!: Allow to pass call options to tools

### DIFF
--- a/docs/modules/agents/agent_types/openai_functions_agent.md
+++ b/docs/modules/agents/agent_types/openai_functions_agent.md
@@ -54,7 +54,10 @@ final tool = BaseTool.fromFunction(
     },
     'required': ['query'],
   },
-  func: (final Map<String, dynamic> toolInput) async {
+  func: (
+      final Map<String, dynamic> toolInput, {
+      final ToolOptions? options,
+  }) async {
     final query = toolInput['query'];
     final n = toolInput['n'];
     return callYourSearchFunction(query, n);

--- a/docs/modules/agents/tools/openai_dall_e.md
+++ b/docs/modules/agents/tools/openai_dall_e.md
@@ -14,7 +14,7 @@ final llm = ChatOpenAI(
     temperature: 0,
   ),
 );
-final tools = [
+final tools = <BaseTool>[
   CalculatorTool(),
   OpenAIDallETool(apiKey: openAiKey),
 ];

--- a/examples/docs_examples/bin/modules/agents/agent_types/openai_functions_agent.dart
+++ b/examples/docs_examples/bin/modules/agents/agent_types/openai_functions_agent.dart
@@ -50,7 +50,10 @@ Future<void> _openaiFunctionsAgentCustomToolsMemory() async {
       },
       'required': ['query'],
     },
-    func: (final Map<String, dynamic> toolInput) async {
+    func: (
+      final Map<String, dynamic> toolInput, {
+      final ToolOptions? options,
+    }) async {
       final query = toolInput['query'];
       final n = toolInput['n'];
       return callYourSearchFunction(query, n);

--- a/examples/docs_examples/bin/modules/agents/tools/openai_dalle.dart
+++ b/examples/docs_examples/bin/modules/agents/tools/openai_dalle.dart
@@ -13,7 +13,7 @@ void main() async {
       temperature: 0,
     ),
   );
-  final tools = [
+  final tools = <BaseTool>[
     CalculatorTool(),
     OpenAIDallETool(apiKey: openAiKey),
   ];

--- a/packages/langchain/lib/src/agents/tools/calculator.dart
+++ b/packages/langchain/lib/src/agents/tools/calculator.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:math_expressions/math_expressions.dart';
 
 import 'base.dart';
+import 'models/models.dart';
 
 /// {@template calculator_tool}
 /// A tool that can be used to calculate the result of a math expression.
@@ -21,7 +22,7 @@ import 'base.dart';
 /// print(res); // -> '40 raised to the power of 0.43 is approximately 4.8852'
 /// ```
 /// {@endtemplate}
-final class CalculatorTool extends Tool {
+final class CalculatorTool extends Tool<ToolOptions> {
   /// {@macro calculator_tool}
   CalculatorTool()
       : super(
@@ -34,7 +35,10 @@ final class CalculatorTool extends Tool {
   final _parser = Parser();
 
   @override
-  FutureOr<String> runInternalString(final String toolInput) {
+  FutureOr<String> runInternalString(
+    final String toolInput, {
+    final ToolOptions? options,
+  }) {
     try {
       return _parser
           .parse(toolInput)

--- a/packages/langchain/lib/src/agents/tools/exception.dart
+++ b/packages/langchain/lib/src/agents/tools/exception.dart
@@ -2,13 +2,14 @@ import 'dart:async';
 
 import '../executors.dart';
 import 'base.dart';
+import 'models/models.dart';
 
 /// {@template exception_tool}
 /// A tool used when the agent throws an [OutputParserException].
 ///
 /// Returns the output of [AgentExecutor.handleParsingErrors].
 /// {@endtemplate}
-final class ExceptionTool extends Tool {
+final class ExceptionTool extends Tool<ToolOptions> {
   /// {@macro exception_tool}
   ExceptionTool()
       : super(
@@ -20,7 +21,10 @@ final class ExceptionTool extends Tool {
   static const toolName = '_exception';
 
   @override
-  FutureOr<String> runInternalString(final String toolInput) {
+  FutureOr<String> runInternalString(
+    final String toolInput, {
+    final ToolOptions? options,
+  }) {
     return toolInput;
   }
 }

--- a/packages/langchain/lib/src/agents/tools/invalid.dart
+++ b/packages/langchain/lib/src/agents/tools/invalid.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 
 import 'base.dart';
+import 'models/models.dart';
 
 /// {@template invalid_tool}
 /// Tool that is run when invalid tool name is encountered by agent
 /// {@endtemplate}
-final class InvalidTool extends Tool {
+final class InvalidTool extends Tool<ToolOptions> {
   /// {@macro invalid_tool}
   InvalidTool()
       : super(
@@ -14,7 +15,10 @@ final class InvalidTool extends Tool {
         );
 
   @override
-  FutureOr<String> runInternalString(final String toolInput) {
+  FutureOr<String> runInternalString(
+    final String toolInput, {
+    final ToolOptions? options,
+  }) {
     return '$toolInput is not a valid tool, try another one.';
   }
 }

--- a/packages/langchain/lib/src/agents/tools/models/models.dart
+++ b/packages/langchain/lib/src/agents/tools/models/models.dart
@@ -1,5 +1,14 @@
+import '../../../model_io/language_models/models/models.dart';
 import '../../../utils/exception.dart';
 import '../base.dart';
+
+/// {@template tool_options}
+/// Generation options to pass into the Tool.
+/// {@endtemplate}
+class ToolOptions extends LanguageModelOptions {
+  /// {@macro tool_options}
+  const ToolOptions();
+}
 
 /// {@template tool_exception}
 /// An exception that a tool throws when execution error occurs.

--- a/packages/langchain/lib/src/agents/tools/tools.dart
+++ b/packages/langchain/lib/src/agents/tools/tools.dart
@@ -1,2 +1,3 @@
 export 'base.dart';
 export 'calculator.dart';
+export 'models/models.dart';

--- a/packages/langchain/test/agents/executors_test.dart
+++ b/packages/langchain/test/agents/executors_test.dart
@@ -143,7 +143,7 @@ void main() {
   });
 }
 
-final class _MockTool extends Tool {
+final class _MockTool extends Tool<ToolOptions> {
   _MockTool({
     super.name = 'tool',
     super.returnDirect = false,
@@ -152,7 +152,10 @@ final class _MockTool extends Tool {
         );
 
   @override
-  FutureOr<String> runInternalString(final String toolInput) {
+  FutureOr<String> runInternalString(
+    final String toolInput, {
+    final ToolOptions? options,
+  }) {
     return '$name-output';
   }
 }

--- a/packages/langchain/test/agents/tools/base_test.dart
+++ b/packages/langchain/test/agents/tools/base_test.dart
@@ -7,7 +7,10 @@ void main() {
       final echoTool = BaseTool.fromFunction(
         name: 'echo-int',
         description: 'echo-int',
-        func: (final Map<String, dynamic> toolInput) =>
+        func: (
+          final Map<String, dynamic> toolInput, {
+          final ToolOptions? options,
+        }) =>
             toolInput['input'].toString(),
         inputJsonSchema: const {'type': 'integer'},
       );
@@ -21,7 +24,11 @@ void main() {
       final echoTool = Tool.fromFunction(
         name: 'echo',
         description: 'echo',
-        func: (final String toolInput) => toolInput,
+        func: (
+          final String toolInput, {
+          final ToolOptions? options,
+        }) =>
+            toolInput,
       );
 
       expect(echoTool.name, 'echo');

--- a/packages/langchain_openai/lib/src/agents/functions.dart
+++ b/packages/langchain_openai/lib/src/agents/functions.dart
@@ -118,7 +118,7 @@ class OpenAIFunctionsAgent extends BaseSingleActionAgent {
   ///   system message and the input from the agent.
   factory OpenAIFunctionsAgent.fromLLMAndTools({
     required final ChatOpenAI llm,
-    required final List<BaseTool> tools,
+    required final List<BaseTool<ToolOptions>> tools,
     final BaseChatMemory? memory,
     final SystemChatMessagePromptTemplate systemChatMessage =
         _systemChatMessagePromptTemplate,

--- a/packages/langchain_openai/test/agents/functions_test.dart
+++ b/packages/langchain_openai/test/agents/functions_test.dart
@@ -53,7 +53,10 @@ void main() {
           },
           'required': ['query'],
         },
-        func: (final Map<String, dynamic> toolInput) async {
+        func: (
+          final Map<String, dynamic> toolInput, {
+          final ToolOptions? options,
+        }) async {
           final n = toolInput['n'];
           final res = List<String>.generate(n, (final i) => 'Result ${i + 1}');
           return 'Results:\n${res.join('\n')}';


### PR DESCRIPTION
Before it was only possible to pass parameters to your tools when creating the tool instance. Now you can pass tool options when calling the tools in the same way you can pass options to your llms.

Eg.

```dart
final dallETool = OpenAIDallETool(apiKey: openAiKey);
final res1 = await dallETool.invoke(
  {'input': 'Prompt'},
  options: const OpenAIDallEToolOptions(
    quality: ImageQuality.hd,
    style: ImageStyle.vivid,
  ),
);
final res2 = await dallETool.invoke(
  {'input': 'Prompt'},
  options: const OpenAIDallEToolOptions(
    quality: ImageQuality.standard,
    style: ImageStyle.natural,
  ),
);
```

You can also use `bind` on your runnable pipelines to bind some options to the tool:

```dart
dallETool.bind(
  const OpenAIDallEToolOptions(
    model: 'dall-e-2',
  ),
);
``` 

## Breaking changes

You will have to add the new options parameter to your tool.

**BaseTool.fromFunction**:

Before:
```dart
final echoTool = BaseTool.fromFunction(
  name: 'echo-int',
  description: 'echo-int',
  func: (final Map<String, dynamic> toolInput) =>
      toolInput['input'].toString(),
  inputJsonSchema: const {'type': 'integer'},
);
```

After:
```dart
final echoTool = BaseTool.fromFunction(
  name: 'echo-int',
  description: 'echo-int',
  func: (
    final Map<String, dynamic> toolInput, {
    final ToolOptions? options,
  }) => toolInput['input'].toString(),
  inputJsonSchema: const {'type': 'integer'},
);
```

**Tool.fromFunction**:

Before:
```dart
final echoTool = Tool.fromFunction(
  name: 'echo',
  description: 'echo',
  func: (final String toolInput) => toolInput,
);
```

After:
```dart
final echoTool = Tool.fromFunction(
  name: 'echo',
  description: 'echo',
  func: (
    final String toolInput, {
    final ToolOptions? options,
  }) => toolInput,
);
```

**Custom tool**:

Before:
```dart
final class InvalidTool extends Tool {
  InvalidTool()
      : super(
          name: 'invalid_tool',
          description: 'Called when tool name is invalid.',
        );

  @override
  FutureOr<String> runInternalString(final String toolInput) {
    return '$toolInput is not a valid tool, try another one.';
  }
}
```

After:
```dart
final class InvalidTool extends Tool<ToolOptions> {
  InvalidTool()
      : super(
          name: 'invalid_tool',
          description: 'Called when tool name is invalid.',
        );

  @override
  FutureOr<String> runInternalString(
    final String toolInput, {
    final ToolOptions? options,
  }) {
    return '$toolInput is not a valid tool, try another one.';
  }
}
```

If you need to provide custom option to your tool, just create a class that extends `ToolOptions` (e.g. `MyToolOptions`) and pass it in the generic parameter of `Tool` (e.g. `final class MyTool extends Tool<MyToolOptions> {...}`.