### PR TITLE
refactor(llms): Make all LLM options fields nullable and add copyWith

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -30,7 +30,7 @@ linter:
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
     - avoid_print
-    - avoid_redundant_argument_values
+    # - avoid_redundant_argument_values # Sometimes is useful to be explicit
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters

--- a/docs/expression_language/cookbook/tools.md
+++ b/docs/expression_language/cookbook/tools.md
@@ -4,10 +4,7 @@ Tools are also runnables, and can therefore be used within a chain:
 
 ```dart
 final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
-final model = ChatOpenAI(
-  apiKey: openaiApiKey,
-  defaultOptions: const ChatOpenAIOptions(temperature: 0),
-);
+final model = ChatOpenAI(apiKey: openaiApiKey);
 const stringOutputParser = StringOutputParser();
 
 final promptTemplate = ChatPromptTemplate.fromTemplate('''
@@ -29,6 +26,7 @@ final chain = Runnable.getMapFromInput() |
 final res = await chain.invoke(
   'If I had 3 apples and you had 5 apples but we ate 3. '
   'If we cut the remaining apples in half, how many pieces would we have?',
+  options: const ChatOpenAIOptions(temperature: 0),
 );
 print(res);
 // 10.0

--- a/examples/browser_summarizer/pubspec.lock
+++ b/examples/browser_summarizer/pubspec.lock
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
+      sha256: "8c951c9cb6504b2aa6b3666e6de504032d9baec24bf4cbabd3eea9edd73d4d77"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/examples/docs_examples/bin/expression_language/cookbook/tools.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/tools.dart
@@ -10,12 +10,7 @@ void main(final List<String> arguments) async {
 
 Future<void> _calculator() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
-  final model = ChatOpenAI(
-    apiKey: openaiApiKey,
-    defaultOptions: const ChatOpenAIOptions(
-      temperature: 0,
-    ),
-  );
+  final model = ChatOpenAI(apiKey: openaiApiKey);
   const stringOutputParser = StringOutputParser();
 
   final promptTemplate = ChatPromptTemplate.fromTemplate('''
@@ -37,6 +32,7 @@ MATH EXPRESSION:''');
   final res = await chain.invoke(
     'If I had 3 apples and you had 5 apples but we ate 3. '
     'If we cut the remaining apples in half, how many pieces would we have?',
+    options: const ChatOpenAIOptions(temperature: 0),
   );
   print(res);
   // 10.0

--- a/examples/docs_examples/pubspec.lock
+++ b/examples/docs_examples/pubspec.lock
@@ -370,10 +370,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: bb55f38968b9427ce5dcdb8aaaa41049282195e0cfa4cf48593572fa3d1f36bc
+      sha256: "8c951c9cb6504b2aa6b3666e6de504032d9baec24bf4cbabd3eea9edd73d4d77"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.1"
+    version: "4.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/examples/hello_world_backend/pubspec.lock
+++ b/examples/hello_world_backend/pubspec.lock
@@ -306,10 +306,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: bb55f38968b9427ce5dcdb8aaaa41049282195e0cfa4cf48593572fa3d1f36bc
+      sha256: "8c951c9cb6504b2aa6b3666e6de504032d9baec24bf4cbabd3eea9edd73d4d77"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.1"
+    version: "4.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/examples/hello_world_cli/pubspec.lock
+++ b/examples/hello_world_cli/pubspec.lock
@@ -266,10 +266,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: bb55f38968b9427ce5dcdb8aaaa41049282195e0cfa4cf48593572fa3d1f36bc
+      sha256: "8c951c9cb6504b2aa6b3666e6de504032d9baec24bf4cbabd3eea9edd73d4d77"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.1"
+    version: "4.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/examples/hello_world_flutter/pubspec.lock
+++ b/examples/hello_world_flutter/pubspec.lock
@@ -324,10 +324,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
+      sha256: "8c951c9cb6504b2aa6b3666e6de504032d9baec24bf4cbabd3eea9edd73d4d77"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/packages/googleai_dart/pubspec.yaml
+++ b/packages/googleai_dart/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   build_runner: ^2.4.6
   freezed: ^2.4.5
   json_serializable: ^6.7.1
-  #  openapi_spec: ^0.7.8
+#  openapi_spec: ^0.7.8
   openapi_spec:
     git:
       url: https://github.com/davidmigloz/openapi_spec.git

--- a/packages/langchain/lib/src/model_io/language_models/base.dart
+++ b/packages/langchain/lib/src/model_io/language_models/base.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../core/core.dart';
 import '../chat_models/models/models.dart';
 import '../prompts/models/models.dart';
@@ -83,4 +85,33 @@ abstract class BaseLanguageModel<Input extends Object,
 
   @override
   String toString() => modelType;
+
+  /// Throws an error if the model id is not specified.
+  @protected
+  Never throwNullModelError() {
+    throw ArgumentError('''
+Null model in $runtimeType.
+        
+You need to specify the id of model to use either in `$runtimeType.defaultOptions` 
+or in the options passed when invoking the model.
+
+Example:
+```
+// In defaultOptions
+final model = $runtimeType(
+  defaultOptions: ${runtimeType}Options(
+    model: 'model-id',
+  ),
+);
+
+// Or when invoking the model
+final res = await model.invoke(
+  prompt,
+  options: ${runtimeType}Options(
+    model: 'model-id',
+  ),
+);
+```
+''');
+  }
 }

--- a/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
@@ -146,7 +146,9 @@ class ChatGoogleGenerativeAI
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const ChatGoogleGenerativeAIOptions(),
+    this.defaultOptions = const ChatGoogleGenerativeAIOptions(
+      model: 'gemini-pro',
+    ),
   }) : _client = GoogleAIClient(
           apiKey: apiKey,
           baseUrl: baseUrl,
@@ -173,7 +175,8 @@ class ChatGoogleGenerativeAI
     final ChatGoogleGenerativeAIOptions? options,
   }) async {
     final id = _uuid.v4();
-    final model = options?.model ?? defaultOptions.model;
+    final model =
+        options?.model ?? defaultOptions.model ?? throwNullModelError();
     final completion = await _client.generateContent(
       modelId: model,
       request: _generateCompletionRequest(messages, options: options),
@@ -237,7 +240,7 @@ class ChatGoogleGenerativeAI
     final ChatGoogleGenerativeAIOptions? options,
   }) async {
     final tokens = await _client.countTokens(
-      modelId: options?.model ?? defaultOptions.model,
+      modelId: options?.model ?? defaultOptions.model ?? throwNullModelError(),
       request: CountTokensRequest(
         contents: promptValue.toChatMessages().toContentList(),
       ),

--- a/packages/langchain_google/lib/src/chat_models/google_ai/models/models.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/models/models.dart
@@ -19,7 +19,7 @@ class ChatGoogleGenerativeAIOptions extends ChatModelOptions {
   /// The LLM to use.
   ///
   /// You can find a list of available models here: https://ai.google.dev/models
-  final String model;
+  final String? model;
 
   /// The maximum cumulative probability of tokens to consider when sampling.
   /// The model uses combined Top-k and nucleus sampling. Tokens are sorted
@@ -76,6 +76,30 @@ class ChatGoogleGenerativeAIOptions extends ChatModelOptions {
   /// is no safety setting for a given category provided in the list, the API will use
   /// the default safety setting for that category.
   final List<ChatGoogleGenerativeAISafetySetting>? safetySettings;
+
+  /// Creates a copy of this [ChatGoogleGenerativeAIOptions] object with the given fields
+  /// replaced with the new values.
+  ChatGoogleGenerativeAIOptions copyWith({
+    final String? model,
+    final double? topP,
+    final int? topK,
+    final int? candidateCount,
+    final int? maxOutputTokens,
+    final double? temperature,
+    final List<String>? stopSequences,
+    final List<ChatGoogleGenerativeAISafetySetting>? safetySettings,
+  }) {
+    return ChatGoogleGenerativeAIOptions(
+      model: model ?? this.model,
+      topP: topP ?? this.topP,
+      topK: topK ?? this.topK,
+      candidateCount: candidateCount ?? this.candidateCount,
+      maxOutputTokens: maxOutputTokens ?? this.maxOutputTokens,
+      temperature: temperature ?? this.temperature,
+      stopSequences: stopSequences ?? this.stopSequences,
+      safetySettings: safetySettings ?? this.safetySettings,
+    );
+  }
 }
 
 /// {@template chat_google_generative_ai_safety_setting}

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/models/models.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/models/models.dart
@@ -8,19 +8,19 @@ class ChatVertexAIOptions extends ChatModelOptions {
   const ChatVertexAIOptions({
     this.publisher = 'google',
     this.model = 'chat-bison',
-    this.maxOutputTokens = 1024,
-    this.temperature = 0.2,
-    this.topP = 0.95,
-    this.topK = 40,
-    this.stopSequences = const [],
-    this.candidateCount = 1,
+    this.maxOutputTokens,
+    this.temperature,
+    this.topP,
+    this.topK,
+    this.stopSequences,
+    this.candidateCount,
     this.examples,
   });
 
   /// The publisher of the model.
   ///
   /// Use `google` for first-party models.
-  final String publisher;
+  final String? publisher;
 
   /// The text model to use.
   ///
@@ -31,7 +31,7 @@ class ChatVertexAIOptions extends ChatModelOptions {
   ///
   /// You can find a list of available models here:
   /// https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models
-  final String model;
+  final String? model;
 
   /// Maximum number of tokens that can be generated in the response. A token
   /// is approximately four characters. 100 tokens correspond to roughly
@@ -41,7 +41,7 @@ class ChatVertexAIOptions extends ChatModelOptions {
   /// responses.
   ///
   /// Range: `[1, 1024]`
-  final int maxOutputTokens;
+  final int? maxOutputTokens;
 
   /// The temperature is used for sampling during response generation, which
   /// occurs when topP and topK are applied. Temperature controls the degree of
@@ -56,7 +56,7 @@ class ChatVertexAIOptions extends ChatModelOptions {
   /// fallback response, try increasing the temperature.
   ///
   /// Range: `[0.0, 1.0]`
-  final double temperature;
+  final double? temperature;
 
   /// Top-P changes how the model selects tokens for output. Tokens are
   /// selected from the most (see top-K) to least probable until the sum of
@@ -69,7 +69,7 @@ class ChatVertexAIOptions extends ChatModelOptions {
   /// more random responses.
   ///
   /// Range: `[0.0, 1.0]`
-  final double topP;
+  final double? topP;
 
   /// Top-K changes how the model selects tokens for output. A top-K of 1 means
   /// the next selected token is the most probable among all tokens in the
@@ -85,19 +85,45 @@ class ChatVertexAIOptions extends ChatModelOptions {
   /// more random responses.
   ///
   /// Range: `[1, 40]`
-  final int topK;
+  final int? topK;
 
   /// Specifies a list of strings that tells the model to stop generating text
   /// if one of the strings is encountered in the response. If a string appears
   /// multiple times in the response, then the response truncates where it's
   /// first encountered. The strings are case-sensitive.
-  final List<String> stopSequences;
+  final List<String>? stopSequences;
 
   /// The number of response variations to return.
   ///
   /// Range: `[1–8]`
-  final int candidateCount;
+  final int? candidateCount;
 
   /// List of messages to the model to learn how to respond to the conversation.
   final List<ChatExample>? examples;
+
+  /// Creates a copy of this [ChatVertexAIOptions] object with the given fields
+  /// replaced with the new values.
+  ChatVertexAIOptions copyWith({
+    final String? publisher,
+    final String? model,
+    final int? maxOutputTokens,
+    final double? temperature,
+    final double? topP,
+    final int? topK,
+    final List<String>? stopSequences,
+    final int? candidateCount,
+    final List<ChatExample>? examples,
+  }) {
+    return ChatVertexAIOptions(
+      publisher: publisher ?? this.publisher,
+      model: model ?? this.model,
+      maxOutputTokens: maxOutputTokens ?? this.maxOutputTokens,
+      temperature: temperature ?? this.temperature,
+      topP: topP ?? this.topP,
+      topK: topK ?? this.topK,
+      stopSequences: stopSequences ?? this.stopSequences,
+      candidateCount: candidateCount ?? this.candidateCount,
+      examples: examples ?? this.examples,
+    );
+  }
 }

--- a/packages/langchain_google/lib/src/llms/models/models.dart
+++ b/packages/langchain_google/lib/src/llms/models/models.dart
@@ -8,18 +8,18 @@ class VertexAIOptions extends LLMOptions {
   const VertexAIOptions({
     this.publisher = 'google',
     this.model = 'text-bison',
-    this.maxOutputTokens = 1024,
-    this.temperature = 0.2,
-    this.topP = 0.95,
-    this.topK = 40,
-    this.stopSequences = const [],
-    this.candidateCount = 1,
+    this.maxOutputTokens,
+    this.temperature,
+    this.topP,
+    this.topK,
+    this.stopSequences,
+    this.candidateCount,
   });
 
   /// The publisher of the model.
   ///
   /// Use `google` for first-party models.
-  final String publisher;
+  final String? publisher;
 
   /// The text model to use.
   ///
@@ -30,7 +30,7 @@ class VertexAIOptions extends LLMOptions {
   ///
   /// You can find a list of available models here:
   /// https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models
-  final String model;
+  final String? model;
 
   /// Maximum number of tokens that can be generated in the response. A token
   /// is approximately four characters. 100 tokens correspond to roughly
@@ -40,7 +40,7 @@ class VertexAIOptions extends LLMOptions {
   /// responses.
   ///
   /// Range: `[1, 1024]`
-  final int maxOutputTokens;
+  final int? maxOutputTokens;
 
   /// The temperature is used for sampling during response generation, which
   /// occurs when topP and topK are applied. Temperature controls the degree of
@@ -55,7 +55,7 @@ class VertexAIOptions extends LLMOptions {
   /// fallback response, try increasing the temperature.
   ///
   /// Range: `[0.0, 1.0]`
-  final double temperature;
+  final double? temperature;
 
   /// Top-P changes how the model selects tokens for output. Tokens are
   /// selected from the most (see top-K) to least probable until the sum of
@@ -68,7 +68,7 @@ class VertexAIOptions extends LLMOptions {
   /// more random responses.
   ///
   /// Range: `[0.0, 1.0]`
-  final double topP;
+  final double? topP;
 
   /// Top-K changes how the model selects tokens for output. A top-K of 1 means
   /// the next selected token is the most probable among all tokens in the
@@ -84,16 +84,40 @@ class VertexAIOptions extends LLMOptions {
   /// more random responses.
   ///
   /// Range: `[1, 40]`
-  final int topK;
+  final int? topK;
 
   /// Specifies a list of strings that tells the model to stop generating text
   /// if one of the strings is encountered in the response. If a string appears
   /// multiple times in the response, then the response truncates where it's
   /// first encountered. The strings are case-sensitive.
-  final List<String> stopSequences;
+  final List<String>? stopSequences;
 
   /// The number of response variations to return.
   ///
   /// Range: `[1–8]`
-  final int candidateCount;
+  final int? candidateCount;
+
+  /// Creates a copy of this [VertexAIOptions] object with the given fields
+  /// replaced with the new values.
+  VertexAIOptions copyWith({
+    final String? publisher,
+    final String? model,
+    final int? maxOutputTokens,
+    final double? temperature,
+    final double? topP,
+    final int? topK,
+    final List<String>? stopSequences,
+    final int? candidateCount,
+  }) {
+    return VertexAIOptions(
+      publisher: publisher ?? this.publisher,
+      model: model ?? this.model,
+      maxOutputTokens: maxOutputTokens ?? this.maxOutputTokens,
+      temperature: temperature ?? this.temperature,
+      topP: topP ?? this.topP,
+      topK: topK ?? this.topK,
+      stopSequences: stopSequences ?? this.stopSequences,
+      candidateCount: candidateCount ?? this.candidateCount,
+    );
+  }
 }

--- a/packages/langchain_google/test/chat_models/chat_vertex_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/chat_vertex_ai_test.dart
@@ -12,6 +12,9 @@ import '../utils/auth.dart';
 
 void main() async {
   final authHttpClient = await getAuthHttpClient();
+  const defaultPublisher = 'google';
+  const defaultModel = 'chat-bison';
+
   group('ChatVertexAI tests', () {
     test('Test ChatVertexAI parameters', () async {
       final llm = ChatVertexAI(
@@ -20,8 +23,8 @@ void main() async {
         location: 'us-central1',
         rootUrl: 'https://us-central1-aiplatform.googleapis.com/',
         defaultOptions: const ChatVertexAIOptions(
-          publisher: 'google',
-          model: 'chat-bison@001',
+          publisher: defaultPublisher,
+          model: defaultModel,
           maxOutputTokens: 10,
           temperature: 0.1,
           topP: 0.1,
@@ -35,8 +38,8 @@ void main() async {
       expect(
         llm.defaultOptions,
         const ChatVertexAIOptions(
-          publisher: 'google',
-          model: 'chat-bison@001',
+          publisher: defaultPublisher,
+          model: defaultModel,
           maxOutputTokens: 10,
           temperature: 0.1,
           topP: 0.1,
@@ -51,7 +54,11 @@ void main() async {
       final chat = ChatVertexAI(
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
-        defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
+        defaultOptions: const ChatVertexAIOptions(
+          publisher: defaultPublisher,
+          model: 'chat-bison',
+          maxOutputTokens: 10,
+        ),
       );
       final res = await chat([ChatMessage.humanText('Hello')]);
       expect(res.content, isNotEmpty);
@@ -61,7 +68,11 @@ void main() async {
       final chat = ChatVertexAI(
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
-        defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
+        defaultOptions: const ChatVertexAIOptions(
+          publisher: defaultPublisher,
+          model: 'chat-bison',
+          maxOutputTokens: 10,
+        ),
       );
       final res = await chat.generate(
         [
@@ -77,7 +88,11 @@ void main() async {
       final chat = ChatVertexAI(
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
-        defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
+        defaultOptions: const ChatVertexAIOptions(
+          publisher: defaultPublisher,
+          model: 'chat-bison',
+          maxOutputTokens: 10,
+        ),
       );
       final res = await chat.generate(
         [ChatMessage.humanText('Hello, how are you?')],
@@ -94,7 +109,11 @@ void main() async {
       final chat = ChatVertexAI(
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
-        defaultOptions: const ChatVertexAIOptions(maxOutputTokens: 10),
+        defaultOptions: const ChatVertexAIOptions(
+          publisher: defaultPublisher,
+          model: 'chat-bison',
+          maxOutputTokens: 10,
+        ),
       );
       final systemMessage =
           ChatMessage.system('You are to chat with the user.');
@@ -108,15 +127,15 @@ void main() async {
       final chat = ChatVertexAI(
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
-        defaultOptions: const ChatVertexAIOptions(
-          stopSequences: ['4'],
-        ),
       );
-      final res = await chat.generate([
-        ChatMessage.humanText(
-          'List the numbers from 1 to 9 in order without any spaces or commas',
-        ),
-      ]);
+      final res = await chat.generate(
+        [
+          ChatMessage.humanText(
+            'List the numbers from 1 to 9 in order without any spaces or commas',
+          ),
+        ],
+        options: const ChatVertexAIOptions(stopSequences: ['4']),
+      );
       expect(res.firstOutputAsString, contains('123'));
       expect(res.firstOutputAsString, isNot(contains('456789')));
 

--- a/packages/langchain_google/test/llms/vertex_ai_test.dart
+++ b/packages/langchain_google/test/llms/vertex_ai_test.dart
@@ -12,6 +12,9 @@ import '../utils/auth.dart';
 
 Future<void> main() async {
   final authHttpClient = await getAuthHttpClient();
+  const defaultPublisher = 'google';
+  const defaultModel = 'text-bison';
+
   group('VertexAI tests', () {
     test('Test VertexAI parameters', () async {
       final llm = VertexAI(
@@ -20,8 +23,8 @@ Future<void> main() async {
         location: 'us-central1',
         rootUrl: 'https://us-central1-aiplatform.googleapis.com/',
         defaultOptions: const VertexAIOptions(
-          publisher: 'google',
-          model: 'text-bison@001',
+          publisher: defaultPublisher,
+          model: defaultModel,
           maxOutputTokens: 10,
           temperature: 0.1,
           topP: 0.1,
@@ -35,8 +38,8 @@ Future<void> main() async {
       expect(
         llm.defaultOptions,
         const VertexAIOptions(
-          publisher: 'google',
-          model: 'text-bison@001',
+          publisher: defaultPublisher,
+          model: defaultModel,
           maxOutputTokens: 10,
           temperature: 0.1,
           topP: 0.1,
@@ -60,7 +63,11 @@ Future<void> main() async {
       final llm = VertexAI(
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
-        defaultOptions: const VertexAIOptions(maxOutputTokens: 10),
+        defaultOptions: const VertexAIOptions(
+          publisher: defaultPublisher,
+          model: defaultModel,
+          maxOutputTokens: 10,
+        ),
       );
       final res = await llm.generate('Hello, how are you?');
       expect(res.generations.length, 1);
@@ -70,7 +77,11 @@ Future<void> main() async {
       final llm = VertexAI(
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
-        defaultOptions: const VertexAIOptions(maxOutputTokens: 10),
+        defaultOptions: const VertexAIOptions(
+          publisher: defaultPublisher,
+          model: defaultModel,
+          maxOutputTokens: 10,
+        ),
       );
       final res = await llm.generate('Hello, how are you?');
       expect(res.modelOutput, isNotNull);
@@ -86,6 +97,8 @@ Future<void> main() async {
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const VertexAIOptions(
+          publisher: defaultPublisher,
+          model: defaultModel,
           stopSequences: ['4'],
         ),
       );
@@ -111,6 +124,8 @@ Future<void> main() async {
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
         defaultOptions: const VertexAIOptions(
+          publisher: defaultPublisher,
+          model: defaultModel,
           temperature: 1,
           candidateCount: 3,
         ),

--- a/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
@@ -154,7 +154,9 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const ChatMistralAIOptions(),
+    this.defaultOptions = const ChatMistralAIOptions(
+      model: 'mistral-small',
+    ),
     this.encoding = 'cl100k_base',
   }) : _client = MistralAIClient(
           apiKey: apiKey,
@@ -222,8 +224,9 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
     final ChatMistralAIOptions? options,
   }) {
     return ChatCompletionRequest(
-      model:
-          ChatCompletionModel.modelId(options?.model ?? defaultOptions.model),
+      model: ChatCompletionModel.modelId(
+        options?.model ?? defaultOptions.model ?? throwNullModelError(),
+      ),
       messages: messages.toChatCompletionMessages(),
       temperature: options?.temperature ?? defaultOptions.temperature,
       topP: options?.topP ?? defaultOptions.topP,
@@ -252,7 +255,9 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
   }) async {
     final encoding = this.encoding != null
         ? getEncoding(this.encoding!)
-        : encodingForModel(options?.model ?? defaultOptions.model);
+        : encodingForModel(
+            options?.model ?? defaultOptions.model ?? throwNullModelError(),
+          );
     return encoding.encode(promptValue.toString());
   }
 

--- a/packages/langchain_mistralai/lib/src/chat_models/models/models.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/models/models.dart
@@ -7,31 +7,31 @@ class ChatMistralAIOptions extends ChatModelOptions {
   /// {@macro chat_mistral_ai_options}
   const ChatMistralAIOptions({
     this.model = 'mistral-small',
-    this.temperature = 0.7,
-    this.topP = 1.0,
+    this.temperature,
+    this.topP,
     this.maxTokens,
-    this.safeMode = false,
+    this.safeMode,
     this.randomSeed,
   });
 
   /// ID of the model to use. You can use the [List Available Models](https://docs.mistral.ai/api#operation/listModels)
   /// API to see all of your available models, or see our [Model overview](https://docs.mistral.ai/models)
   /// for model descriptions.
-  final String model;
+  final String? model;
 
   /// What sampling temperature to use, between 0.0 and 2.0. Higher values like
   /// 0.8 will make the output more random, while lower values like 0.2 will
   /// make it more focused and deterministic.
   ///
   /// We generally recommend altering this or `top_p` but not both.
-  final double temperature;
+  final double? temperature;
 
   /// Nucleus sampling, where the model considers the results of the tokens
   /// with `top_p` probability mass. So 0.1 means only the tokens comprising
   /// the top 10% probability mass are considered.
   ///
   /// We generally recommend altering this or `temperature` but not both.
-  final double topP;
+  final double? topP;
 
   /// The maximum number of tokens to generate in the completion.
   ///
@@ -40,9 +40,29 @@ class ChatMistralAIOptions extends ChatModelOptions {
   final int? maxTokens;
 
   /// Whether to inject a safety prompt before all conversations.
-  final bool safeMode;
+  final bool? safeMode;
 
   /// The seed to use for random sampling.
   /// If set, different calls will generate deterministic results.
   final int? randomSeed;
+
+  /// Creates a copy of this [ChatMistralAIOptions] object with the given fields
+  /// replaced with the new values.
+  ChatMistralAIOptions copyWith({
+    final String? model,
+    final double? temperature,
+    final double? topP,
+    final int? maxTokens,
+    final bool? safeMode,
+    final int? randomSeed,
+  }) {
+    return ChatMistralAIOptions(
+      model: model ?? this.model,
+      temperature: temperature ?? this.temperature,
+      topP: topP ?? this.topP,
+      maxTokens: maxTokens ?? this.maxTokens,
+      safeMode: safeMode ?? this.safeMode,
+      randomSeed: randomSeed ?? this.randomSeed,
+    );
+  }
 }

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
@@ -149,7 +149,9 @@ class ChatOllama extends BaseChatModel<ChatOllamaOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const ChatOllamaOptions(),
+    this.defaultOptions = const ChatOllamaOptions(
+      model: 'llama2',
+    ),
     this.encoding = 'cl100k_base',
   }) : _client = OllamaClient(
           baseUrl: baseUrl,
@@ -226,7 +228,7 @@ class ChatOllama extends BaseChatModel<ChatOllamaOptions> {
     final ChatOllamaOptions? options,
   }) {
     return GenerateChatCompletionRequest(
-      model: options?.model ?? defaultOptions.model,
+      model: options?.model ?? defaultOptions.model ?? throwNullModelError(),
       messages: messages.toMessages(),
       format: options?.format?.toResponseFormat(),
       stream: stream,
@@ -291,7 +293,9 @@ class ChatOllama extends BaseChatModel<ChatOllamaOptions> {
   }) async {
     final encoding = this.encoding != null
         ? getEncoding(this.encoding!)
-        : encodingForModel(options?.model ?? defaultOptions.model);
+        : encodingForModel(
+            options?.model ?? defaultOptions.model ?? throwNullModelError(),
+          );
     return encoding.encode(promptValue.toString());
   }
 

--- a/packages/langchain_ollama/lib/src/chat_models/models/models.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/models/models.dart
@@ -46,7 +46,7 @@ class ChatOllamaOptions extends ChatModelOptions {
   });
 
   /// The model used to generate completions
-  final String model;
+  final String? model;
 
   /// The format to return a response in. Currently the only accepted value is
   /// json.
@@ -206,4 +206,82 @@ class ChatOllamaOptions extends ChatModelOptions {
   /// value to the number of physical CPU cores your system has (as opposed to
   /// the logical number of cores).
   final int? numThread;
+
+  /// Creates a copy of this [ChatOllamaOptions] object with the given fields
+  /// replaced with the new values.
+  ChatOllamaOptions copyWith({
+    final String? model,
+    final OllamaResponseFormat? format,
+    final int? numKeep,
+    final int? seed,
+    final int? numPredict,
+    final int? topK,
+    final double? topP,
+    final double? tfsZ,
+    final double? typicalP,
+    final int? repeatLastN,
+    final double? temperature,
+    final double? repeatPenalty,
+    final double? presencePenalty,
+    final double? frequencyPenalty,
+    final int? mirostat,
+    final double? mirostatTau,
+    final double? mirostatEta,
+    final bool? penalizeNewline,
+    final List<String>? stop,
+    final bool? numa,
+    final int? numCtx,
+    final int? numBatch,
+    final int? numGqa,
+    final int? numGpu,
+    final int? mainGpu,
+    final bool? lowVram,
+    final bool? f16KV,
+    final bool? logitsAll,
+    final bool? vocabOnly,
+    final bool? useMmap,
+    final bool? useMlock,
+    final bool? embeddingOnly,
+    final double? ropeFrequencyBase,
+    final double? ropeFrequencyScale,
+    final int? numThread,
+  }) {
+    return ChatOllamaOptions(
+      model: model ?? this.model,
+      format: format ?? this.format,
+      numKeep: numKeep ?? this.numKeep,
+      seed: seed ?? this.seed,
+      numPredict: numPredict ?? this.numPredict,
+      topK: topK ?? this.topK,
+      topP: topP ?? this.topP,
+      tfsZ: tfsZ ?? this.tfsZ,
+      typicalP: typicalP ?? this.typicalP,
+      repeatLastN: repeatLastN ?? this.repeatLastN,
+      temperature: temperature ?? this.temperature,
+      repeatPenalty: repeatPenalty ?? this.repeatPenalty,
+      presencePenalty: presencePenalty ?? this.presencePenalty,
+      frequencyPenalty: frequencyPenalty ?? this.frequencyPenalty,
+      mirostat: mirostat ?? this.mirostat,
+      mirostatTau: mirostatTau ?? this.mirostatTau,
+      mirostatEta: mirostatEta ?? this.mirostatEta,
+      penalizeNewline: penalizeNewline ?? this.penalizeNewline,
+      stop: stop ?? this.stop,
+      numa: numa ?? this.numa,
+      numCtx: numCtx ?? this.numCtx,
+      numBatch: numBatch ?? this.numBatch,
+      numGqa: numGqa ?? this.numGqa,
+      numGpu: numGpu ?? this.numGpu,
+      mainGpu: mainGpu ?? this.mainGpu,
+      lowVram: lowVram ?? this.lowVram,
+      f16KV: f16KV ?? this.f16KV,
+      logitsAll: logitsAll ?? this.logitsAll,
+      vocabOnly: vocabOnly ?? this.vocabOnly,
+      useMmap: useMmap ?? this.useMmap,
+      useMlock: useMlock ?? this.useMlock,
+      embeddingOnly: embeddingOnly ?? this.embeddingOnly,
+      ropeFrequencyBase: ropeFrequencyBase ?? this.ropeFrequencyBase,
+      ropeFrequencyScale: ropeFrequencyScale ?? this.ropeFrequencyScale,
+      numThread: numThread ?? this.numThread,
+    );
+  }
 }

--- a/packages/langchain_ollama/lib/src/llms/models/models.dart
+++ b/packages/langchain_ollama/lib/src/llms/models/models.dart
@@ -48,7 +48,7 @@ class OllamaOptions extends LLMOptions {
   });
 
   /// The model used to generate completions
-  final String model;
+  final String? model;
 
   /// The system prompt (Overrides what is defined in the Modelfile).
   final String? system;
@@ -228,6 +228,92 @@ class OllamaOptions extends LLMOptions {
   /// value to the number of physical CPU cores your system has (as opposed to
   /// the logical number of cores).
   final int? numThread;
+
+  /// Creates a copy of this [OllamaOptions] object with the given fields
+  /// replaced with the new values.
+  OllamaOptions copyWith({
+    final String? model,
+    final String? system,
+    final String? template,
+    final List<int>? context,
+    final OllamaResponseFormat? format,
+    final bool? raw,
+    final int? numKeep,
+    final int? seed,
+    final int? numPredict,
+    final int? topK,
+    final double? topP,
+    final double? tfsZ,
+    final double? typicalP,
+    final int? repeatLastN,
+    final double? temperature,
+    final double? repeatPenalty,
+    final double? presencePenalty,
+    final double? frequencyPenalty,
+    final int? mirostat,
+    final double? mirostatTau,
+    final double? mirostatEta,
+    final bool? penalizeNewline,
+    final List<String>? stop,
+    final bool? numa,
+    final int? numCtx,
+    final int? numBatch,
+    final int? numGqa,
+    final int? numGpu,
+    final int? mainGpu,
+    final bool? lowVram,
+    final bool? f16KV,
+    final bool? logitsAll,
+    final bool? vocabOnly,
+    final bool? useMmap,
+    final bool? useMlock,
+    final bool? embeddingOnly,
+    final double? ropeFrequencyBase,
+    final double? ropeFrequencyScale,
+    final int? numThread,
+  }) {
+    return OllamaOptions(
+      model: model ?? this.model,
+      system: system ?? this.system,
+      template: template ?? this.template,
+      context: context ?? this.context,
+      format: format ?? this.format,
+      raw: raw ?? this.raw,
+      numKeep: numKeep ?? this.numKeep,
+      seed: seed ?? this.seed,
+      numPredict: numPredict ?? this.numPredict,
+      topK: topK ?? this.topK,
+      topP: topP ?? this.topP,
+      tfsZ: tfsZ ?? this.tfsZ,
+      typicalP: typicalP ?? this.typicalP,
+      repeatLastN: repeatLastN ?? this.repeatLastN,
+      temperature: temperature ?? this.temperature,
+      repeatPenalty: repeatPenalty ?? this.repeatPenalty,
+      presencePenalty: presencePenalty ?? this.presencePenalty,
+      frequencyPenalty: frequencyPenalty ?? this.frequencyPenalty,
+      mirostat: mirostat ?? this.mirostat,
+      mirostatTau: mirostatTau ?? this.mirostatTau,
+      mirostatEta: mirostatEta ?? this.mirostatEta,
+      penalizeNewline: penalizeNewline ?? this.penalizeNewline,
+      stop: stop ?? this.stop,
+      numa: numa ?? this.numa,
+      numCtx: numCtx ?? this.numCtx,
+      numBatch: numBatch ?? this.numBatch,
+      numGqa: numGqa ?? this.numGqa,
+      numGpu: numGpu ?? this.numGpu,
+      mainGpu: mainGpu ?? this.mainGpu,
+      lowVram: lowVram ?? this.lowVram,
+      f16KV: f16KV ?? this.f16KV,
+      logitsAll: logitsAll ?? this.logitsAll,
+      vocabOnly: vocabOnly ?? this.vocabOnly,
+      useMmap: useMmap ?? this.useMmap,
+      useMlock: useMlock ?? this.useMlock,
+      embeddingOnly: embeddingOnly ?? this.embeddingOnly,
+      ropeFrequencyBase: ropeFrequencyBase ?? this.ropeFrequencyBase,
+      ropeFrequencyScale: ropeFrequencyScale ?? this.ropeFrequencyScale,
+      numThread: numThread ?? this.numThread,
+    );
+  }
 }
 
 /// The format to return a response in.

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -149,7 +149,9 @@ class Ollama extends BaseLLM<OllamaOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const OllamaOptions(),
+    this.defaultOptions = const OllamaOptions(
+      model: 'llama2',
+    ),
     this.encoding = 'cl100k_base',
   }) : _client = OllamaClient(
           baseUrl: baseUrl,
@@ -214,7 +216,7 @@ class Ollama extends BaseLLM<OllamaOptions> {
     final OllamaOptions? options,
   }) {
     return GenerateCompletionRequest(
-      model: options?.model ?? defaultOptions.model,
+      model: options?.model ?? defaultOptions.model ?? throwNullModelError(),
       prompt: prompt,
       system: options?.system,
       template: options?.template,
@@ -283,7 +285,9 @@ class Ollama extends BaseLLM<OllamaOptions> {
   }) async {
     final encoding = this.encoding != null
         ? getEncoding(this.encoding!)
-        : encodingForModel(options?.model ?? defaultOptions.model);
+        : encodingForModel(
+            options?.model ?? defaultOptions.model ?? throwNullModelError(),
+          );
     return encoding.encode(promptValue.toString());
   }
 

--- a/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
+++ b/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
@@ -7,7 +7,7 @@ import 'package:langchain_ollama/langchain_ollama.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('ChatOllama tests', skip: true, () {
+  group('ChatOllama tests', skip: Platform.environment.containsKey('CI'), () {
     late ChatOllama chatModel;
     const defaultModel = 'llama2:latest';
     const visionModel = 'llava:latest';
@@ -193,7 +193,7 @@ void main() {
       expect(content, contains('123456789'));
     });
 
-    test('Test response seed', () async {
+    test('Test response seed', skip: true, () async {
       final prompt = PromptValue.string(
         'Why is the sky blue? Reply in one sentence.',
       );

--- a/packages/langchain_ollama/test/embeddings/ollama_test.dart
+++ b/packages/langchain_ollama/test/embeddings/ollama_test.dart
@@ -1,9 +1,12 @@
+import 'dart:io';
+
 import 'package:langchain/langchain.dart';
 import 'package:langchain_ollama/langchain_ollama.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('OllamaEmbeddings tests', skip: true, () {
+  group('OllamaEmbeddings tests', skip: Platform.environment.containsKey('CI'),
+      () {
     late OllamaEmbeddings embeddings;
     const defaultModel = 'llama2:latest';
 

--- a/packages/langchain_ollama/test/llms/ollama_test.dart
+++ b/packages/langchain_ollama/test/llms/ollama_test.dart
@@ -1,10 +1,12 @@
 // ignore_for_file: avoid_redundant_argument_values
+import 'dart:io';
+
 import 'package:langchain/langchain.dart';
 import 'package:langchain_ollama/langchain_ollama.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Ollama tests', skip: true, () {
+  group('Ollama tests', skip: Platform.environment.containsKey('CI'), () {
     late Ollama llm;
     const defaultModel = 'llama2:latest';
 
@@ -231,7 +233,7 @@ void main() {
       );
     });
 
-    test('Test response seed', () async {
+    test('Test response seed', skip: true, () async {
       final prompt = PromptValue.string(
         'Why is the sky blue? Reply in one sentence.',
       );

--- a/packages/langchain_openai/lib/src/chat_models/models/models.dart
+++ b/packages/langchain_openai/lib/src/chat_models/models/models.dart
@@ -7,16 +7,16 @@ class ChatOpenAIOptions extends ChatModelOptions {
   /// {@macro chat_openai_options}
   const ChatOpenAIOptions({
     this.model = 'gpt-3.5-turbo',
-    this.frequencyPenalty = 0,
+    this.frequencyPenalty,
     this.logitBias,
     this.maxTokens,
-    this.n = 1,
-    this.presencePenalty = 0,
+    this.n,
+    this.presencePenalty,
     this.responseFormat,
     this.seed,
     this.stop,
-    this.temperature = 1,
-    this.topP = 1,
+    this.temperature,
+    this.topP,
     this.functions,
     this.functionCall,
     this.user,
@@ -25,14 +25,14 @@ class ChatOpenAIOptions extends ChatModelOptions {
   /// ID of the model to use (e.g. 'gpt-3.5-turbo').
   ///
   /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-model
-  final String model;
+  final String? model;
 
   /// Number between -2.0 and 2.0. Positive values penalize new tokens based on
   /// their existing frequency in the text so far, decreasing the model's
   /// likelihood to repeat the same line verbatim.
   ///
   /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-frequency_penalty
-  final double frequencyPenalty;
+  final double? frequencyPenalty;
 
   /// Modify the likelihood of specified tokens appearing in the completion.
   ///
@@ -48,14 +48,14 @@ class ChatOpenAIOptions extends ChatModelOptions {
   /// How many chat completion choices to generate for each input message.
   ///
   /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-n
-  final int n;
+  final int? n;
 
   /// Number between -2.0 and 2.0. Positive values penalize new tokens based on
   /// whether they appear in the text so far, increasing the model's likelihood
   /// to talk about new topics.
   ///
   /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-presence_penalty
-  final double presencePenalty;
+  final double? presencePenalty;
 
   /// An object specifying the format that the model must output.
   ///
@@ -91,14 +91,14 @@ class ChatOpenAIOptions extends ChatModelOptions {
   /// What sampling temperature to use, between 0 and 2.
   ///
   /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature
-  final double temperature;
+  final double? temperature;
 
   /// An alternative to sampling with temperature, called nucleus sampling,
   /// where the model considers the results of the tokens with top_p
   /// probability mass.
   ///
   /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p
-  final double topP;
+  final double? topP;
 
   /// A list of functions the model may generate JSON inputs for.
   ///
@@ -115,6 +115,42 @@ class ChatOpenAIOptions extends ChatModelOptions {
   ///
   /// Ref: https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids
   final String? user;
+
+  /// Creates a copy of this [ChatOpenAIOptions] object with the given fields
+  /// replaced with the new values.
+  ChatOpenAIOptions copyWith({
+    final String? model,
+    final double? frequencyPenalty,
+    final Map<String, int>? logitBias,
+    final int? maxTokens,
+    final int? n,
+    final double? presencePenalty,
+    final ChatOpenAIResponseFormat? responseFormat,
+    final int? seed,
+    final List<String>? stop,
+    final double? temperature,
+    final double? topP,
+    final List<ChatFunction>? functions,
+    final ChatFunctionCall? functionCall,
+    final String? user,
+  }) {
+    return ChatOpenAIOptions(
+      model: model ?? this.model,
+      frequencyPenalty: frequencyPenalty ?? this.frequencyPenalty,
+      logitBias: logitBias ?? this.logitBias,
+      maxTokens: maxTokens ?? this.maxTokens,
+      n: n ?? this.n,
+      presencePenalty: presencePenalty ?? this.presencePenalty,
+      responseFormat: responseFormat ?? this.responseFormat,
+      seed: seed ?? this.seed,
+      stop: stop ?? this.stop,
+      temperature: temperature ?? this.temperature,
+      topP: topP ?? this.topP,
+      functions: functions ?? this.functions,
+      functionCall: functionCall ?? this.functionCall,
+      user: user ?? this.user,
+    );
+  }
 }
 
 /// {@template chat_openai_response_format}

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -185,7 +185,9 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const ChatOpenAIOptions(),
+    this.defaultOptions = const ChatOpenAIOptions(
+      model: 'gpt-3.5-turbo',
+    ),
     this.encoding,
   }) : _client = OpenAIClient(
           apiKey: apiKey ?? '',
@@ -281,7 +283,7 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
 
     return CreateChatCompletionRequest(
       model: ChatCompletionModel.modelId(
-        options?.model ?? defaultOptions.model,
+        options?.model ?? defaultOptions.model ?? throwNullModelError(),
       ),
       messages: messagesDtos,
       functions: functionsDtos,
@@ -314,7 +316,8 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final PromptValue promptValue, {
     final ChatOpenAIOptions? options,
   }) async {
-    final model = options?.model ?? defaultOptions.model;
+    final model =
+        options?.model ?? defaultOptions.model ?? throwNullModelError();
     return _getTiktoken(model).encode(promptValue.toString());
   }
 
@@ -323,7 +326,8 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final PromptValue promptValue, {
     final ChatOpenAIOptions? options,
   }) async {
-    final model = options?.model ?? defaultOptions.model;
+    final model =
+        options?.model ?? defaultOptions.model ?? throwNullModelError();
     final tiktoken = _getTiktoken(model);
     final messages = promptValue.toChatMessages();
 
@@ -384,5 +388,10 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
   /// Returns the tiktoken model to use for the given model.
   Tiktoken _getTiktoken(final String model) {
     return encoding != null ? getEncoding(encoding!) : encodingForModel(model);
+  }
+
+  /// Closes the client and cleans up any resources associated with it.
+  void close() {
+    _client.endSession();
   }
 }

--- a/packages/langchain_openai/lib/src/llms/models/models.dart
+++ b/packages/langchain_openai/lib/src/llms/models/models.dart
@@ -7,38 +7,38 @@ class OpenAIOptions extends LLMOptions {
   /// {@macro openai_options}
   const OpenAIOptions({
     this.model = 'gpt-3.5-turbo-instruct',
-    this.bestOf = 1,
-    this.frequencyPenalty = 0,
+    this.bestOf,
+    this.frequencyPenalty,
     this.logitBias,
     this.logprobs,
     this.maxTokens = 256,
-    this.n = 1,
-    this.presencePenalty = 0,
+    this.n,
+    this.presencePenalty,
     this.seed,
     this.stop,
     this.suffix,
-    this.temperature = 1,
-    this.topP = 1,
+    this.temperature,
+    this.topP,
     this.user,
   });
 
   /// ID of the model to use (e.g. 'gpt-3.5-turbo-instruct').
   ///
   /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-model
-  final String model;
+  final String? model;
 
   /// Generates best_of completions server-side and returns the "best"
   /// (the one with the highest log probability per token).
   ///
   /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-best_of
-  final int bestOf;
+  final int? bestOf;
 
   /// Number between -2.0 and 2.0. Positive values penalize new tokens based on
   /// their existing frequency in the text so far, decreasing the model's
   /// likelihood to repeat the same line verbatim.
   ///
   /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-frequency_penalty
-  final double frequencyPenalty;
+  final double? frequencyPenalty;
 
   /// Modify the likelihood of specified tokens appearing in the completion.
   ///
@@ -64,14 +64,14 @@ class OpenAIOptions extends LLMOptions {
   /// How many completions to generate for each prompt.
   ///
   /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-n
-  final int n;
+  final int? n;
 
   /// Number between -2.0 and 2.0. Positive values penalize new tokens based on
   /// whether they appear in the text so far, increasing the model's likelihood
   /// to talk about new topics.
   ///
   /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-presence_penalty
-  final double presencePenalty;
+  final double? presencePenalty;
 
   /// If specified, our system will make a best effort to sample
   /// deterministically, such that repeated requests with the same seed and
@@ -97,14 +97,14 @@ class OpenAIOptions extends LLMOptions {
   /// What sampling temperature to use, between 0 and 2.
   ///
   /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-temperature
-  final double temperature;
+  final double? temperature;
 
   /// An alternative to sampling with temperature, called nucleus sampling,
   /// where the model considers the results of the tokens with top_p
   /// probability mass.
   ///
   /// See https://platform.openai.com/docs/api-reference/completions/create#completions-create-top_p
-  final double topP;
+  final double? topP;
 
   /// A unique identifier representing your end-user, which can help OpenAI to
   /// monitor and detect abuse.
@@ -114,4 +114,40 @@ class OpenAIOptions extends LLMOptions {
   ///
   /// Ref: https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids
   final String? user;
+
+  /// Creates a copy of this [OpenAIOptions] object with the given fields
+  /// replaced with the new values.
+  OpenAIOptions copyWith({
+    final String? model,
+    final int? bestOf,
+    final double? frequencyPenalty,
+    final Map<String, int>? logitBias,
+    final int? logprobs,
+    final int? maxTokens,
+    final int? n,
+    final double? presencePenalty,
+    final int? seed,
+    final List<String>? stop,
+    final String? suffix,
+    final double? temperature,
+    final double? topP,
+    final String? user,
+  }) {
+    return OpenAIOptions(
+      model: model ?? this.model,
+      bestOf: bestOf ?? this.bestOf,
+      frequencyPenalty: frequencyPenalty ?? this.frequencyPenalty,
+      logitBias: logitBias ?? this.logitBias,
+      logprobs: logprobs ?? this.logprobs,
+      maxTokens: maxTokens ?? this.maxTokens,
+      n: n ?? this.n,
+      presencePenalty: presencePenalty ?? this.presencePenalty,
+      seed: seed ?? this.seed,
+      stop: stop ?? this.stop,
+      suffix: suffix ?? this.suffix,
+      temperature: temperature ?? this.temperature,
+      topP: topP ?? this.topP,
+      user: user ?? this.user,
+    );
+  }
 }

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -183,7 +183,10 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const OpenAIOptions(),
+    this.defaultOptions = const OpenAIOptions(
+      model: 'gpt-3.5-turbo-instruct',
+      maxTokens: 256,
+    ),
     this.encoding,
   }) : _client = OpenAIClient(
           apiKey: apiKey ?? '',
@@ -265,7 +268,9 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     final OpenAIOptions? options,
   }) {
     return CreateCompletionRequest(
-      model: CompletionModel.modelId(options?.model ?? defaultOptions.model),
+      model: CompletionModel.modelId(
+        options?.model ?? defaultOptions.model ?? throwNullModelError(),
+      ),
       prompt: CompletionPrompt.string(prompt),
       bestOf: options?.bestOf ?? defaultOptions.bestOf,
       frequencyPenalty:
@@ -299,7 +304,9 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
   }) async {
     final encoding = this.encoding != null
         ? getEncoding(this.encoding!)
-        : encodingForModel(options?.model ?? defaultOptions.model);
+        : encodingForModel(
+            options?.model ?? defaultOptions.model ?? throwNullModelError(),
+          );
     return encoding.encode(promptValue.toString());
   }
 

--- a/packages/langchain_openai/test/chains/qa_with_sources_test.dart
+++ b/packages/langchain_openai/test/chains/qa_with_sources_test.dart
@@ -116,6 +116,7 @@ Question: {question}
       final chatModel = ChatOpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const ChatOpenAIOptions(
+          model: 'gpt-3.5-turbo',
           temperature: 0,
         ),
       );

--- a/packages/langchain_openai/test/chat_models/openai_test.dart
+++ b/packages/langchain_openai/test/chat_models/openai_test.dart
@@ -11,12 +11,13 @@ import 'package:test/test.dart';
 void main() {
   group('ChatOpenAI tests', () {
     final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
+    const defaultModel = 'gpt-3.5-turbo';
 
     test('Test ChatOpenAI parameters', () async {
       final chat = ChatOpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const ChatOpenAIOptions(
-          model: 'foo',
+          model: defaultModel,
           temperature: 0.1,
           topP: 0.1,
           n: 10,
@@ -27,7 +28,7 @@ void main() {
           user: 'foo',
         ),
       );
-      expect(chat.defaultOptions.model, 'foo');
+      expect(chat.defaultOptions.model, defaultModel);
       expect(chat.defaultOptions.maxTokens, 10);
       expect(chat.defaultOptions.temperature, 0.1);
       expect(chat.defaultOptions.topP, 0.1);
@@ -42,6 +43,7 @@ void main() {
       final chat = ChatOpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const ChatOpenAIOptions(
+          model: defaultModel,
           maxTokens: 10,
         ),
       );
@@ -65,6 +67,7 @@ void main() {
       final chat = ChatOpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const ChatOpenAIOptions(
+          model: defaultModel,
           maxTokens: 10,
         ),
       );
@@ -73,7 +76,7 @@ void main() {
       );
       expect(res.modelOutput, isNotNull);
       expect(res.modelOutput!['created'], isNotNull);
-      expect(res.modelOutput!['model'], startsWith(chat.defaultOptions.model));
+      expect(res.modelOutput!['model'], startsWith(chat.defaultOptions.model!));
     });
 
     test('Test stop logic on valid configuration', () async {
@@ -82,6 +85,7 @@ void main() {
       final chat = ChatOpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const ChatOpenAIOptions(
+          model: defaultModel,
           temperature: 0,
         ),
       );
@@ -97,6 +101,7 @@ void main() {
       final chat = ChatOpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const ChatOpenAIOptions(
+          model: defaultModel,
           maxTokens: 10,
         ),
       );
@@ -112,6 +117,7 @@ void main() {
       final chat = ChatOpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const ChatOpenAIOptions(
+          model: defaultModel,
           maxTokens: 10,
           n: 5,
         ),
@@ -301,7 +307,10 @@ void main() {
       );
       final chat = ChatOpenAI(
         apiKey: openaiApiKey,
-        defaultOptions: const ChatOpenAIOptions(temperature: 0),
+        defaultOptions: const ChatOpenAIOptions(
+          model: defaultModel,
+          temperature: 0,
+        ),
       ).bind(
         ChatOpenAIOptions(
           functions: const [function],
@@ -331,6 +340,7 @@ void main() {
       final llm = ChatOpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const ChatOpenAIOptions(
+          model: defaultModel,
           temperature: 0,
           seed: 9999,
         ),

--- a/packages/langchain_openai/test/llms/openai_test.dart
+++ b/packages/langchain_openai/test/llms/openai_test.dart
@@ -10,12 +10,13 @@ import 'package:test/test.dart';
 void main() {
   group('OpenAI tests', () {
     final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
+    const defaultModel = 'gpt-3.5-turbo-instruct';
 
     test('Test OpenAI parameters', () async {
       final llm = OpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const OpenAIOptions(
-          model: 'foo',
+          model: defaultModel,
           maxTokens: 10,
           temperature: 0.1,
           topP: 0.1,
@@ -27,7 +28,7 @@ void main() {
           user: 'foo',
         ),
       );
-      expect(llm.defaultOptions.model, 'foo');
+      expect(llm.defaultOptions.model, defaultModel);
       expect(llm.defaultOptions.maxTokens, 10);
       expect(llm.defaultOptions.temperature, 0.1);
       expect(llm.defaultOptions.topP, 0.1);
@@ -42,7 +43,10 @@ void main() {
     test('Test call to OpenAI', () async {
       final llm = OpenAI(
         apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(maxTokens: 10),
+        defaultOptions: const OpenAIOptions(
+          model: defaultModel,
+          maxTokens: 10,
+        ),
       );
       final output = await llm('Say foo:');
       expect(output, isNotEmpty);
@@ -51,7 +55,10 @@ void main() {
     test('Test close OpenAI', () async {
       final llm = OpenAI(
         apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(maxTokens: 10),
+        defaultOptions: const OpenAIOptions(
+          model: defaultModel,
+          maxTokens: 10,
+        ),
       );
       final output = await llm('Say foo:');
       expect(output, isNotEmpty);
@@ -62,7 +69,10 @@ void main() {
     test('Test generate to OpenAI', () async {
       final llm = OpenAI(
         apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(maxTokens: 10),
+        defaultOptions: const OpenAIOptions(
+          model: defaultModel,
+          maxTokens: 10,
+        ),
       );
       final res = await llm.generate('Hello, how are you?');
       expect(res.generations.length, 1);
@@ -71,7 +81,10 @@ void main() {
     test('Test model output contains metadata', () async {
       final llm = OpenAI(
         apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(maxTokens: 10),
+        defaultOptions: const OpenAIOptions(
+          model: defaultModel,
+          maxTokens: 10,
+        ),
       );
       final res = await llm.generate('Hello, how are you?');
       expect(res.modelOutput, isNotNull);
@@ -84,7 +97,10 @@ void main() {
       const query = 'write an ordered list of five items';
       final llm = OpenAI(
         apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(temperature: 0.0),
+        defaultOptions: const OpenAIOptions(
+          model: defaultModel,
+          temperature: 0,
+        ),
       );
       final res = await llm(query, options: const OpenAIOptions(stop: ['3']));
       expect(res.contains('2.'), isTrue);
@@ -94,7 +110,11 @@ void main() {
     test('Test OpenAI wrapper with multiple completions', () async {
       final llm = OpenAI(
         apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(n: 5, bestOf: 5),
+        defaultOptions: const OpenAIOptions(
+          model: defaultModel,
+          n: 5,
+          bestOf: 5,
+        ),
       );
       final res = await llm.generate('Hello, how are you?');
       expect(res.generations.length, 5);
@@ -153,6 +173,7 @@ void main() {
       final llm = OpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const OpenAIOptions(
+          model: defaultModel,
           temperature: 0,
           seed: 9999,
         ),

--- a/packages/mistralai_dart/lib/src/generated/schema/chat_completion_request.dart
+++ b/packages/mistralai_dart/lib/src/generated/schema/chat_completion_request.dart
@@ -40,7 +40,9 @@ class ChatCompletionRequest with _$ChatCompletionRequest {
     @JsonKey(includeIfNull: false) @Default(false) bool? stream,
 
     /// Whether to inject a safety prompt before all conversations.
-    @JsonKey(name: 'safe_mode') @Default(false) bool safeMode,
+    @JsonKey(name: 'safe_mode', includeIfNull: false)
+    @Default(false)
+    bool? safeMode,
 
     /// The seed to use for random sampling. If set, different calls will generate deterministic results.
     @JsonKey(name: 'random_seed', includeIfNull: false) int? randomSeed,

--- a/packages/mistralai_dart/lib/src/generated/schema/schema.freezed.dart
+++ b/packages/mistralai_dart/lib/src/generated/schema/schema.freezed.dart
@@ -52,8 +52,8 @@ mixin _$ChatCompletionRequest {
   bool? get stream => throw _privateConstructorUsedError;
 
   /// Whether to inject a safety prompt before all conversations.
-  @JsonKey(name: 'safe_mode')
-  bool get safeMode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'safe_mode', includeIfNull: false)
+  bool? get safeMode => throw _privateConstructorUsedError;
 
   /// The seed to use for random sampling. If set, different calls will generate deterministic results.
   @JsonKey(name: 'random_seed', includeIfNull: false)
@@ -78,7 +78,7 @@ abstract class $ChatCompletionRequestCopyWith<$Res> {
       @JsonKey(name: 'top_p', includeIfNull: false) double? topP,
       @JsonKey(name: 'max_tokens', includeIfNull: false) int? maxTokens,
       @JsonKey(includeIfNull: false) bool? stream,
-      @JsonKey(name: 'safe_mode') bool safeMode,
+      @JsonKey(name: 'safe_mode', includeIfNull: false) bool? safeMode,
       @JsonKey(name: 'random_seed', includeIfNull: false) int? randomSeed});
 
   $ChatCompletionModelCopyWith<$Res> get model;
@@ -104,7 +104,7 @@ class _$ChatCompletionRequestCopyWithImpl<$Res,
     Object? topP = freezed,
     Object? maxTokens = freezed,
     Object? stream = freezed,
-    Object? safeMode = null,
+    Object? safeMode = freezed,
     Object? randomSeed = freezed,
   }) {
     return _then(_value.copyWith(
@@ -132,10 +132,10 @@ class _$ChatCompletionRequestCopyWithImpl<$Res,
           ? _value.stream
           : stream // ignore: cast_nullable_to_non_nullable
               as bool?,
-      safeMode: null == safeMode
+      safeMode: freezed == safeMode
           ? _value.safeMode
           : safeMode // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       randomSeed: freezed == randomSeed
           ? _value.randomSeed
           : randomSeed // ignore: cast_nullable_to_non_nullable
@@ -168,7 +168,7 @@ abstract class _$$ChatCompletionRequestImplCopyWith<$Res>
       @JsonKey(name: 'top_p', includeIfNull: false) double? topP,
       @JsonKey(name: 'max_tokens', includeIfNull: false) int? maxTokens,
       @JsonKey(includeIfNull: false) bool? stream,
-      @JsonKey(name: 'safe_mode') bool safeMode,
+      @JsonKey(name: 'safe_mode', includeIfNull: false) bool? safeMode,
       @JsonKey(name: 'random_seed', includeIfNull: false) int? randomSeed});
 
   @override
@@ -193,7 +193,7 @@ class __$$ChatCompletionRequestImplCopyWithImpl<$Res>
     Object? topP = freezed,
     Object? maxTokens = freezed,
     Object? stream = freezed,
-    Object? safeMode = null,
+    Object? safeMode = freezed,
     Object? randomSeed = freezed,
   }) {
     return _then(_$ChatCompletionRequestImpl(
@@ -221,10 +221,10 @@ class __$$ChatCompletionRequestImplCopyWithImpl<$Res>
           ? _value.stream
           : stream // ignore: cast_nullable_to_non_nullable
               as bool?,
-      safeMode: null == safeMode
+      safeMode: freezed == safeMode
           ? _value.safeMode
           : safeMode // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       randomSeed: freezed == randomSeed
           ? _value.randomSeed
           : randomSeed // ignore: cast_nullable_to_non_nullable
@@ -243,7 +243,7 @@ class _$ChatCompletionRequestImpl extends _ChatCompletionRequest {
       @JsonKey(name: 'top_p', includeIfNull: false) this.topP = 1.0,
       @JsonKey(name: 'max_tokens', includeIfNull: false) this.maxTokens,
       @JsonKey(includeIfNull: false) this.stream = false,
-      @JsonKey(name: 'safe_mode') this.safeMode = false,
+      @JsonKey(name: 'safe_mode', includeIfNull: false) this.safeMode = false,
       @JsonKey(name: 'random_seed', includeIfNull: false) this.randomSeed})
       : _messages = messages,
         super._();
@@ -295,8 +295,8 @@ class _$ChatCompletionRequestImpl extends _ChatCompletionRequest {
 
   /// Whether to inject a safety prompt before all conversations.
   @override
-  @JsonKey(name: 'safe_mode')
-  final bool safeMode;
+  @JsonKey(name: 'safe_mode', includeIfNull: false)
+  final bool? safeMode;
 
   /// The seed to use for random sampling. If set, different calls will generate deterministic results.
   @override
@@ -309,7 +309,7 @@ class _$ChatCompletionRequestImpl extends _ChatCompletionRequest {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionRequestImpl &&
@@ -364,7 +364,7 @@ abstract class _ChatCompletionRequest extends ChatCompletionRequest {
       @JsonKey(name: 'top_p', includeIfNull: false) final double? topP,
       @JsonKey(name: 'max_tokens', includeIfNull: false) final int? maxTokens,
       @JsonKey(includeIfNull: false) final bool? stream,
-      @JsonKey(name: 'safe_mode') final bool safeMode,
+      @JsonKey(name: 'safe_mode', includeIfNull: false) final bool? safeMode,
       @JsonKey(name: 'random_seed', includeIfNull: false)
       final int? randomSeed}) = _$ChatCompletionRequestImpl;
   const _ChatCompletionRequest._() : super._();
@@ -410,8 +410,8 @@ abstract class _ChatCompletionRequest extends ChatCompletionRequest {
   @override
 
   /// Whether to inject a safety prompt before all conversations.
-  @JsonKey(name: 'safe_mode')
-  bool get safeMode;
+  @JsonKey(name: 'safe_mode', includeIfNull: false)
+  bool? get safeMode;
   @override
 
   /// The seed to use for random sampling. If set, different calls will generate deterministic results.
@@ -556,7 +556,7 @@ class _$ChatCompletionModelEnumerationImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionModelEnumerationImpl &&
@@ -717,7 +717,7 @@ class _$ChatCompletionModelStringImpl extends ChatCompletionModelString {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionModelStringImpl &&
@@ -1050,7 +1050,7 @@ class _$ChatCompletionResponseImpl extends _ChatCompletionResponse {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionResponseImpl &&
@@ -1300,7 +1300,7 @@ class _$ChatCompletionResponseChoicesInnerImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionResponseChoicesInnerImpl &&
@@ -1486,7 +1486,7 @@ class _$ChatCompletionMessageImpl extends _ChatCompletionMessage {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionMessageImpl &&
@@ -1685,7 +1685,7 @@ class _$ChatCompletionUsageImpl extends _ChatCompletionUsage {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionUsageImpl &&
@@ -1953,7 +1953,7 @@ class _$ChatCompletionStreamResponseImpl extends _ChatCompletionStreamResponse {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionStreamResponseImpl &&
@@ -2217,7 +2217,7 @@ class _$ChatCompletionStreamResponseChoicesInnerImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionStreamResponseChoicesInnerImpl &&
@@ -2431,7 +2431,7 @@ class _$ChatCompletionStreamDeltaImpl extends _ChatCompletionStreamDelta {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ChatCompletionStreamDeltaImpl &&
@@ -2660,7 +2660,7 @@ class _$EmbeddingRequestImpl extends _EmbeddingRequest {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EmbeddingRequestImpl &&
@@ -2851,7 +2851,7 @@ class _$EmbeddingModelEnumerationImpl extends EmbeddingModelEnumeration {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EmbeddingModelEnumerationImpl &&
@@ -3007,7 +3007,7 @@ class _$EmbeddingModelStringImpl extends EmbeddingModelString {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EmbeddingModelStringImpl &&
@@ -3315,7 +3315,7 @@ class _$EmbeddingResponseImpl extends _EmbeddingResponse {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EmbeddingResponseImpl &&
@@ -3511,7 +3511,7 @@ class _$EmbeddingUsageImpl extends _EmbeddingUsage {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EmbeddingUsageImpl &&
@@ -3710,7 +3710,7 @@ class _$EmbeddingImpl extends _Embedding {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EmbeddingImpl &&
@@ -3891,7 +3891,7 @@ class _$ModelListImpl extends _ModelList {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ModelListImpl &&
@@ -4103,7 +4103,7 @@ class _$ModelImpl extends _Model {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ModelImpl &&

--- a/packages/mistralai_dart/lib/src/generated/schema/schema.g.dart
+++ b/packages/mistralai_dart/lib/src/generated/schema/schema.g.dart
@@ -40,7 +40,7 @@ Map<String, dynamic> _$$ChatCompletionRequestImplToJson(
   writeNotNull('top_p', instance.topP);
   writeNotNull('max_tokens', instance.maxTokens);
   writeNotNull('stream', instance.stream);
-  val['safe_mode'] = instance.safeMode;
+  writeNotNull('safe_mode', instance.safeMode);
   writeNotNull('random_seed', instance.randomSeed);
   return val;
 }

--- a/packages/mistralai_dart/oas/mistral_openapi_curated.yaml
+++ b/packages/mistralai_dart/oas/mistral_openapi_curated.yaml
@@ -159,6 +159,7 @@ components:
         safe_mode:
           type: boolean
           default: false
+          nullable: true
           description: |
             Whether to inject a safety prompt before all conversations.
         random_seed:


### PR DESCRIPTION
Before the LLM options object (e.g. `ChatOpenAIOptions`, `ChatOllamaOptions`, etc.) used to include some non-nullable fields with default values. This was problematic when you wanted to override a specific value without modifying the rest (as those default values were always set). It was also difficult to see the default values from the LLM wrapper, as you had to go inside the options object.

Now, all the fields from the options object are nullable and don't include any value that is not required by the model provider API. The default values are now also set by the LLM constructor, so they are easier to find.

The only required property is the `model`, if any other property is `null`, the default value from the model provider will be used.

All options objects now also have a `copyWith` method to make it easier to update individual values.
