### PR TITLE
Migrate tokenizer to langchain_tiktoken package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Check out the #announcements channel in the [LangChain.dart Discord](https://discord.gg/x4qbhqecVR)
 server for more details about each release.
 
+## 2024-01-08
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+- There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`langchain_openai` - `v0.3.1+2`](#langchain_openai---v0312)
+
+---
+
+#### `langchain_openai` - `v0.3.1+2`
+
+ - **FIX**(tokens): Switched to using flutter_tiktoken package to fix release-mode extremely long build time.
+
+
 ## 2024-01-04
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Packages with other changes:
 
 #### `langchain_openai` - `v0.3.1+2`
 
- - **FIX**(tokens): Switched to using flutter_tiktoken package to fix release-mode extremely long build time.
+ - **FIX**(tokens): Switched to using langchain_tiktoken package to fix release-mode extremely long build time.
 
 
 ## 2024-01-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,27 +3,6 @@
 Check out the #announcements channel in the [LangChain.dart Discord](https://discord.gg/x4qbhqecVR)
 server for more details about each release.
 
-## 2024-01-08
-
-### Changes
-
----
-
-Packages with breaking changes:
-
-- There are no breaking changes in this release.
-
-Packages with other changes:
-
- - [`langchain_openai` - `v0.3.1+2`](#langchain_openai---v0312)
-
----
-
-#### `langchain_openai` - `v0.3.1+2`
-
- - **FIX**(tokens): Switched to using langchain_tiktoken package to fix release-mode extremely long build time.
-
-
 ## 2024-01-04
 
 ### Changes

--- a/examples/browser_summarizer/pubspec.lock
+++ b/examples/browser_summarizer/pubspec.lock
@@ -142,14 +142,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.18+3"
-  flutter_tiktoken:
-    dependency: transitive
-    description:
-      name: flutter_tiktoken
-      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -233,6 +225,14 @@ packages:
       relative: true
     source: path
     version: "0.3.1+1"
+  langchain_tiktoken:
+    dependency: transitive
+    description:
+      name: langchain_tiktoken
+      sha256: c1804f4b3e56574ca67e562305d9f11e3eabe3c8aa87fea8635992f7efc66674
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   markdown:
     dependency: transitive
     description:
@@ -308,10 +308,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   path_provider_windows:
     dependency: transitive
     description:
@@ -396,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a
+      sha256: "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   shared_preferences_web:
     dependency: transitive
     description:
@@ -502,5 +502,5 @@ packages:
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
+  dart: ">=3.2.3 <4.0.0"
   flutter: ">=3.16.0"

--- a/examples/browser_summarizer/pubspec.lock
+++ b/examples/browser_summarizer/pubspec.lock
@@ -142,6 +142,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.18+3"
+  flutter_tiktoken:
+    dependency: transitive
+    description:
+      name: flutter_tiktoken
+      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -445,14 +453,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  tiktoken:
-    dependency: transitive
-    description:
-      name: tiktoken
-      sha256: a100ca6e387e18be7b711478c8d18627e0753536846600a5961a83631ce5c586
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
   typed_data:
     dependency: transitive
     description:

--- a/examples/docs_examples/pubspec.lock
+++ b/examples/docs_examples/pubspec.lock
@@ -104,19 +104,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
-  flutter:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
-  flutter_tiktoken:
-    dependency: transitive
-    description:
-      name: flutter_tiktoken
-      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.1"
   freezed_annotation:
     dependency: transitive
     description:
@@ -254,14 +241,14 @@ packages:
       relative: true
     source: path
     version: "0.3.1+1"
-  material_color_utilities:
+  langchain_tiktoken:
     dependency: transitive
     description:
-      name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      name: langchain_tiktoken
+      sha256: c1804f4b3e56574ca67e562305d9f11e3eabe3c8aa87fea8635992f7efc66674
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "1.0.1"
   math_expressions:
     dependency: transitive
     description:
@@ -282,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mistralai_dart:
     dependency: "direct overridden"
     description:
@@ -339,11 +326,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
-  sky_engine:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -388,10 +370,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
+      sha256: bb55f38968b9427ce5dcdb8aaaa41049282195e0cfa4cf48593572fa3d1f36bc
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.1"
   vector_math:
     dependency: transitive
     description:
@@ -411,10 +393,9 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: edc8a9573dd8c5a83a183dae1af2b6fd4131377404706ca4e5420474784906fa
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.0"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.2.3 <4.0.0"

--- a/examples/docs_examples/pubspec.lock
+++ b/examples/docs_examples/pubspec.lock
@@ -104,6 +104,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  flutter:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_tiktoken:
+    dependency: transitive
+    description:
+      name: flutter_tiktoken
+      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   freezed_annotation:
     dependency: transitive
     description:
@@ -241,6 +254,14 @@ packages:
       relative: true
     source: path
     version: "0.3.1+1"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   math_expressions:
     dependency: transitive
     description:
@@ -261,10 +282,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   mistralai_dart:
     dependency: "direct overridden"
     description:
@@ -318,6 +339,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  sky_engine:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -350,14 +376,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  tiktoken:
-    dependency: transitive
-    description:
-      name: tiktoken
-      sha256: a100ca6e387e18be7b711478c8d18627e0753536846600a5961a83631ce5c586
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
   typed_data:
     dependency: transitive
     description:
@@ -370,10 +388,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: bb55f38968b9427ce5dcdb8aaaa41049282195e0cfa4cf48593572fa3d1f36bc
+      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.1"
+    version: "4.2.2"
   vector_math:
     dependency: transitive
     description:
@@ -393,9 +411,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: edc8a9573dd8c5a83a183dae1af2b6fd4131377404706ca4e5420474784906fa
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.0"
 sdks:
   dart: ">=3.2.0 <4.0.0"
+  flutter: ">=1.17.0"

--- a/examples/hello_world_backend/pubspec.lock
+++ b/examples/hello_world_backend/pubspec.lock
@@ -81,6 +81,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  flutter:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_tiktoken:
+    dependency: transitive
+    description:
+      name: flutter_tiktoken
+      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   freezed_annotation:
     dependency: transitive
     description:
@@ -167,6 +180,14 @@ packages:
       relative: true
     source: path
     version: "0.3.1+1"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   math_expressions:
     dependency: transitive
     description:
@@ -187,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   openai_dart:
     dependency: "direct overridden"
     description:
@@ -238,6 +259,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.4"
+  sky_engine:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -286,14 +312,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  tiktoken:
-    dependency: transitive
-    description:
-      name: tiktoken
-      sha256: a100ca6e387e18be7b711478c8d18627e0753536846600a5961a83631ce5c586
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
   typed_data:
     dependency: transitive
     description:
@@ -306,10 +324,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: bb55f38968b9427ce5dcdb8aaaa41049282195e0cfa4cf48593572fa3d1f36bc
+      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.1"
+    version: "4.2.2"
   vector_math:
     dependency: transitive
     description:
@@ -322,9 +340,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: edc8a9573dd8c5a83a183dae1af2b6fd4131377404706ca4e5420474784906fa
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.0"
 sdks:
   dart: ">=3.2.0 <4.0.0"
+  flutter: ">=1.17.0"

--- a/examples/hello_world_backend/pubspec.lock
+++ b/examples/hello_world_backend/pubspec.lock
@@ -81,19 +81,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
-  flutter:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
-  flutter_tiktoken:
-    dependency: transitive
-    description:
-      name: flutter_tiktoken
-      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.1"
   freezed_annotation:
     dependency: transitive
     description:
@@ -180,14 +167,14 @@ packages:
       relative: true
     source: path
     version: "0.3.1+1"
-  material_color_utilities:
+  langchain_tiktoken:
     dependency: transitive
     description:
-      name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      name: langchain_tiktoken
+      sha256: c1804f4b3e56574ca67e562305d9f11e3eabe3c8aa87fea8635992f7efc66674
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "1.0.1"
   math_expressions:
     dependency: transitive
     description:
@@ -208,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   openai_dart:
     dependency: "direct overridden"
     description:
@@ -259,11 +246,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.4"
-  sky_engine:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -324,10 +306,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
+      sha256: bb55f38968b9427ce5dcdb8aaaa41049282195e0cfa4cf48593572fa3d1f36bc
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.1"
   vector_math:
     dependency: transitive
     description:
@@ -340,10 +322,9 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: edc8a9573dd8c5a83a183dae1af2b6fd4131377404706ca4e5420474784906fa
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.0"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.2.3 <4.0.0"

--- a/examples/hello_world_cli/pubspec.lock
+++ b/examples/hello_world_cli/pubspec.lock
@@ -81,19 +81,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
-  flutter:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
-  flutter_tiktoken:
-    dependency: transitive
-    description:
-      name: flutter_tiktoken
-      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.1"
   freezed_annotation:
     dependency: transitive
     description:
@@ -172,14 +159,14 @@ packages:
       relative: true
     source: path
     version: "0.3.1+1"
-  material_color_utilities:
+  langchain_tiktoken:
     dependency: transitive
     description:
-      name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      name: langchain_tiktoken
+      sha256: c1804f4b3e56574ca67e562305d9f11e3eabe3c8aa87fea8635992f7efc66674
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "1.0.1"
   math_expressions:
     dependency: transitive
     description:
@@ -200,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   openai_dart:
     dependency: "direct overridden"
     description:
@@ -235,11 +222,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
-  sky_engine:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -284,10 +266,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
+      sha256: bb55f38968b9427ce5dcdb8aaaa41049282195e0cfa4cf48593572fa3d1f36bc
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.1"
   vector_math:
     dependency: transitive
     description:
@@ -300,10 +282,9 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: edc8a9573dd8c5a83a183dae1af2b6fd4131377404706ca4e5420474784906fa
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.0"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.2.3 <4.0.0"

--- a/examples/hello_world_cli/pubspec.lock
+++ b/examples/hello_world_cli/pubspec.lock
@@ -81,6 +81,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  flutter:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_tiktoken:
+    dependency: transitive
+    description:
+      name: flutter_tiktoken
+      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   freezed_annotation:
     dependency: transitive
     description:
@@ -159,6 +172,14 @@ packages:
       relative: true
     source: path
     version: "0.3.1+1"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   math_expressions:
     dependency: transitive
     description:
@@ -179,10 +200,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   openai_dart:
     dependency: "direct overridden"
     description:
@@ -214,6 +235,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  sky_engine:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -246,14 +272,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  tiktoken:
-    dependency: transitive
-    description:
-      name: tiktoken
-      sha256: a100ca6e387e18be7b711478c8d18627e0753536846600a5961a83631ce5c586
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
   typed_data:
     dependency: transitive
     description:
@@ -266,10 +284,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: bb55f38968b9427ce5dcdb8aaaa41049282195e0cfa4cf48593572fa3d1f36bc
+      sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.1"
+    version: "4.2.2"
   vector_math:
     dependency: transitive
     description:
@@ -282,9 +300,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: edc8a9573dd8c5a83a183dae1af2b6fd4131377404706ca4e5420474784906fa
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.0"
 sdks:
   dart: ">=3.2.0 <4.0.0"
+  flutter: ">=1.17.0"

--- a/examples/hello_world_flutter/pubspec.lock
+++ b/examples/hello_world_flutter/pubspec.lock
@@ -110,6 +110,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.3"
+  flutter_tiktoken:
+    dependency: transitive
+    description:
+      name: flutter_tiktoken
+      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   freezed_annotation:
     dependency: transitive
     description:
@@ -304,14 +312,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  tiktoken:
-    dependency: transitive
-    description:
-      name: tiktoken
-      sha256: a100ca6e387e18be7b711478c8d18627e0753536846600a5961a83631ce5c586
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
   typed_data:
     dependency: transitive
     description:
@@ -346,4 +346,4 @@ packages:
     version: "0.3.0"
 sdks:
   dart: ">=3.2.0 <4.0.0"
-  flutter: ">=1.16.0"
+  flutter: ">=1.17.0"

--- a/examples/hello_world_flutter/pubspec.lock
+++ b/examples/hello_world_flutter/pubspec.lock
@@ -110,14 +110,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.3"
-  flutter_tiktoken:
-    dependency: transitive
-    description:
-      name: flutter_tiktoken
-      sha256: a9fa91490c627e630d7feaefc0d6ade6fa56f21c4338a4a7bab9eadcbb07164f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.1"
   freezed_annotation:
     dependency: transitive
     description:
@@ -196,6 +188,14 @@ packages:
       relative: true
     source: path
     version: "0.3.1+1"
+  langchain_tiktoken:
+    dependency: transitive
+    description:
+      name: langchain_tiktoken
+      sha256: c1804f4b3e56574ca67e562305d9f11e3eabe3c8aa87fea8635992f7efc66674
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -345,5 +345,5 @@ packages:
     source: hosted
     version: "0.3.0"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.2.3 <4.0.0"
+  flutter: ">=1.16.0"

--- a/packages/langchain/pubspec.yaml
+++ b/packages/langchain/pubspec.yaml
@@ -1,6 +1,6 @@
 name: langchain
 description: Build powerful LLM-based Dart and Flutter applications with LangChain.dart.
-version: 0.3.1+1
+version: 0.3.1+2
 repository: https://github.com/davidmigloz/langchain_dart/tree/main/packages/langchain
 issue_tracker: https://github.com/davidmigloz/langchain_dart/issues
 homepage: https://github.com/davidmigloz/langchain_dart

--- a/packages/langchain/pubspec.yaml
+++ b/packages/langchain/pubspec.yaml
@@ -1,6 +1,6 @@
 name: langchain
 description: Build powerful LLM-based Dart and Flutter applications with LangChain.dart.
-version: 0.3.1+2
+version: 0.3.1+1
 repository: https://github.com/davidmigloz/langchain_dart/tree/main/packages/langchain
 issue_tracker: https://github.com/davidmigloz/langchain_dart/issues
 homepage: https://github.com/davidmigloz/langchain_dart

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
@@ -1,6 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:tiktoken/tiktoken.dart';
+import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 import 'package:uuid/uuid.dart';
 import 'package:vertex_ai/vertex_ai.dart';
 

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
@@ -1,6 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:flutter_tiktoken/flutter_tiktoken.dart';
+import 'package:tiktoken/tiktoken.dart';
 import 'package:uuid/uuid.dart';
 import 'package:vertex_ai/vertex_ai.dart';
 

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
@@ -1,6 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:tiktoken/tiktoken.dart';
+import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:uuid/uuid.dart';
 import 'package:vertex_ai/vertex_ai.dart';
 
@@ -182,7 +182,7 @@ class ChatVertexAI extends BaseChatModel<ChatVertexAIOptions> {
   /// Tokenizes the given prompt using tiktoken.
   ///
   /// Currently Google does not provide a tokenizer for Vertex AI models.
-  /// So we use tiktoken and text-davinci-003 model to get an approximation
+  /// So we use tiktoken and gpt-3.5-turbo-instruct model to get an approximation
   /// for counting tokens. Mind that the actual tokens will be totally
   /// different from the ones used by the Vertex AI model.
   ///
@@ -192,7 +192,7 @@ class ChatVertexAI extends BaseChatModel<ChatVertexAIOptions> {
     final PromptValue promptValue, {
     final ChatVertexAIOptions? options,
   }) async {
-    final encoding = encodingForModel('text-davinci-003');
+    final encoding = encodingForModel('gpt-3.5-turbo-instruct');
     return encoding.encode(promptValue.toString());
   }
 }

--- a/packages/langchain_google/lib/src/llms/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_tiktoken/flutter_tiktoken.dart';
+import 'package:tiktoken/tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:vertex_ai/vertex_ai.dart';

--- a/packages/langchain_google/lib/src/llms/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai.dart
@@ -1,6 +1,6 @@
+import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:tiktoken/tiktoken.dart';
 import 'package:vertex_ai/vertex_ai.dart';
 
 import 'models/mappers.dart';

--- a/packages/langchain_google/lib/src/llms/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai.dart
@@ -1,6 +1,6 @@
-import 'package:tiktoken/tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
+import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:vertex_ai/vertex_ai.dart';
 
 import 'models/mappers.dart';
@@ -163,7 +163,7 @@ class VertexAI extends BaseLLM<VertexAIOptions> {
   /// Tokenizes the given prompt using tiktoken.
   ///
   /// Currently Google does not provide a tokenizer for Vertex AI models.
-  /// So we use tiktoken and text-davinci-003 model to get an approximation
+  /// So we use tiktoken and gpt-3.5-turbo-instruct model to get an approximation
   /// for counting tokens. Mind that the actual tokens will be totally
   /// different from the ones used by the Vertex AI model.
   ///
@@ -173,7 +173,7 @@ class VertexAI extends BaseLLM<VertexAIOptions> {
     final PromptValue promptValue, {
     final VertexAIOptions? options,
   }) async {
-    final encoding = encodingForModel('text-davinci-003');
+    final encoding = encodingForModel('gpt-3.5-turbo-instruct');
     return encoding.encode(promptValue.toString());
   }
 }

--- a/packages/langchain_google/pubspec.yaml
+++ b/packages/langchain_google/pubspec.yaml
@@ -24,8 +24,8 @@ dependencies:
   googleapis_auth: ^1.4.1
   http: ^1.1.0
   langchain: ^0.3.1+1
+  langchain_tiktoken: ^1.0.1
   meta: ^1.9.1
-  tiktoken: ^1.0.3
   uuid: ^4.0.0
   vertex_ai: ^0.0.7+2
 

--- a/packages/langchain_google/pubspec.yaml
+++ b/packages/langchain_google/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   http: ^1.1.0
   langchain: ^0.3.1+1
   meta: ^1.9.1
-  tiktoken: ^1.0.3
+  flutter_tiktoken: ^0.0.1
   uuid: ^4.0.0
   vertex_ai: ^0.0.7+2
 

--- a/packages/langchain_google/pubspec.yaml
+++ b/packages/langchain_google/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   http: ^1.1.0
   langchain: ^0.3.1+1
   meta: ^1.9.1
-  flutter_tiktoken: ^0.0.1
+  tiktoken: ^1.0.3
   uuid: ^4.0.0
   vertex_ai: ^0.0.7+2
 

--- a/packages/langchain_google/test/chat_models/chat_vertex_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/chat_vertex_ai_test.dart
@@ -170,7 +170,7 @@ void main() async {
       const text = 'Hello, how are you?';
 
       final tokens = await chat.tokenize(PromptValue.string(text));
-      expect(tokens, [15496, 11, 703, 389, 345, 30]);
+      expect(tokens, [9906, 11, 1268, 527, 499, 30]);
     });
 
     test('Test countTokens string', () async {
@@ -207,7 +207,7 @@ void main() async {
       ];
 
       final numTokens = await chat.countTokens(PromptValue.chat(messages));
-      expect(numTokens, 42);
+      expect(numTokens, 41);
     });
   });
 }

