### PR TITLE
feat(prompts): Make ChatPromptTemplates more convenient to use

### DIFF
--- a/packages/langchain/lib/src/model_io/language_models/models/models.dart
+++ b/packages/langchain/lib/src/model_io/language_models/models/models.dart
@@ -41,7 +41,20 @@ class LanguageModelResult<O extends Object> {
   /// Whether the result of the language model is being streamed.
   final bool streaming;
 
+  /// Returns the first output.
+  ///
+  /// This is a convenience method for getting the first output.
+  /// - If you are using an `LLM`, this will be a String.
+  /// - If you are using a `ChatModel`, this will be a `ChatMessage`.
+  O get firstOutput {
+    return generations.first.output;
+  }
+
   /// Returns the first output as a string.
+  ///
+  /// This is a convenience method for getting the first output as a string.
+  /// - If you are using an `LLM`, this will be the output String.
+  /// - If you are using a `ChatModel`, this will be the content of the output `ChatMessage`.
   String get firstOutputAsString {
     return generations.firstOrNull?.outputAsString ?? '';
   }

--- a/packages/langchain/lib/src/model_io/prompts/base_chat_message_prompt.dart
+++ b/packages/langchain/lib/src/model_io/prompts/base_chat_message_prompt.dart
@@ -1,0 +1,260 @@
+import 'package:meta/meta.dart';
+
+import '../../core/core.dart';
+import '../chat_models/models/models.dart';
+import 'base_prompt.dart';
+import 'chat_prompt.dart';
+import 'models/models.dart';
+import 'prompt.dart';
+
+/// {@template chat_message_prompt_template}
+/// Base class for all message templates in a [ChatPromptTemplate].
+/// {@endtemplate}
+@immutable
+abstract base class ChatMessagePromptTemplate
+    extends Runnable<InputValues, BaseLangChainOptions, List<ChatMessage>> {
+  /// {@macro chat_message_prompt_template}
+  const ChatMessagePromptTemplate({required this.prompt});
+
+  /// The prompt template for the message.
+  final BasePromptTemplate prompt;
+
+  /// Input variables of all the messages in the prompt template.
+  Set<String> get inputVariables;
+
+  /// Partial variables.
+  PartialValues? get partialVariables;
+
+  /// Creates a [SystemChatMessagePromptTemplate] from a string template.
+  ///
+  /// This is a convenience factory equivalent to [SystemChatMessagePromptTemplate.fromTemplate].
+  ///
+  /// Example:
+  /// ```dart
+  /// final msgTemplate = ChatMessagePromptTemplate.system("Here's some context: {context}");
+  /// ```
+  ///
+  /// - [template] the template string.
+  /// - [partialVariables] the partial variables to use for the template.
+  /// - [validateTemplate] whether to validate the template.
+  factory ChatMessagePromptTemplate.system(
+    final String template, {
+    final PartialValues? partialVariables,
+    final bool validateTemplate = true,
+  }) {
+    return SystemChatMessagePromptTemplate.fromTemplate(
+      template,
+      partialVariables: partialVariables,
+      validateTemplate: validateTemplate,
+    );
+  }
+
+  /// Creates a [HumanChatMessagePromptTemplate] from a string template.
+  ///
+  /// This is a convenience factory equivalent to [HumanChatMessagePromptTemplate.fromTemplate].
+  ///
+  /// Example:
+  /// ```dart
+  /// final msgTemplate = ChatMessagePromptTemplate.human(
+  ///   "Hello {foo}, I'm {bar}. Thanks for the {context}",
+  /// );
+  /// ```
+  ///
+  /// - [template] the template string.
+  /// - [partialVariables] the partial variables to use for the template.
+  /// - [validateTemplate] whether to validate the template.
+  factory ChatMessagePromptTemplate.human(
+    final String template, {
+    final PartialValues? partialVariables,
+    final bool validateTemplate = true,
+  }) {
+    return HumanChatMessagePromptTemplate.fromTemplate(
+      template,
+      partialVariables: partialVariables,
+      validateTemplate: validateTemplate,
+    );
+  }
+
+  /// Creates a [AIChatMessagePromptTemplate] from a string template.
+  ///
+  /// This is a convenience factory equivalent to [AIChatMessagePromptTemplate.fromTemplate].
+  ///
+  /// Example:
+  /// ```dart
+  /// final msgTemplate = ChatMessagePromptTemplate.ai("I'm an AI. I'm {foo}. I'm {bar}.");
+  /// ```
+  ///
+  /// - [template] the template string.
+  /// - [partialVariables] the partial variables to use for the template.
+  /// - [validateTemplate] whether to validate the template.
+  factory ChatMessagePromptTemplate.ai(
+    final String template, {
+    final PartialValues? partialVariables,
+    final bool validateTemplate = true,
+  }) {
+    return AIChatMessagePromptTemplate.fromTemplate(
+      template,
+      partialVariables: partialVariables,
+      validateTemplate: validateTemplate,
+    );
+  }
+
+  /// Creates a [CustomChatMessagePromptTemplate] from a string template.
+  ///
+  /// This is a convenience factory equivalent to [CustomChatMessagePromptTemplate.fromTemplate].
+  ///
+  /// Example:
+  /// ```dart
+  /// final msgTemplate = ChatMessagePromptTemplate.custom(
+  ///   "I'm an assistant. I'm {foo}. I'm {bar}.",
+  ///   role: 'assistant',
+  /// );
+  /// ```
+  ///
+  /// - [template] the template string.
+  /// - [role] the role of the message.
+  /// - [partialVariables] the partial variables to use for the template.
+  /// - [validateTemplate] whether to validate the template.
+  factory ChatMessagePromptTemplate.custom(
+    final String template, {
+    required final String role,
+    final PartialValues? partialVariables,
+    final bool validateTemplate = true,
+  }) {
+    return CustomChatMessagePromptTemplate.fromTemplate(
+      template,
+      role: role,
+      partialVariables: partialVariables,
+      validateTemplate: validateTemplate,
+    );
+  }
+
+  /// Creates a [MessagePlaceholder], a prompt template that assumes the variable is a [ChatMessage].
+  ///
+  /// This is useful when you want to use a single [ChatMessage] in the prompt.
+  /// For example, when you decide the type of message at runtime (e.g.
+  /// [HumanChatMessage] or [FunctionChatMessage]).
+  ///
+  /// This is a convenience factory equivalent to [MessagePlaceholder] constructor.
+  ///
+  /// If you need to add multiple messages, use [ChatMessagePromptTemplate.messagesPlaceholder].
+  ///
+  /// Example:
+  /// ```dart
+  /// final promptTemplate = ChatPromptTemplate.fromPromptMessages([
+  ///   ChatMessagePromptTemplate.system('You are a helpful AI assistant'),
+  ///   ChatMessagePromptTemplate.messagesPlaceholder('history'),
+  ///   ChatMessagePromptTemplate.messagePlaceholder('input'),
+  /// ]);
+  /// ```
+  ///
+  /// - [variableName] the name of the placeholder variable.
+  factory ChatMessagePromptTemplate.messagePlaceholder(
+    final String variableName,
+  ) {
+    return MessagePlaceholder(variableName: variableName);
+  }
+
+  /// Creates a [MessagesPlaceholder], a prompt template that assumes the variable is a list of [ChatMessage].
+  ///
+  /// This is useful for when you want to use a list of messages in the prompt.
+  /// For example, after retrieving them from memory.
+  ///
+  /// This is a convenience factory equivalent to [MessagesPlaceholder] constructor.
+  ///
+  /// If you need to add a single message, use [ChatMessagePromptTemplate.messagePlaceholder].
+  ///
+  /// Example:
+  /// ```dart
+  /// final promptTemplate = ChatPromptTemplate.fromPromptMessages([
+  ///   ChatMessagePromptTemplate.system('You are a helpful AI assistant'),
+  ///   ChatMessagePromptTemplate.messagesPlaceholder('history'),
+  ///   ChatMessagePromptTemplate.messagePlaceholder('input'),
+  /// ]);
+  /// ```
+  ///
+  /// - [variableName] the name of the placeholder variable.
+  factory ChatMessagePromptTemplate.messagesPlaceholder(
+    final String variableName,
+  ) {
+    return MessagesPlaceholder(variableName: variableName);
+  }
+
+  /// Format the prompt with the inputs returning a list of messages.
+  ///
+  /// - [input] - Any arguments to be passed to the prompt template.
+  @override
+  Future<List<ChatMessage>> invoke(
+    final InputValues input, {
+    final BaseLangChainOptions? options,
+  }) {
+    return Future.value(formatMessages(input));
+  }
+
+  /// Format the prompt with the inputs returning a list of messages.
+  ///
+  /// - [values] - Any arguments to be passed to the prompt template.
+  List<ChatMessage> formatMessages(final InputValues values);
+
+  @override
+  bool operator ==(covariant final ChatMessagePromptTemplate other) =>
+      identical(this, other) ||
+      runtimeType == other.runtimeType && prompt == other.prompt;
+
+  @override
+  int get hashCode => prompt.hashCode;
+
+  @override
+  String toString() {
+    return '''
+BaseChatMessagePromptTemplate{
+  prompt: $prompt, 
+  inputVariables: $inputVariables, 
+  partialVariables: $partialVariables,
+}''';
+  }
+
+  /// Return a new [ChatMessagePromptTemplate] instance with the given
+  /// values.
+  ChatMessagePromptTemplate copyWith({
+    final BasePromptTemplate? prompt,
+  });
+}
+
+/// {@template string_message_prompt_template}
+/// Base class for all string message templates in a [ChatPromptTemplate].
+/// {@endtemplate}
+@immutable
+abstract base class StringMessagePromptTemplate
+    extends ChatMessagePromptTemplate {
+  /// {@macro string_message_prompt_template}
+  const StringMessagePromptTemplate({
+    required final PromptTemplate prompt,
+  }) : super(prompt: prompt);
+
+  @override
+  PromptTemplate get prompt => super.prompt as PromptTemplate;
+
+  @override
+  Set<String> get inputVariables => prompt.inputVariables;
+
+  @override
+  PartialValues? get partialVariables => prompt.partialVariables;
+
+  @override
+  List<ChatMessage> formatMessages(final InputValues values) {
+    return [format(values)];
+  }
+
+  /// Format the prompt with the inputs.
+  ///
+  /// - [values] - Any arguments to be passed to the prompt template.
+  ChatMessage format([final InputValues values = const {}]);
+
+  /// Return a new [StringMessagePromptTemplate] instance with the given
+  /// values.
+  @override
+  StringMessagePromptTemplate copyWith({
+    final BasePromptTemplate? prompt,
+  });
+}

--- a/packages/langchain/lib/src/model_io/prompts/base_chat_prompt.dart
+++ b/packages/langchain/lib/src/model_io/prompts/base_chat_prompt.dart
@@ -1,6 +1,5 @@
 import 'package:meta/meta.dart';
 
-import '../../core/core.dart';
 import '../chat_models/models/models.dart';
 import 'base_prompt.dart';
 import 'models/models.dart';
@@ -11,8 +10,7 @@ import 'models/models.dart';
 /// It exposes two methods:
 /// - [format]: returns a [String] prompt given a set of input values.
 /// - [formatPrompt]: returns a [PromptValue] given a set of input values.
-/// - [formatMessages]: returns a list of [ChatMessage] given a set of input
-///   values.
+/// - [formatMessages]: returns a list of [ChatMessage] given a set of input values.
 /// {@endtemplate}
 @immutable
 abstract base class BaseChatPromptTemplate extends BasePromptTemplate {
@@ -29,107 +27,9 @@ abstract base class BaseChatPromptTemplate extends BasePromptTemplate {
 
   @override
   PromptValue formatPrompt(final InputValues values) {
-    return ChatPromptValue(formatMessages(values));
+    return PromptValue.chat(formatMessages(values));
   }
 
   /// Format input values into a list of messages.
   List<ChatMessage> formatMessages(final InputValues values);
-}
-
-/// {@template base_message_prompt_template}
-/// Base class for all message templates in a [ChatPromptTemplate].
-/// {@endtemplate}
-@immutable
-abstract base class BaseChatMessagePromptTemplate
-    extends Runnable<InputValues, BaseLangChainOptions, List<ChatMessage>> {
-  /// {@macro base_message_prompt_template}
-  const BaseChatMessagePromptTemplate({required this.prompt});
-
-  /// The prompt template for the message.
-  final BasePromptTemplate prompt;
-
-  /// Input variables of all the messages in the prompt template.
-  Set<String> get inputVariables;
-
-  /// Partial variables.
-  PartialValues? get partialVariables;
-
-  /// Format the prompt with the inputs returning a list of messages.
-  ///
-  /// - [input] - Any arguments to be passed to the prompt template.
-  @override
-  Future<List<ChatMessage>> invoke(
-    final InputValues input, {
-    final BaseLangChainOptions? options,
-  }) {
-    return Future.value(formatMessages(input));
-  }
-
-  /// Format the prompt with the inputs returning a list of messages.
-  ///
-  /// - [values] - Any arguments to be passed to the prompt template.
-  List<ChatMessage> formatMessages(final InputValues values);
-
-  @override
-  bool operator ==(covariant final BaseChatMessagePromptTemplate other) =>
-      identical(this, other) ||
-      runtimeType == other.runtimeType && prompt == other.prompt;
-
-  @override
-  int get hashCode => prompt.hashCode;
-
-  @override
-  String toString() {
-    return '''
-BaseChatMessagePromptTemplate{
-  prompt: $prompt, 
-  inputVariables: $inputVariables, 
-  partialVariables: $partialVariables,
-}''';
-  }
-
-  /// Return a new [BaseChatMessagePromptTemplate] instance with the given
-  /// values.
-  BaseChatMessagePromptTemplate copyWith({
-    final BasePromptTemplate? prompt,
-  });
-}
-
-/// {@template base_string_message_prompt_template}
-/// Base class for all string message templates in a [ChatPromptTemplate].
-/// {@endtemplate}
-@immutable
-abstract base class BaseStringMessagePromptTemplate
-    extends BaseChatMessagePromptTemplate {
-  /// {@macro base_string_message_prompt_template}
-  const BaseStringMessagePromptTemplate({
-    required final BaseStringPromptTemplate prompt,
-  }) : super(prompt: prompt);
-
-  @override
-  BaseStringPromptTemplate get prompt =>
-      super.prompt as BaseStringPromptTemplate;
-
-  @override
-  Set<String> get inputVariables => prompt.inputVariables;
-
-  @override
-  PartialValues? get partialVariables => prompt.partialVariables;
-
-  @override
-  List<ChatMessage> formatMessages(final InputValues values) {
-    return [format(values)];
-  }
-
-  /// Format the prompt with the inputs.
-  ///
-  /// - [values] - Any arguments to be passed to the prompt template.
-  ChatMessage format([final InputValues values = const {}]);
-
-  /// Return a new [BaseStringMessagePromptTemplate] instance with the given
-  /// values.
-  @override
-  BaseStringMessagePromptTemplate copyWith({
-    final BasePromptTemplate? prompt,
-  });
 }

--- a/packages/langchain/lib/src/model_io/prompts/base_prompt.dart
+++ b/packages/langchain/lib/src/model_io/prompts/base_prompt.dart
@@ -152,21 +152,3 @@ BasePromptTemplate{
     final Map<String, dynamic>? partialVariables,
   });
 }
