### PR TITLE
feat!: Update OpenAIEmbeddings' default model to text-embedding-3-small

### DIFF
--- a/packages/langchain/lib/src/documents/embeddings/cache.dart
+++ b/packages/langchain/lib/src/documents/embeddings/cache.dart
@@ -54,7 +54,7 @@ class CacheBackedEmbeddings implements Embeddings {
   /// final cacheBackedEmbeddings = CacheBackedEmbeddings.fromByteStore(
   ///   underlyingEmbeddings: OpenAIEmbeddings(apiKey: openaiApiKey),
   ///   documentEmbeddingsStore: InMemoryStore(),
-  ///   namespace: 'text-embedding-ada-002',
+  ///   namespace: 'text-embedding-3-small',
   /// );
   factory CacheBackedEmbeddings.fromByteStore({
     required final Embeddings underlyingEmbeddings,

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
@@ -220,7 +220,7 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
   /// it using this field.
   ///
   /// Supported encodings:
-  /// - `cl100k_base` (used by gpt-4, gpt-3.5-turbo, text-embedding-ada-002).
+  /// - `cl100k_base` (used by gpt-4, gpt-3.5-turbo, text-embedding-3-small).
   ///
   /// For an exhaustive list check:
   /// https://github.com/mvitlov/tiktoken/blob/master/lib/tiktoken.dart

--- a/packages/langchain_openai/lib/src/embeddings/openai.dart
+++ b/packages/langchain_openai/lib/src/embeddings/openai.dart
@@ -130,7 +130,7 @@ class OpenAIEmbeddings implements Embeddings {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.model = 'text-embedding-ada-002',
+    this.model = 'text-embedding-3-small',
     this.dimensions,
     this.batchSize = 512,
     this.user,
@@ -163,7 +163,7 @@ class OpenAIEmbeddings implements Embeddings {
 
   /// The maximum number of documents to embed in a single request.
   /// This is limited by max input tokens for the model
-  /// (e.g. 8191 tokens for text-embedding-ada-002).
+  /// (e.g. 8191 tokens for text-embedding-3-small).
   int batchSize;
 
   /// A unique identifier representing your end-user, which can help OpenAI to

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -214,7 +214,7 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
   /// it using this field.
   ///
   /// Supported encodings:
-  /// - `cl100k_base` (used by gpt-4, gpt-3.5-turbo, text-embedding-ada-002).
+  /// - `cl100k_base` (used by gpt-4, gpt-3.5-turbo, text-embedding-3-small).
   ///
   /// For an exhaustive list check:
   /// https://github.com/mvitlov/tiktoken/blob/master/lib/tiktoken.dart


### PR DESCRIPTION
The new default model of `OpenAIEmbeddings` wrapper is now `text-embedding-3-small`.

If you are not planning to migrate to `text-embedding-3-small`, you have to explicitly set the model to `text-embedding-ada-002`, otherwise `text-embedding-3-small` will be used.

```dart
final embeddings = OpenAIEmbeddings(
  apiKey: openaiApiKey,
  model: 'text-embedding-ada-002',
);
```

---

https://openai.com/blog/new-embedding-models-and-api-updates#new-embedding-models-with-lower-pricing

> text-embedding-3-small is our new highly efficient embedding model and provides a significant upgrade over its predecessor, the text-embedding-ada-002 model released in [December 2022](https://openai.com/blog/new-and-improved-embedding-model). 
>
> Stronger performance. Comparing text-embedding-ada-002 to text-embedding-3-small, the average score on a commonly used benchmark for multi-language retrieval ([MIRACL](https://github.com/project-miracl/miracl)) has increased from 31.4% to 44.0%, while the average score on a commonly used benchmark for English tasks ([MTEB](https://github.com/embeddings-benchmark/mteb)) has increased from 61.0% to 62.3%.
>
> Reduced price. text-embedding-3-small is also substantially more efficient than our previous generation text-embedding-ada-002 model. Pricing for text-embedding-3-small has therefore been reduced by 5X compared to text-embedding-ada-002, from a price per 1k tokens of $0.0001 to $0.00002.
>
> We are not deprecating text-embedding-ada-002, so while we recommend the newer model, customers are welcome to continue using the previous generation model.