### PR TITLE
feat(tools)!: Move all DallE config options to OpenAIDallEToolOptions

### DIFF
--- a/packages/langchain_openai/lib/src/agents/tools/dall_e.dart
+++ b/packages/langchain_openai/lib/src/agents/tools/dall_e.dart
@@ -5,6 +5,8 @@ import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:openai_dart/openai_dart.dart';
 
+import 'models/models.dart';
+
 export 'package:openai_dart/openai_dart.dart'
     show ImageQuality, ImageResponseFormat, ImageSize, ImageStyle;
 
@@ -17,15 +19,19 @@ export 'package:openai_dart/openai_dart.dart'
 /// ```dart
 /// final llm = ChatOpenAI(
 ///   apiKey: openAiKey,
-///   model: 'gpt-4',
-///   temperature: 0,
+///   defaultOptions: const ChatOpenAIOptions(
+///     model: 'gpt-4',
+///     temperature: 0,
+///   ),
 /// );
 /// final tools = [
 ///   CalculatorTool(),
 ///   OpenAIDallETool(
 ///     apiKey: openAiKey,
-///     model: 'dall-e-2',
-///     size: ImageSize.v256x256,
+///     defaultOptions: const OpenAIDallEToolOptions(
+///       model: 'dall-e-2',
+///       size: ImageSize.v256x256,
+///     ),
 ///   ),
 /// ];
 /// final agent = OpenAIFunctionsAgent.fromLLMAndTools(
@@ -39,7 +45,7 @@ export 'package:openai_dart/openai_dart.dart'
 /// );
 /// ```
 /// {@endtemplate}