--- a/packages/langchain_google/test/llms/vertex_ai_test.dart
+++ b/packages/langchain_google/test/llms/vertex_ai_test.dart
@@ -139,7 +139,7 @@ Future<void> main() async {
       const text = 'Hello, how are you?';
 
       final tokens = await llm.tokenize(PromptValue.string(text));
-      expect(tokens, [15496, 11, 703, 389, 345, 30]);
+      expect(tokens, [9906, 11, 1268, 527, 499, 30]);
     });
 
     test('Test countTokens', () async {

--- a/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
@@ -1,7 +1,7 @@
+import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:mistralai_dart/mistralai_dart.dart';
-import 'package:tiktoken/tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';

--- a/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_tiktoken/flutter_tiktoken.dart';
+import 'package:tiktoken/tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:mistralai_dart/mistralai_dart.dart';

--- a/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
@@ -1,6 +1,6 @@
-import 'package:tiktoken/tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
+import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:mistralai_dart/mistralai_dart.dart';
 
 import 'models/mappers.dart';

--- a/packages/langchain_mistralai/pubspec.yaml
+++ b/packages/langchain_mistralai/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
   collection: ^1.17.1
   http: ^1.1.0
   langchain: ^0.3.1+1
+  langchain_tiktoken: ^1.0.1
   meta: ^1.9.1
   mistralai_dart: ^0.0.2
-  tiktoken: ^1.0.3
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_mistralai/pubspec.yaml
+++ b/packages/langchain_mistralai/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   mistralai_dart: ^0.0.2
-  flutter_tiktoken: ^0.0.1
+  tiktoken: ^1.0.3
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_mistralai/pubspec.yaml
+++ b/packages/langchain_mistralai/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   mistralai_dart: ^0.0.2
-  tiktoken: ^1.0.3
+  flutter_tiktoken: ^0.0.1
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
+++ b/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
@@ -86,13 +86,13 @@ void main() {
     });
 
     test('Test different encoding than the model', () async {
-      chatModel.encoding = 'p50k_base';
+      chatModel.encoding = 'cl100k_base';
       const text = 'antidisestablishmentarianism';
 
       final tokens = await chatModel.tokenize(
         PromptValue.chat([ChatMessage.humanText(text)]),
       );
-      expect(tokens, [20490, 25, 1885, 29207, 44390, 3699, 1042]);
+      expect(tokens, [35075, 25, 3276, 85342, 34500, 479, 8997, 2191]);
     });
 
     test('Test countTokens', () async {

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
@@ -1,6 +1,6 @@
-import 'package:tiktoken/tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
+import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:ollama_dart/ollama_dart.dart';
 import 'package:uuid/uuid.dart';
 

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
@@ -1,7 +1,7 @@
+import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:ollama_dart/ollama_dart.dart';
-import 'package:tiktoken/tiktoken.dart';
 import 'package:uuid/uuid.dart';
 
 import '../llms/models/mappers.dart';

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_tiktoken/flutter_tiktoken.dart';
+import 'package:tiktoken/tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:ollama_dart/ollama_dart.dart';

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -1,6 +1,6 @@
-import 'package:tiktoken/tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
+import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:ollama_dart/ollama_dart.dart';
 
 import 'models/mappers.dart';

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -1,7 +1,7 @@
+import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:ollama_dart/ollama_dart.dart';
-import 'package:tiktoken/tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_tiktoken/flutter_tiktoken.dart';
+import 'package:tiktoken/tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:ollama_dart/ollama_dart.dart';

--- a/packages/langchain_ollama/pubspec.yaml
+++ b/packages/langchain_ollama/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
   collection: ^1.17.1
   http: ^1.1.0
   langchain: ^0.3.1+1
+  langchain_tiktoken: ^1.0.1
   meta: ^1.9.1
   ollama_dart: ^0.0.2
-  tiktoken: ^1.0.3
   uuid: ^4.0.0
 
 dev_dependencies:

--- a/packages/langchain_ollama/pubspec.yaml
+++ b/packages/langchain_ollama/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   ollama_dart: ^0.0.2
-  tiktoken: ^1.0.3
+  flutter_tiktoken: ^0.0.1
   uuid: ^4.0.0
 
 dev_dependencies:

--- a/packages/langchain_ollama/pubspec.yaml
+++ b/packages/langchain_ollama/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   ollama_dart: ^0.0.2
-  flutter_tiktoken: ^0.0.1
+  tiktoken: ^1.0.3
   uuid: ^4.0.0
 
 dev_dependencies:

--- a/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
+++ b/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
@@ -153,13 +153,13 @@ void main() {
     });
 
     test('Test different encoding than the model', () async {
-      chatModel.encoding = 'p50k_base';
+      chatModel.encoding = 'cl100k_base';
       const text = 'antidisestablishmentarianism';
 
       final tokens = await chatModel.tokenize(
         PromptValue.chat([ChatMessage.humanText(text)]),
       );
-      expect(tokens, [20490, 25, 1885, 29207, 44390, 3699, 1042]);
+      expect(tokens, [35075, 25, 3276, 85342, 34500, 479, 8997, 2191]);
     });
 
     test('Test countTokens', () async {

--- a/packages/langchain_ollama/test/llms/ollama_test.dart
+++ b/packages/langchain_ollama/test/llms/ollama_test.dart
@@ -167,11 +167,11 @@ void main() {
     });
 
     test('Test different encoding than the model', () async {
-      llm.encoding = 'p50k_base';
+      llm.encoding = 'cl100k_base';
       const text = 'antidisestablishmentarianism';
 
       final tokens = await llm.tokenize(PromptValue.string(text));
-      expect(tokens, [415, 29207, 44390, 3699, 1042]);
+      expect(tokens, [519, 85342, 34500, 479, 8997, 2191]);
     });
 
     test('Test countTokens', () async {

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -1,7 +1,7 @@
+import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:openai_dart/openai_dart.dart';
-import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';
@@ -316,6 +316,8 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final PromptValue promptValue, {
     final ChatOpenAIOptions? options,
   }) async {
+    await TiktokenDataProcessCenter().initata();
+
     final model = options?.model ?? defaultOptions.model;
     return _getTiktoken(model).encode(promptValue.toString());
   }
@@ -325,6 +327,8 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final PromptValue promptValue, {
     final ChatOpenAIOptions? options,
   }) async {
+    await TiktokenDataProcessCenter().initata();
+
     final model = options?.model ?? defaultOptions.model;
     final tiktoken = _getTiktoken(model);
     final messages = promptValue.toChatMessages();

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -1,7 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:openai_dart/openai_dart.dart';
-import 'package:tiktoken/tiktoken.dart';
+import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -214,8 +214,6 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
   ///
   /// Supported encodings:
   /// - `cl100k_base` (used by gpt-4, gpt-3.5-turbo, text-embedding-ada-002).
-  /// - `p50k_base` (used by codex models, text-davinci-002, text-davinci-003).
-  /// - `r50k_base` (used by gpt-3 models like davinci).
   ///
   /// For an exhaustive list check:
   /// https://github.com/mvitlov/tiktoken/blob/master/lib/tiktoken.dart

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -1,7 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:langchain_tiktoken/tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
+import 'package:tiktoken/tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -1,7 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
+import 'package:langchain_tiktoken/tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
-import 'package:tiktoken/tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -1,6 +1,6 @@
-import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
+import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import 'models/mappers.dart';
@@ -316,8 +316,6 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final PromptValue promptValue, {
     final ChatOpenAIOptions? options,
   }) async {
-    await TiktokenDataProcessCenter().initata();
-
     final model = options?.model ?? defaultOptions.model;
     return _getTiktoken(model).encode(promptValue.toString());
   }
@@ -327,8 +325,6 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final PromptValue promptValue, {
     final ChatOpenAIOptions? options,
   }) async {
-    await TiktokenDataProcessCenter().initata();
-
     final model = options?.model ?? defaultOptions.model;
     final tiktoken = _getTiktoken(model);
     final messages = promptValue.toChatMessages();

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -1,6 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:langchain_tiktoken/tiktoken.dart';
+import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import 'models/mappers.dart';

--- a/packages/langchain_openai/lib/src/chat_models/openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/openai.dart
@@ -1,6 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:langchain_tiktoken/langchain_tiktoken.dart';
+import 'package:langchain_tiktoken/tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import 'models/mappers.dart';

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -1,6 +1,6 @@
-import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
+import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import 'models/mappers.dart';
@@ -299,8 +299,6 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     final PromptValue promptValue, {
     final OpenAIOptions? options,
   }) async {
-    await TiktokenDataProcessCenter().initata();
-
     final encoding = this.encoding != null
         ? getEncoding(this.encoding!)
         : encodingForModel(options?.model ?? defaultOptions.model);

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -299,6 +299,7 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     final PromptValue promptValue, {
     final OpenAIOptions? options,
   }) async {
+    await TiktokenDataProcessCenter().initata();
     final encoding = this.encoding != null
         ? getEncoding(this.encoding!)
         : encodingForModel(options?.model ?? defaultOptions.model);

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -1,7 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:openai_dart/openai_dart.dart';
-import 'package:tiktoken/tiktoken.dart';
+import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -1,7 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:langchain_tiktoken/tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
+import 'package:tiktoken/tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -1,7 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
+import 'package:langchain_tiktoken/tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
-import 'package:tiktoken/tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -1,6 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:langchain_tiktoken/tiktoken.dart';
+import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import 'models/mappers.dart';

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -1,7 +1,7 @@
+import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
 import 'package:openai_dart/openai_dart.dart';
-import 'package:flutter_tiktoken/flutter_tiktoken.dart';
 
 import 'models/mappers.dart';
 import 'models/models.dart';
@@ -300,6 +300,7 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     final OpenAIOptions? options,
   }) async {
     await TiktokenDataProcessCenter().initata();
+
     final encoding = this.encoding != null
         ? getEncoding(this.encoding!)
         : encodingForModel(options?.model ?? defaultOptions.model);

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -1,6 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain/langchain.dart';
-import 'package:langchain_tiktoken/langchain_tiktoken.dart';
+import 'package:langchain_tiktoken/tiktoken.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import 'models/mappers.dart';

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -212,8 +212,6 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
   ///
   /// Supported encodings:
   /// - `cl100k_base` (used by gpt-4, gpt-3.5-turbo, text-embedding-ada-002).
-  /// - `p50k_base` (used by codex models, text-davinci-002, text-davinci-003).
-  /// - `r50k_base` (used by gpt-3 models like davinci).
   ///
   /// For an exhaustive list check:
   /// https://github.com/mvitlov/tiktoken/blob/master/lib/tiktoken.dart

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   openai_dart: ^0.1.3
-  tiktoken: ^1.0.3
+  flutter_tiktoken: ^0.0.1
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -23,11 +23,12 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   openai_dart: ^0.1.3
-
-  langchain_tiktoken:
-    git:
-      url: https://github.com/orenagiv/langchain_tiktoken.git
-      ref: dart-only
+  
+  tiktoken: ^1.0.3
+  # langchain_tiktoken:
+  #   git:
+  #     url: https://github.com/orenagiv/langchain_tiktoken.git
+  #     ref: dart-only
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -24,11 +24,11 @@ dependencies:
   meta: ^1.9.1
   openai_dart: ^0.1.3
   
-  tiktoken: ^1.0.3
-  # langchain_tiktoken:
-  #   git:
-  #     url: https://github.com/orenagiv/langchain_tiktoken.git
-  #     ref: dart-only
+  # tiktoken: ^1.0.3
+  langchain_tiktoken:
+    git:
+      url: https://github.com/orenagiv/langchain_tiktoken.git
+      ref: dart-only
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -5,6 +5,7 @@ repository: https://github.com/davidmigloz/langchain_dart/tree/main/packages/lan
 issue_tracker: https://github.com/davidmigloz/langchain_dart/issues
 homepage: https://github.com/davidmigloz/langchain_dart
 documentation: https://langchaindart.com
+publish_to: none
 
 topics:
   - ai

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 dependency_overrides:
   langchain_tiktoken:
     git:
-      url: https://github.com/inPact/tabit_flutter_package_theme.git
+      url: https://github.com/orenagiv/langchain_tiktoken.git
       ref: dart-only
 
 dev_dependencies:

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -5,7 +5,6 @@ repository: https://github.com/davidmigloz/langchain_dart/tree/main/packages/lan
 issue_tracker: https://github.com/davidmigloz/langchain_dart/issues
 homepage: https://github.com/davidmigloz/langchain_dart
 documentation: https://langchaindart.com
-publish_to: none
 
 topics:
   - ai
@@ -24,11 +23,11 @@ dependencies:
   meta: ^1.9.1
   openai_dart: ^0.1.3
   
-  # tiktoken: ^1.0.3
-  langchain_tiktoken:
-    git:
-      url: https://github.com/orenagiv/langchain_tiktoken.git
-      ref: dart-only
+  langchain_tiktoken: ^1.0.1
+  # langchain_tiktoken:
+  #   git:
+  #     url: https://github.com/orenagiv/langchain_tiktoken.git
+  #     ref: main
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -5,7 +5,6 @@ repository: https://github.com/davidmigloz/langchain_dart/tree/main/packages/lan
 issue_tracker: https://github.com/davidmigloz/langchain_dart/issues
 homepage: https://github.com/davidmigloz/langchain_dart
 documentation: https://langchaindart.com
-publish_to: 'none'
 
 topics:
   - ai
@@ -23,11 +22,13 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   openai_dart: ^0.1.3
-  #langchain_tiktoken: ^1.0.0
+  langchain_tiktoken: ^1.0.0
+
+dependency_overrides:
   langchain_tiktoken:
     git:
-      url: https://github.com/orenagiv/langchain_tiktoken.git
-      ref: main
+      url: https://github.com/inPact/tabit_flutter_package_theme.git
+      ref: dart-only
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: langchain_openai
 description: LangChain.dart integration module for OpenAI (GPT-3, GPT-4, Functions, etc.).
-version: 0.3.1+2
+version: 0.3.1+1
 repository: https://github.com/davidmigloz/langchain_dart/tree/main/packages/langchain_openai
 issue_tracker: https://github.com/davidmigloz/langchain_dart/issues
 homepage: https://github.com/davidmigloz/langchain_dart
@@ -20,9 +20,9 @@ dependencies:
   collection: ^1.17.1
   http: ^1.1.0
   langchain: ^0.3.1+1
+  langchain_tiktoken: ^1.0.1
   meta: ^1.9.1
   openai_dart: ^0.1.3
-  langchain_tiktoken: ^1.0.1
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: langchain_openai
 description: LangChain.dart integration module for OpenAI (GPT-3, GPT-4, Functions, etc.).
-version: 0.3.1+1
+version: 0.3.1+2
 repository: https://github.com/davidmigloz/langchain_dart/tree/main/packages/langchain_openai
 issue_tracker: https://github.com/davidmigloz/langchain_dart/issues
 homepage: https://github.com/davidmigloz/langchain_dart

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -22,9 +22,7 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   openai_dart: ^0.1.3
-  langchain_tiktoken: ^1.0.0
 
-dependency_overrides:
   langchain_tiktoken:
     git:
       url: https://github.com/orenagiv/langchain_tiktoken.git

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -22,12 +22,7 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   openai_dart: ^0.1.3
-  
   langchain_tiktoken: ^1.0.1
-  # langchain_tiktoken:
-  #   git:
-  #     url: https://github.com/orenagiv/langchain_tiktoken.git
-  #     ref: main
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -5,6 +5,7 @@ repository: https://github.com/davidmigloz/langchain_dart/tree/main/packages/lan
 issue_tracker: https://github.com/davidmigloz/langchain_dart/issues
 homepage: https://github.com/davidmigloz/langchain_dart
 documentation: https://langchaindart.com
+publish_to: 'none'
 
 topics:
   - ai
@@ -22,7 +23,11 @@ dependencies:
   langchain: ^0.3.1+1
   meta: ^1.9.1
   openai_dart: ^0.1.3
-  flutter_tiktoken: ^0.0.1
+  #langchain_tiktoken: ^1.0.0
+  langchain_tiktoken:
+    git:
+      url: https://github.com/orenagiv/langchain_tiktoken.git
+      ref: main
 
 dev_dependencies:
   test: ^1.24.5

--- a/packages/langchain_openai/test/chat_models/openai_test.dart
+++ b/packages/langchain_openai/test/chat_models/openai_test.dart
@@ -200,11 +200,11 @@ void main() {
     });
 
     test('Test encoding', () async {
-      final chat = ChatOpenAI(apiKey: openaiApiKey, encoding: 'p50k_base');
+      final chat = ChatOpenAI(apiKey: openaiApiKey, encoding: 'cl100k_base');
       const text = 'Hello, how are you?';
 
       final tokens = await chat.tokenize(PromptValue.string(text));
-      expect(tokens, [15496, 11, 703, 389, 345, 30]);
+      expect(tokens, [9906, 11, 1268, 527, 499, 30]);
     });
 
     test('Test countTokens string', () async {

--- a/packages/langchain_openai/test/llms/openai_test.dart
+++ b/packages/langchain_openai/test/llms/openai_test.dart
@@ -108,7 +108,7 @@ void main() {
       const text = 'Hello, how are you?';
 
       final tokens = await llm.tokenize(PromptValue.string(text));
-      expect(tokens, [15496, 11, 703, 389, 345, 30]);
+      expect(tokens, [9906, 11, 1268, 527, 499, 30]);
     });
 
     test('Test different encoding than the model', () async {


### PR DESCRIPTION
Switched from the tiktoken package to langchain_tiktoken in order to resolve the extremely long build-time release-mode issue.

Original issue:
https://github.com/mvitlov/tiktoken/issues/5

The package owner didn't merge the pull request:
https://github.com/mvitlov/tiktoken/pull/6

So we're using the forked and refactored langchain_tiktoken package instead:
https://pub.dev/packages/langchain_tiktoken
