### PR TITLE
fix(prompts): PromptTemplate stream should only emit if it has all inputs

### DIFF
--- a/packages/langchain/lib/src/core/runnable/map.dart
+++ b/packages/langchain/lib/src/core/runnable/map.dart
@@ -76,9 +76,7 @@ class RunnableMap<RunInput extends Object>
       steps.entries.map((final entry) {
         return entry.value
             .streamFromInputStream(inputStream, options: options)
-            .map(
-              (final output) => {entry.key: output},
-            );
+            .map((final output) => {entry.key: output});
       }),
     );
   }


### PR DESCRIPTION
When calling stream in a pipeline that contains a `PromptTemplate`,  `PromptTemplate` should wait to receive all the input values it needs before formatting the prompt and emitting it. Otherwise, it throws an exception when trying to format the prompt as not all the input values may have been emitted.
