### PR TITLE
feat(retrievers)!: Move all retriever config options to RetrieverOptions

### DIFF
--- a/docs/expression_language/cookbook/retrieval.md
+++ b/docs/expression_language/cookbook/retrieval.md
@@ -164,7 +164,9 @@ In this example, we will add a memory to the chain and return the source documen
 
 ```dart
 final retriever = vectorStore.asRetriever(
-  searchType: const VectorStoreSimilaritySearch(k: 1),
+  defaultOptions: const VectorStoreRetrieverOptions(
+    searchType: VectorStoreSimilaritySearch(k: 1),
+  ),
 );
 final model = ChatOpenAI(apiKey: openaiApiKey);
 final stringOutputParser = const StringOutputParser();

--- a/examples/docs_examples/bin/expression_language/cookbook/retrieval.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/retrieval.dart
@@ -190,7 +190,9 @@ Future<void> _conversationalRetrievalChainMemoryAndDocs() async {
   final vectorStore = Chroma(embeddings: embeddings);
 
   final retriever = vectorStore.asRetriever(
-    searchType: const VectorStoreSimilaritySearch(k: 1),
+    defaultOptions: const VectorStoreRetrieverOptions(
+      searchType: VectorStoreSimilaritySearch(k: 1),
+    ),
   );
   final model = ChatOpenAI(apiKey: openaiApiKey);
   const stringOutputParser = StringOutputParser();

--- a/packages/langchain/lib/src/chains/retrieval_qa.dart
+++ b/packages/langchain/lib/src/chains/retrieval_qa.dart
@@ -72,7 +72,7 @@ class RetrievalQAChain extends BaseChain {
   });
 
   /// Retriever to use.
-  final BaseRetriever retriever;
+  final Retriever retriever;
 
   /// Chain to use to combine the documents.
   final BaseCombineDocumentsChain combineDocumentsChain;
@@ -111,7 +111,7 @@ class RetrievalQAChain extends BaseChain {
   String get chainType => 'retrieval_qa';
 
   /// Creates a [RetrievalQAChain] from a [BaseLanguageModel] and a
-  /// [BaseRetriever].
+  /// [Retriever].
   ///
   /// By default, it uses a prompt template optimized for question answering
   /// that includes the retrieved documents and the question.
@@ -134,7 +134,7 @@ class RetrievalQAChain extends BaseChain {
   /// [prompt]. Use 'context' and 'question' as the variable names.
   factory RetrievalQAChain.fromLlm({
     required final BaseLanguageModel llm,
-    required final BaseRetriever retriever,
+    required final Retriever retriever,
     final PromptTemplate? prompt,
   }) {
     return RetrievalQAChain(

--- a/packages/langchain/lib/src/documents/retrievers/base.dart
+++ b/packages/langchain/lib/src/documents/retrievers/base.dart
@@ -1,27 +1,33 @@
 import '../../core/core.dart';
 import '../models/models.dart';
+import 'models/models.dart';
 
 /// {@template base_retriever}
 /// Base Index class. All indexes should extend this class.
 /// {@endtemplate}
-abstract class BaseRetriever
-    extends Runnable<String, BaseLangChainOptions, List<Document>> {
+abstract class Retriever<Options extends RetrieverOptions>
+    extends Runnable<String, Options, List<Document>> {
   /// {@macro base_retriever}
-  const BaseRetriever();
+  const Retriever();
 
   /// Get the most relevant documents for a given query.
   ///
   /// - [input] - The query to search for.
+  /// - [options] - Retrieval options.
   @override
   Future<List<Document>> invoke(
     final String input, {
-    final BaseLangChainOptions? options,
+    final Options? options,
   }) {
-    return getRelevantDocuments(input);
+    return getRelevantDocuments(input, options: options);
   }
 
   /// Get the most relevant documents for a given query.
   ///
   /// - [query] - The query to search for.
-  Future<List<Document>> getRelevantDocuments(final String query);
+  /// - [options] - Retrieval options.
+  Future<List<Document>> getRelevantDocuments(
+    final String query, {
+    final Options? options,
+  });
 }

--- a/packages/langchain/lib/src/documents/retrievers/fake.dart
+++ b/packages/langchain/lib/src/documents/retrievers/fake.dart
@@ -1,11 +1,12 @@
 import '../models/models.dart';
 import 'base.dart';
+import 'models/models.dart';
 
 /// {@template fake_retriever}
 /// A retriever that returns a fixed list of documents.
 /// This class is meant for testing purposes only.
 /// {@endtemplate}
-class FakeRetriever extends BaseRetriever {
+class FakeRetriever extends Retriever<RetrieverOptions> {
   /// {@macro fake_retriever}
   const FakeRetriever(this.docs);
 
@@ -13,7 +14,10 @@ class FakeRetriever extends BaseRetriever {
   final List<Document> docs;
 
   @override
-  Future<List<Document>> getRelevantDocuments(final String query) {
+  Future<List<Document>> getRelevantDocuments(
+    final String query, {
+    final RetrieverOptions? options,
+  }) {
     return Future.value(docs);
   }
 }

--- a/packages/langchain/lib/src/documents/retrievers/models/models.dart
+++ b/packages/langchain/lib/src/documents/retrievers/models/models.dart
@@ -1,0 +1,29 @@
+import 'package:meta/meta.dart';
+
+import '../../../core/base.dart';
+import '../../vector_stores/models/models.dart';
+import '../retrievers.dart';
+
+/// {@template retriever_options}
+/// Base class for [Retriever] options.
+/// {@endtemplate}
+@immutable
+class RetrieverOptions extends BaseLangChainOptions {
+  /// {@macro retriever_options}
+  const RetrieverOptions();
+}
+
+/// {@template vector_store_retriever_options}
+/// Options for [VectorStoreRetriever].
+/// {@endtemplate}
+class VectorStoreRetrieverOptions extends RetrieverOptions {
+  /// {@macro vector_store_retriever_options}
+  const VectorStoreRetrieverOptions({
+    this.searchType = const VectorStoreSimilaritySearch(),
+  });
+
+  /// The type of search to perform, either:
+  /// - [VectorStoreSearchType.similarity] (default)
+  /// - [VectorStoreSearchType.mmr]
+  final VectorStoreSearchType searchType;
+}

--- a/packages/langchain/lib/src/documents/retrievers/retrievers.dart
+++ b/packages/langchain/lib/src/documents/retrievers/retrievers.dart
@@ -1,3 +1,4 @@
 export 'base.dart';
 export 'fake.dart';
+export 'models/models.dart';
 export 'vector_store.dart';

--- a/packages/langchain/lib/src/documents/retrievers/vector_store.dart
+++ b/packages/langchain/lib/src/documents/retrievers/vector_store.dart
@@ -1,25 +1,33 @@
 import '../models/models.dart';
 import '../vector_stores/vector_stores.dart';
 import 'base.dart';
+import 'models/models.dart';
 
 /// {@template vector_store_retriever}
 /// A retriever that uses a vector store to retrieve documents.
 /// {@endtemplate}
-class VectorStoreRetriever<V extends VectorStore> extends BaseRetriever {
+class VectorStoreRetriever<V extends VectorStore>
+    extends Retriever<VectorStoreRetrieverOptions> {
   /// {@macro vector_store_retriever}
   const VectorStoreRetriever({
     required this.vectorStore,
-    this.searchType = const VectorStoreSimilaritySearch(),
+    this.defaultOptions = const VectorStoreRetrieverOptions(),
   });
 
   /// The vector store to retrieve documents from.
   final V vectorStore;
 
-  /// The type of search to perform.
-  final VectorStoreSearchType searchType;
+  /// Default options for this retriever.
+  final VectorStoreRetrieverOptions defaultOptions;
 
   @override
-  Future<List<Document>> getRelevantDocuments(final String query) {
-    return vectorStore.search(query: query, searchType: searchType);
+  Future<List<Document>> getRelevantDocuments(
+    final String query, {
+    final VectorStoreRetrieverOptions? options,
+  }) {
+    return vectorStore.search(
+      query: query,
+      searchType: options?.searchType ?? defaultOptions.searchType,
+    );
   }
 }

--- a/packages/langchain/lib/src/documents/vector_stores/base.dart
+++ b/packages/langchain/lib/src/documents/vector_stores/base.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_unused_constructor_parameters
 import '../embeddings/base.dart';
 import '../models/models.dart';
+import '../retrievers/models/models.dart';
 import '../retrievers/vector_store.dart';
 import 'models/models.dart';
 
@@ -170,16 +171,14 @@ abstract class VectorStore {
 
   /// Returns a [VectorStoreRetriever] that uses this vector store.
   ///
-  /// - [searchType] is the type of search to perform, either
-  ///   [VectorStoreSearchType.similarity] (default) or
-  ///   [VectorStoreSearchType.mmr].
+  /// - [defaultOptions] are the default options for the retriever.
   VectorStoreRetriever asRetriever({
-    final VectorStoreSearchType searchType =
-        const VectorStoreSimilaritySearch(),
+    final VectorStoreRetrieverOptions defaultOptions =
+        const VectorStoreRetrieverOptions(),
   }) {
     return VectorStoreRetriever(
       vectorStore: this,
-      searchType: searchType,
+      defaultOptions: defaultOptions,
     );
   }
 }


### PR DESCRIPTION
Continuing the efforts to add full LCEL support to all core components.

In this case, the `Retriever` class didn't allow to pass any options when invoking it. `VectorStoreRetriever` only supported config options in the constructor, which forced users to re-create the retriever every time they wanted to change the options.

A typical use case that was hard to implement was to do an initial search with a high `scoreThreshold` and then repeat the search with a lower `scoreThreshold` if the first search didn't return any results.

Now the `Retriever` classes support defining default options when instantiating them, but you can always override them when invoking the retriever.

```dart
const query = 'How much does my order cost?';
// Default options
final retriever = vectorStore.asRetriever(
  defaultOptions: const VectorStoreRetrieverOptions(
    searchType: VectorStoreSimilaritySearch(scoreThreshold: 0.8),
  ),
);

