### PR TITLE
feat: Allow to update OpenAI key without having to recreate the wrapper

### DIFF
--- a/packages/langchain_openai/lib/src/agents/tools/dall_e.dart
+++ b/packages/langchain_openai/lib/src/agents/tools/dall_e.dart
@@ -76,6 +76,12 @@ final class OpenAIDallETool extends Tool<OpenAIDallEToolOptions> {
   /// The default options to use when calling the DALL-E tool.
   final OpenAIDallEToolOptions defaultOptions;
 
+  /// Set or replace the API key.
+  set apiKey(final String value) => _client.apiKey = value;
+
+  /// Get the API key.
+  String get apiKey => _client.apiKey;
+
   @override
   FutureOr<String> runInternalString(
     final String toolInput, {

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -10,16 +10,68 @@ import 'models/models.dart';
 ///
 /// Example:
 /// ```dart
-/// final chat = ChatOpenAI(apiKey: '...', temperature: 1);
+/// final chatModel = ChatOpenAI(apiKey: '...');
 /// final messages = [
 ///   ChatMessage.system('You are a helpful assistant that translates English to French.'),
-///   ChatMessage.humanText('I love programming.')
+///   ChatMessage.humanText('I love programming.'),
 /// ];
-/// final res = await chat(messages);
+/// final prompt = PromptValue.chat(messages);
+/// final res = await llm.invoke(prompt);
 /// ```
 ///
 /// - [Completions guide](https://platform.openai.com/docs/guides/gpt/chat-completions-api)
 /// - [Completions API docs](https://platform.openai.com/docs/api-reference/chat)
+///
+/// ### Call options
+///
+/// You can configure the parameters that will be used when calling the
+/// chat completions API in several ways:
+///
+/// **Default options:**
+///
+/// Use the [defaultOptions] parameter to set the default options. These
+/// options will be used unless you override them when generating completions.
+///
+/// ```dart
+/// final chatModel = ChatOpenAI(
+///   apiKey: openaiApiKey,
+///   defaultOptions: const ChatOpenAIOptions(
+///     temperature: 0.9,
+///     maxTokens: 100,
+///   ),
+/// );
+/// ```
+///
+/// **Call options:**
+///
+/// You can override the default options when invoking the model:
+///
+/// ```dart
+/// final res = await chatModel.invoke(
+///   prompt,
+///   options: const ChatOpenAIOptions(seed: 9999),
+/// );
+/// ```
+///
+/// **Bind:**
+///
+/// You can also change the options in a [Runnable] pipeline using the bind
+/// method.
+///
+/// In this example, we are using two totally different models for each
+/// question:
+///
+/// ```dart
+/// final llm = OpenAI(apiKey: openaiApiKey,);
+/// const outputParser = StringOutputParser();
+/// final prompt1 = PromptTemplate.fromTemplate('How are you {name}?');
+/// final prompt2 = PromptTemplate.fromTemplate('How old are you {name}?');
+/// final chain = Runnable.fromMap({
+///   'q1': prompt1 | llm.bind(const OpenAIOptions(model: 'gpt-3.5-turbo-instruct')) | outputParser,
+///   'q2': prompt2| llm.bind(const OpenAIOptions(model: 'text-davinci-003')) | outputParser,
+/// });
+/// final res = await chain.invoke({'name': 'David'});
+/// ```
 ///
 /// ### Authentication
 ///
@@ -168,6 +220,12 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
   /// For an exhaustive list check:
   /// https://github.com/mvitlov/tiktoken/blob/master/lib/tiktoken.dart
   final String? encoding;
+
+  /// Set or replace the API key.
+  set apiKey(final String value) => _client.apiKey = value;
+
+  /// Get the API key.
+  String get apiKey => _client.apiKey;
 
   @override
   String get modelType => 'openai-chat';

--- a/packages/langchain_openai/lib/src/embeddings/openai.dart
+++ b/packages/langchain_openai/lib/src/embeddings/openai.dart
@@ -157,6 +157,12 @@ class OpenAIEmbeddings implements Embeddings {
   /// Ref: https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids
   final String? user;
 
+  /// Set or replace the API key.
+  set apiKey(final String value) => _client.apiKey = value;
+
+  /// Get the API key.
+  String get apiKey => _client.apiKey;
+
   @override
   Future<List<List<double>>> embedDocuments(
     final List<Document> documents,

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -6,19 +6,68 @@ import 'package:tiktoken/tiktoken.dart';
 import 'models/mappers.dart';
 import 'models/models.dart';
 
-/// Wrapper around OpenAI Completions API.
+/// Wrapper around [OpenAI Completions API](https://platform.openai.com/docs/api-reference/completions).
 ///
 /// Example:
 /// ```dart
-/// final llm = OpenAI(
-///  apiKey: openaiApiKey,
-///  defaultOptions: const OpenAIOptions(temperature: 1),
-/// );
-/// final res = await llm('Tell me a joke');
+/// final llm = OpenAI(apiKey: '...');
+/// final prompt = PromptValue.string('Tell me a joke');
+/// final res = await llm.invoke(prompt);
 /// ```
 ///
 /// - [Completions guide](https://platform.openai.com/docs/guides/gpt/completions-api)
 /// - [Completions API docs](https://platform.openai.com/docs/api-reference/completions)
+///
+/// ### Call options
+///
+/// You can configure the parameters that will be used when calling the
+/// completions API in several ways:
+///
+/// **Default options:**
+///
+/// Use the [defaultOptions] parameter to set the default options. These
+/// options will be used unless you override them when generating completions.
+///
+/// ```dart
+/// final llm = OpenAI(
+///   apiKey: openaiApiKey,
+///   defaultOptions: const OpenAIOptions(
+///     temperature: 0.9,
+///     maxTokens: 100,
+///   ),
+/// );
+/// ```
+///
+/// **Call options:**
+///
+/// You can override the default options when invoking the model:
+///
+/// ```dart
+/// final res = await llm.invoke(
+///   prompt,
+///   options: const OpenAIOptions(seed: 9999),
+/// );
+/// ```
+///
+/// **Bind:**
+///
+/// You can also change the options in a [Runnable] pipeline using the bind
+/// method.
+///
+/// In this example, we are using two totally different models for each
+/// question:
+///
+/// ```dart
+/// final chatModel = ChatOpenAI(apiKey: openaiApiKey,);
+/// const outputParser = StringOutputParser();
+/// final prompt1 = PromptTemplate.fromTemplate('How are you {name}?');
+/// final prompt2 = PromptTemplate.fromTemplate('How old are you {name}?');
+/// final chain = Runnable.fromMap({
+///   'q1': prompt1 | chatModel.bind(const ChatOpenAIOptions(model: 'gpt-4')) | outputParser,
+///   'q2': prompt2| chatModel.bind(const ChatOpenAIOptions(model: 'gpt-3.5-turbo')) | outputParser,
+/// });
+/// final res = await chain.invoke({'name': 'David'});
+/// ```
 ///
 /// ### Authentication
 ///
@@ -167,6 +216,12 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
   /// For an exhaustive list check:
   /// https://github.com/mvitlov/tiktoken/blob/master/lib/tiktoken.dart
   final String? encoding;
+
+  /// Set or replace the API key.
+  set apiKey(final String value) => _client.apiKey = value;
+
+  /// Get the API key.
+  String get apiKey => _client.apiKey;
 
   @override
   String get modelType => 'openai';

--- a/packages/openai_dart/lib/src/client.dart
+++ b/packages/openai_dart/lib/src/client.dart
@@ -47,6 +47,12 @@ class OpenAIClient extends g.OpenAIClient {
           client: client ?? createDefaultHttpClient(),
         );
 
+  /// Set or replace the API key.
+  set apiKey(final String value) => bearerToken = value;
+
+  /// Get the API key.
+  String get apiKey => bearerToken;
+
   // ------------------------------------------
   // METHOD: createCompletionStream
   // ------------------------------------------


### PR DESCRIPTION
You can now update the OpenAI key at any moment:

```dart
final llm = OpenAI(); // You can instantiate without a key

final key = getKeyFromUser();  // Ask user for the key

llm.apiKey = key; // Update key

lllm.invoke(...); // Use the wrapper
```

Supported in:
- `OpenAI`
- `ChatOpenAI`
- `OpenAIEmbeddings`
- `OpenAIDallETool`