-final class OpenAIDallETool extends Tool {
+final class OpenAIDallETool extends Tool<OpenAIDallEToolOptions> {
   /// {@macro dall_e_tool}
   OpenAIDallETool({
     final String? apiKey,
@@ -48,12 +54,7 @@ final class OpenAIDallETool extends Tool {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.model = 'dall-e-3',
-    this.quality = ImageQuality.standard,
-    this.responseFormat = ImageResponseFormat.url,
-    this.size = ImageSize.v1024x1024,
-    this.style = ImageStyle.vivid,
-    this.user,
+    this.defaultOptions = const OpenAIDallEToolOptions(),
   })  : _client = OpenAIClient(
           apiKey: apiKey ?? '',
           organization: organization,
@@ -72,67 +73,29 @@ final class OpenAIDallETool extends Tool {
   /// A client for interacting with OpenAI API.
   final OpenAIClient _client;
 
-  /// ID of the model to use (e.g. `dall-e-2` or 'dall-e-3').
-  ///
-  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-model
-  final String model;
-
-  /// The quality of the image that will be generated. [ImageQuality.hd]
-  /// creates images with finer details and greater consistency across the
-  /// image. This param is only supported for `dall-e-3`
-  ///
-  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-quality
-  final ImageQuality quality;
-
-  /// The format in which the generated images are returned.
-  ///
-  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-response_format
-  final ImageResponseFormat responseFormat;
-
-  /// The size of the generated images.
-  ///
-  /// Must be one of [ImageSize.v256x256], [ImageSize.v512x512], or
-  /// [ImageSize.v1024x1024] for `dall-e-2`.
-  ///
-  /// Must be one of [ImageSize.v1024x1024], [ImageSize.v1792x1024], or
-  /// [ImageSize.v1024x1792] for `dall-e-3` models.
-  ///
-  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-size
-  final ImageSize size;
-
-  /// The style of the generated images.
-  ///
-  /// [ImageStyle.vivid] causes the model to lean towards generating hyper-real
-  /// and dramatic images. [ImageStyle.natural] causes the model to produce
-  /// more natural, less hyper-real looking images.
-  ///
-  /// This param is only supported for `dall-e-3`.
-  ///
-  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-style
-  final ImageStyle style;
-
-  /// A unique identifier representing your end-user, which can help OpenAI to
-  /// monitor and detect abuse.
-  ///
-  /// If you need to send different users in different requests, you can set
-  /// this field in [ChatOpenAIOptions] instead.
-  ///
-  /// Ref: https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids
-  final String? user;
+  /// The default options to use when calling the DALL-E tool.
+  final OpenAIDallEToolOptions defaultOptions;
 
   @override
-  FutureOr<String> runInternalString(final String toolInput) async {
+  FutureOr<String> runInternalString(
+    final String toolInput, {
+    final OpenAIDallEToolOptions? options,
+  }) async {
     try {
+      final responseFormat =
+          options?.responseFormat ?? defaultOptions.responseFormat;
       final res = await _client.createImage(
         request: CreateImageRequest(
           prompt: toolInput,
-          model: CreateImageRequestModel.modelId(model),
+          model: CreateImageRequestModel.modelId(
+            options?.model ?? defaultOptions.model,
+          ),
           n: 1,
-          quality: quality,
+          quality: options?.quality ?? defaultOptions.quality,
           responseFormat: responseFormat,
-          size: size,
-          style: style,
-          user: user,
+          size: options?.size ?? defaultOptions.size,
+          style: options?.style ?? defaultOptions.style,
+          user: options?.user,
         ),
       );
       final data = res.data.first;

--- a/packages/langchain_openai/lib/src/agents/tools/models/models.dart
+++ b/packages/langchain_openai/lib/src/agents/tools/models/models.dart
@@ -1,0 +1,66 @@
+import 'package:langchain/langchain.dart';
+
+import '../dall_e.dart';
+
+/// {@template open_ai_dall_e_tool_options}
+/// Generation options to pass into the [OpenAIDallETool].
+/// {@endtemplate}
+class OpenAIDallEToolOptions extends ToolOptions {
+  /// {@macro open_ai_dall_e_tool_options}
+  const OpenAIDallEToolOptions({
+    this.model = 'dall-e-3',
+    this.quality = ImageQuality.standard,
+    this.responseFormat = ImageResponseFormat.url,
+    this.size = ImageSize.v1024x1024,
+    this.style = ImageStyle.vivid,
+    this.user,
+  });
+
+  /// ID of the model to use (e.g. `dall-e-2` or 'dall-e-3').
+  ///
+  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-model
+  final String model;
+
+  /// The quality of the image that will be generated. [ImageQuality.hd]
+  /// creates images with finer details and greater consistency across the
+  /// image. This param is only supported for `dall-e-3`
+  ///
+  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-quality
+  final ImageQuality quality;
+
+  /// The format in which the generated images are returned.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-response_format
+  final ImageResponseFormat responseFormat;
+
+  /// The size of the generated images.
+  ///
+  /// Must be one of [ImageSize.v256x256], [ImageSize.v512x512], or
+  /// [ImageSize.v1024x1024] for `dall-e-2`.
+  ///
+  /// Must be one of [ImageSize.v1024x1024], [ImageSize.v1792x1024], or
+  /// [ImageSize.v1024x1792] for `dall-e-3` models.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-size
+  final ImageSize size;
+
+  /// The style of the generated images.
+  ///
+  /// [ImageStyle.vivid] causes the model to lean towards generating hyper-real
+  /// and dramatic images. [ImageStyle.natural] causes the model to produce
+  /// more natural, less hyper-real looking images.
+  ///
+  /// This param is only supported for `dall-e-3`.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/images/create#images-create-style
+  final ImageStyle style;
+
+  /// A unique identifier representing your end-user, which can help OpenAI to
+  /// monitor and detect abuse.
+  ///
+  /// If you need to send different users in different requests, you can set
+  /// this field in [ChatOpenAIOptions] instead.
+  ///
+  /// Ref: https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids
+  final String? user;
+}

--- a/packages/langchain_openai/lib/src/agents/tools/tools.dart
+++ b/packages/langchain_openai/lib/src/agents/tools/tools.dart
@@ -1,1 +1,2 @@
 export 'dall_e.dart';
+export 'models/models.dart';

--- a/packages/langchain_openai/test/agents/tools/dall_e_test.dart
+++ b/packages/langchain_openai/test/agents/tools/dall_e_test.dart
@@ -15,8 +15,10 @@ void main() {
     test('Test generate image returned as URL', () async {
       final tool = OpenAIDallETool(
         apiKey: openAiKey,
-        model: 'dall-e-2',
-        size: ImageSize.v256x256,
+        defaultOptions: const OpenAIDallEToolOptions(
+          model: 'dall-e-2',
+          size: ImageSize.v256x256,
+        ),
       );
       final res = await tool.invoke({Tool.inputVar: 'A cute baby sea otter'});
       expect(res, startsWith('http'));
@@ -26,9 +28,11 @@ void main() {
     test('Test generate image returned as base64', () async {
       final tool = OpenAIDallETool(
         apiKey: openAiKey,
-        model: 'dall-e-2',
-        size: ImageSize.v256x256,
-        responseFormat: ImageResponseFormat.b64Json,
+        defaultOptions: const OpenAIDallEToolOptions(
+          model: 'dall-e-2',
+          size: ImageSize.v256x256,
+          responseFormat: ImageResponseFormat.b64Json,
+        ),
       );
       final res = await tool.invoke({Tool.inputVar: 'A cute baby sea otter'});
       expect(res, isNot(startsWith('http')));
@@ -45,12 +49,14 @@ void main() {
         ),
       );
 
-      final tools = [
+      final List<BaseTool<ToolOptions>> tools = [
         CalculatorTool(),
         OpenAIDallETool(
           apiKey: openAiKey,
-          model: 'dall-e-2',
-          size: ImageSize.v256x256,
+          defaultOptions: const OpenAIDallEToolOptions(
+            model: 'dall-e-2',
+            size: ImageSize.v256x256,
+          ),
         ),
       ];
 


### PR DESCRIPTION
Similar to https://github.com/davidmigloz/langchain_dart/pull/232

All DallE config options have been moved from the constructor to `OpenAIDallEToolOptions`.

## Migration

Before:
```dart
final tool = OpenAIDallETool(
  apiKey: openAiKey,
  model: 'dall-e-2',
  size: ImageSize.v256x256,
);
```

After:
```dart
final tool = OpenAIDallETool(
  apiKey: openAiKey,
  defaultOptions: const OpenAIDallEToolOptions(
    model: 'dall-e-2',
    size: ImageSize.v256x256,
  ),
);
```

---

Before it was only possible to pass parameters to your tools when creating the tool instance. Now you can pass tool options when calling the tools in the same way you can pass options to your llms.

Eg.

```dart
final dallETool = OpenAIDallETool(apiKey: openAiKey);
final res1 = await dallETool.invoke(
  {'input': 'Prompt'},
  options: const OpenAIDallEToolOptions(
    quality: ImageQuality.hd,
    style: ImageStyle.vivid,
  ),
);
final res2 = await dallETool.invoke(
  {'input': 'Prompt'},
  options: const OpenAIDallEToolOptions(
    quality: ImageQuality.standard,
    style: ImageStyle.natural,
  ),
);
```

You can also use `bind` on your runnable pipelines to bind some options to the tool:

```dart
dallETool.bind(
  const OpenAIDallEToolOptions(
    model: 'dall-e-2',
  ),
);
``` 