// We invoke the retriever with the default options
List<Document> res = await retriever.invoke(query);

// If empty, we override the default options with a lower score threshold
if(res.isEmpty) {
  res = await retriever.invoke(
    query,
    options: const VectorStoreRetrieverOptions(
      searchType: VectorStoreSimilaritySearch(scoreThreshold: 0.5),
    ),
  );
}
```

You can also change the options in a `Runnable` pipeline using the bind method.

```dart
final retriever = vectorStore.asRetriever();
final chain = Runnable.fromMap<String>({
  'context1': retriever.bind(retrieverOptions1),
  'context2': retriever.bind(retrieverOptions2),
  'question': Runnable.passthrough(),
}).pipe(promptTemplate).pipe(chatModel).pipe(outputParser);
```

## Migration

### Getting a retriever from a vector store

The `asRetriever` method now takes an optional `defaultOptions` parameter instead of a `searchType`.


Before:
```dart
final retriever = vectorStore.asRetriever(
  searchType: const VectorStoreSimilaritySearch(k: 10),
);
```

Now:
```dart
final retriever = vectorStore.asRetriever(
  defaultOptions: const VectorStoreRetrieverOptions(
    searchType: VectorStoreSimilaritySearch(k: 10),
  ),
);
```

### Custom retrievers

If you have any custom retrievers, the base retriever class has been renamed from `BaseRetriever` to `Retriever`.
You can also define a custom retriever options class (that extends from `RetrieverOptions`) if you retriever supports additional configuration options.

Before:
```dart
class MyCustomRetriever extends BaseRetriever {
  // ...

  @override
  Future<List<Document>> getRelevantDocuments(final String query) {
    // ...
  }
}
```

Now:
```dart
class MyCustomRetriever Retriever<MyCustomRetrieverOptions> {
  // ...

  @override
  Future<List<Document>> getRelevantDocuments(
    final String query, {
    final MyCustomRetrieverOptions? options,
  }) {
    // ...
  }
}
```