-
-/// {@template base_string_prompt_template}
-/// Base class to generate a prompt from a string.
-/// {@endtemplate}
-@immutable
-abstract base class BaseStringPromptTemplate extends BasePromptTemplate {
-  /// {@macro base_string_prompt_template}
-  const BaseStringPromptTemplate({
-    required super.inputVariables,
-    super.partialVariables,
-  });
-
-  @override
-  PromptValue formatPrompt(final InputValues values) {
-    final formattedPrompt = format(values);
-    return StringPromptValue(formattedPrompt);
-  }
-}

--- a/packages/langchain/lib/src/model_io/prompts/pipeline.dart
+++ b/packages/langchain/lib/src/model_io/prompts/pipeline.dart
@@ -18,11 +18,12 @@ import 'prompt.dart';
 /// ```dart
 /// final promptA = PromptTemplate.fromTemplate('{foo}');
 /// final promptB = PromptTemplate.fromTemplate('{bar}');
-/// final pipelinePrompt = PipelinePromptTemplate(
+/// final pipelinePromptTemplate = PipelinePromptTemplate(
 ///   finalPrompt: promptB,
 ///   pipelinePrompts: [('bar', promptA)],
 /// );
-/// final output = pipelinePrompt.format({'foo': 'jim'});
+/// final prompt = pipelinePromptTemplate.formatPrompt({'foo': 'jim'});
+/// final res = await llm.invoke(prompt);
 /// ```
 /// {@endtemplate}
 final class PipelinePromptTemplate extends BasePromptTemplate {

--- a/packages/langchain/lib/src/model_io/prompts/prompt_selector.dart
+++ b/packages/langchain/lib/src/model_io/prompts/prompt_selector.dart
@@ -15,8 +15,29 @@ abstract interface class BasePromptSelector {
 }
 
 /// {@template conditional_prompt_selector}
-/// Prompt collection that goes through conditionals
-/// to select the appropriate prompt.
+/// Prompt collection that goes through conditionals to select the appropriate prompt template.
+///
+/// You can use this to select a prompt template based on the type of language model (LLM vs. ChatModel)
+/// or the specific model used (e.g. GPT-4 vs Gemini Pro).
+///
+/// Example: Selecting a prompt based on the type of language model.
+/// ```dart
+/// final prompt = PromptTemplate.fromTemplate('''
+/// Use the following pieces of context to answer the question at the end.
+/// {context}
+/// Question: {question}
+/// Helpful Answer:
+/// ''');
+/// final chatPrompt = ChatPromptTemplate.fromTemplates([
+///   (ChatMessageRole.system, 'Use the following pieces of context to answer the users question.\n\n{context}'),
+///   (ChatMessageRole.human, '{question}'),
+/// ]);
+/// final promptSelector = ConditionalPromptSelector(
+///   defaultPrompt: prompt,
+///   conditionals: [PromptCondition.isChatModel(chatPrompt)],
+/// );
+/// final prompt = promptSelector.getPrompt(llm);
+/// ```
 /// {@endtemplate}
 class ConditionalPromptSelector implements BasePromptSelector {
   /// {@macro conditional_prompt_selector}
@@ -44,6 +65,10 @@ class ConditionalPromptSelector implements BasePromptSelector {
 
 /// {@template prompt_condition}
 /// Condition for a prompt.
+///
+/// The following pre-defined conditions are available:
+/// - [PromptCondition.isLlm]: checks that the language model is an LLM.
+/// - [PromptCondition.isChatModel]: checks that the language model is a chat model.
 /// {@endtemplate}
 class PromptCondition {
   /// {@macro prompt_condition}

--- a/packages/langchain/lib/src/model_io/prompts/prompts.dart
+++ b/packages/langchain/lib/src/model_io/prompts/prompts.dart
@@ -1,3 +1,4 @@
+export 'base_chat_message_prompt.dart';
 export 'base_chat_prompt.dart';
 export 'base_prompt.dart';
 export 'chat_prompt.dart';

--- a/packages/langchain/lib/src/model_io/prompts/template.dart
+++ b/packages/langchain/lib/src/model_io/prompts/template.dart
@@ -1,39 +1,20 @@
 import 'package:meta/meta.dart';
 
 import '../../utils/exception.dart';
-import 'base_chat_prompt.dart';
+import 'base_chat_message_prompt.dart';
 import 'chat_prompt.dart';
 import 'models/models.dart';
 import 'prompt.dart';
-
-/// Format of a template.
-/// Currently only f-strings are supported.
-enum TemplateFormat {
-  /// Python f-strings format (aka. formatted string literals).
-  /// E.g.: "Hello, my name is {name} and I'm {age} years old."
-  fString,
-
-  /// Jinja2 templating engine format.
-  /// E.g.: "Hello, my name is {{ name }} and I'm {{ age }} years old."
-  jinja2,
-}
 
 /// Checks if the template is a valid [PromptTemplate].
 ///
 /// Throws a [TemplateValidationException] if it is not.
 void checkValidPromptTemplate({
   required final String template,
-  required final TemplateFormat templateFormat,
   required final Set<String> inputVariables,
   required final Iterable<String>? partialVariables,
 }) {
   try {
-    // Check format
-    if (templateFormat == TemplateFormat.jinja2) {
-      throw const TemplateValidationException(
-        message: 'Jinja2 not implemented yet',
-      );
-    }
     // Check reversed keywords
     if (inputVariables.contains('stop') ||
         (partialVariables?.contains('stop') ?? false)) {
@@ -73,7 +54,6 @@ void checkValidPromptTemplate({
     );
     renderTemplate(
       template: template,
-      templateFormat: templateFormat,
       inputValues: dummyInputs,
     );
   } on TemplateValidationException {
@@ -87,7 +67,7 @@ void checkValidPromptTemplate({
 ///
 /// Throws a [TemplateValidationException] if it is not.
 void checkValidChatPromptTemplate({
-  required final List<BaseChatMessagePromptTemplate> promptMessages,
+  required final List<ChatMessagePromptTemplate> promptMessages,
   required final Set<String> inputVariables,
   required final Iterable<String>? partialVariables,
 }) {
@@ -140,15 +120,9 @@ final class TemplateValidationException extends LangChainException {
 /// Renders a template with the given values.
 String renderTemplate({
   required final String template,
-  required final TemplateFormat templateFormat,
   required final InputValues inputValues,
 }) {
-  return switch (templateFormat) {
-    TemplateFormat.fString => renderFStringTemplate(template, inputValues),
-    TemplateFormat.jinja2 => throw const TemplateValidationException(
-        message: 'Jinja2 not implemented yet',
-      ),
-  };
+  return renderFStringTemplate(template, inputValues);
 }
 
 /// Render a template in fString format.

--- a/packages/langchain/test/model_io/prompts/chat_prompt_test.dart
+++ b/packages/langchain/test/model_io/prompts/chat_prompt_test.dart
@@ -33,6 +33,77 @@ void main() {
       ]);
     });
 
+    test('Test ChatPromptTemplate.fromTemplates', () {
+      final chatPrompt = ChatPromptTemplate.fromTemplates(
+        const [
+          (ChatMessageType.system, "Here's some context: {context}"),
+          (
+            ChatMessageType.human,
+            "Hello {foo}, I'm {bar}. Thanks for the {context}"
+          ),
+          (ChatMessageType.ai, "I'm an AI. I'm {foo}. I'm {bar}."),
+          (
+            ChatMessageType.custom,
+            "I'm a generic message. I'm {foo}. I'm {bar}."
+          ),
+        ],
+        customRole: 'test',
+      );
+      final messages = chatPrompt.formatPrompt({
+        'context': 'This is a context',
+        'foo': 'Foo',
+        'bar': 'Bar',
+      });
+      expect(messages.toChatMessages(), [
+        ChatMessage.system("Here's some context: This is a context"),
+        ChatMessage.humanText(
+          "Hello Foo, I'm Bar. Thanks for the This is a context",
+        ),
+        ChatMessage.ai("I'm an AI. I'm Foo. I'm Bar."),
+        ChatMessage.custom(
+          "I'm a generic message. I'm Foo. I'm Bar.",
+          role: 'test',
+        ),
+      ]);
+    });
+
+    test('Test ChatPromptTemplate.fromPromptMessages with factory constructors',
+        () {
+      final chatPrompt = ChatPromptTemplate.fromPromptMessages(
+        [
+          ChatMessagePromptTemplate.system(
+            "Here's some context: {context}",
+          ),
+          ChatMessagePromptTemplate.human(
+            "Hello {foo}, I'm {bar}. Thanks for the {context}",
+          ),
+          ChatMessagePromptTemplate.ai(
+            "I'm an AI. I'm {foo}. I'm {bar}.",
+          ),
+          ChatMessagePromptTemplate.custom(
+            "I'm a generic message. I'm {foo}. I'm {bar}.",
+            role: 'test',
+          ),
+        ],
+      );
+      final messages = chatPrompt.formatPrompt({
+        'context': 'This is a context',
+        'foo': 'Foo',
+        'bar': 'Bar',
+      });
+      expect(messages.toChatMessages(), [
+        ChatMessage.system("Here's some context: This is a context"),
+        ChatMessage.humanText(
+          "Hello Foo, I'm Bar. Thanks for the This is a context",
+        ),
+        ChatMessage.ai("I'm an AI. I'm Foo. I'm Bar."),
+        ChatMessage.custom(
+          "I'm a generic message. I'm Foo. I'm Bar.",
+          role: 'test',
+        ),
+      ]);
+    });
+
     test('Test format with invalid input variables', () {
       const systemPrompt = PromptTemplate(
         template: "Here's some context: {context}",
@@ -301,7 +372,7 @@ void main() {
   });
 }
 
-List<BaseChatMessagePromptTemplate> _createMessages() {
+List<ChatMessagePromptTemplate> _createMessages() {
   return [
     SystemChatMessagePromptTemplate.fromTemplate(
       "Here's some context: {context}",

--- a/packages/langchain/test/model_io/prompts/prompt_test.dart
+++ b/packages/langchain/test/model_io/prompts/prompt_test.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: avoid_redundant_argument_values
 import 'package:langchain/langchain.dart';
-import 'package:langchain/src/model_io/prompts/template.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -114,19 +113,6 @@ void main() {
         () => const PromptTemplate(
           inputVariables: inputVariables,
           template: template,
-        ).validateTemplate(),
-        throwsA(isA<TemplateValidationException>()),
-      );
-    });
-
-    test('Test error is raised when jinja2 template format is used', () {
-      const template = 'This is a {foo} test.';
-      const inputVariables = {'foo'};
-      expect(
-        () => const PromptTemplate(
-          inputVariables: inputVariables,
-          template: template,
-          templateFormat: TemplateFormat.jinja2,
         ).validateTemplate(),
         throwsA(isA<TemplateValidationException>()),
       );

--- a/packages/langchain_openai/lib/src/agents/functions.dart
+++ b/packages/langchain_openai/lib/src/agents/functions.dart
@@ -122,7 +122,7 @@ class OpenAIFunctionsAgent extends BaseSingleActionAgent {
     final BaseChatMemory? memory,
     final SystemChatMessagePromptTemplate systemChatMessage =
         _systemChatMessagePromptTemplate,
-    final List<BaseChatMessagePromptTemplate>? extraPromptMessages,
+    final List<ChatMessagePromptTemplate>? extraPromptMessages,
   }) {
     return OpenAIFunctionsAgent(
       llmChain: LLMChain(
@@ -222,7 +222,7 @@ class OpenAIFunctionsAgent extends BaseSingleActionAgent {
   static BasePromptTemplate createPrompt({
     final SystemChatMessagePromptTemplate systemChatMessage =
         _systemChatMessagePromptTemplate,
-    final List<BaseChatMessagePromptTemplate>? extraPromptMessages,
+    final List<ChatMessagePromptTemplate>? extraPromptMessages,
     final BaseChatMemory? memory,
   }) {
     return ChatPromptTemplate.fromPromptMessages([


### PR DESCRIPTION
Added `ChatPromptTemplate.fromTemplates` convenient factory constructor:

```dart
final promptTemplate = ChatPromptTemplate.fromTemplates([
  (ChatMessageType.system, 'You are a helpful assistant that translates {input_language} to {output_language}.'),
  (ChatMessageType.human, '{text}'),
]);
final prompt = promptTemplate.formatPrompt({
    'input_language': 'English',
    'output_language': 'French',
    'text': 'I love programming.',
});
final res = await chatModel.invoke(prompt);
```

If you need to use message placeholders:
```dart
final promptTemplate = ChatPromptTemplate.fromTemplates([
  (ChatMessageType.system, 'You are a helpful AI assistant'),
  (ChatMessageType.messagesPlaceholder, 'history'),
  (ChatMessageType.messagePlaceholder, 'input'),
]);
```

In general, prefer using `ChatPromptTemplate.fromTemplate` and `ChatPromptTemplate.fromTemplates` to create a `ChatPromptTemplate` as the resulting code is more readable. Use the main `ChatPromptTemplate` constructor or `ChatPromptTemplate.fromPromptMessages` for advanced use cases.