### PR TITLE
build: Attempt to fix git clone errors in CICD

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,9 +34,8 @@ jobs:
           flutter config --no-analytics
           dart --disable-analytics
 
-      - name: Clean Pub Git cache
-        run: |
-          rm -rf $HOME/.pub-cache/git/cache
+      - name: Clear pub cache
+        run: flutter pub cache clean
 
       - name: Install Melos
         uses: bluefireteam/melos-action@720a109b686f61979b4f9f0d14f582ab1637647e

--- a/packages/chromadb/pubspec.yaml
+++ b/packages/chromadb/pubspec.yaml
@@ -27,6 +27,6 @@ dev_dependencies:
 #  openapi_spec: ^0.7.8
   openapi_spec:
     git:
-      url: https://github.com/davidmigloz/openapi_spec
+      url: https://github.com/davidmigloz/openapi_spec.git
       ref: 52bd544753980267da6d4b299cbf1067a0d07131
   test: ^1.24.3

--- a/packages/googleai_dart/pubspec.yaml
+++ b/packages/googleai_dart/pubspec.yaml
@@ -30,6 +30,6 @@ dev_dependencies:
   #  openapi_spec: ^0.7.8
   openapi_spec:
     git:
-      url: https://github.com/davidmigloz/openapi_spec
+      url: https://github.com/davidmigloz/openapi_spec.git
       ref: 52bd544753980267da6d4b299cbf1067a0d07131
   test: ^1.24.3

--- a/packages/mistralai_dart/pubspec.yaml
+++ b/packages/mistralai_dart/pubspec.yaml
@@ -29,6 +29,6 @@ dev_dependencies:
   #  openapi_spec: ^0.7.8
   openapi_spec:
     git:
-      url: https://github.com/davidmigloz/openapi_spec
+      url: https://github.com/davidmigloz/openapi_spec.git
       ref: 52bd544753980267da6d4b299cbf1067a0d07131
   test: ^1.24.3

--- a/packages/ollama_dart/pubspec.yaml
+++ b/packages/ollama_dart/pubspec.yaml
@@ -29,6 +29,6 @@ dev_dependencies:
   #  openapi_spec: ^0.7.8
   openapi_spec:
     git:
-      url: https://github.com/davidmigloz/openapi_spec
+      url: https://github.com/davidmigloz/openapi_spec.git
       ref: 52bd544753980267da6d4b299cbf1067a0d07131
   test: ^1.24.3

--- a/packages/openai_dart/pubspec.yaml
+++ b/packages/openai_dart/pubspec.yaml
@@ -29,6 +29,6 @@ dev_dependencies:
 #  openapi_spec: ^0.7.8
   openapi_spec:
     git:
-      url: https://github.com/davidmigloz/openapi_spec
+      url: https://github.com/davidmigloz/openapi_spec.git
       ref: 52bd544753980267da6d4b299cbf1067a0d07131
   test: ^1.24.3


### PR DESCRIPTION
The CICD workflow throws the following error from time to time:
```
melos bootstrap
  └> /home/runner/work/langchain_dart/langchain_dart

Running "flutter pub get" in workspace packages...
  - googleai_dart
    └> packages/googleai_dart

       └> Failed to install.
Git error. Command: `git clone --mirror https://github.com/davidmigloz/openapi_spec /opt/hostedtoolcache/flutter/stable-3.16.5-x64/.pub-cache/git/cache/openapi_spec-cd3779bcae98e6d4eef6fcdf66ff9bf6228fe093`
Resolving dependencies...
stdout: 
stderr: Cloning into bare repository '/opt/hostedtoolcache/flutter/stable-3.16.5-x64/.pub-cache/git/cache/openapi_spec-cd3779bcae98e6d4eef6fcdf66ff9bf6228fe093'...
BUG: refs/files-backend.c:3055: initial ref transaction called with existing refs
exit code: -6
BootstrapException: Failed to install.: googleai_dart at 
```