### PR TITLE
#69 add support for supabase vectorstore

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -83,6 +83,7 @@
         - [Memory](/modules/retrieval/vector_stores/integrations/memory.md)
         - [Chroma](/modules/retrieval/vector_stores/integrations/chroma.md)
         - [Pinecone](/modules/retrieval/vector_stores/integrations/pinecone.md)
+        - [Supabase](/modules/retrieval/vector_stores/integrations/supabase.md)
         - [Vertex AI Vector Search](/modules/retrieval/vector_stores/integrations/vertex_ai.md)
     - [Retrievers](/modules/retrieval/retrievers/retrievers.md)
   - [Chains](/modules/chains/chains.md)

--- a/docs/modules/retrieval/vector_stores/integrations/supabase.md
+++ b/docs/modules/retrieval/vector_stores/integrations/supabase.md
@@ -1,0 +1,180 @@
+# Supabase
+
+Vector store for [Supabase Vector](https://supabase.com/vector) embedding database.
+
+It uses [`pgvector`](https://github.com/pgvector/pgvector) extension to store, query, and index vector embeddings in a Postgres database instance.
+
+> [Supabase Vector Docs](https://supabase.com/docs/guides/ai)
+
+## Setup
+
+### Enable `pgvector` extension
+
+1. Go to the [Database page](https://supabase.com/dashboard/project/_/database/tables) in the Dashboard.
+2. Click on Extensions in the sidebar.
+3. Search for "vector" and enable the extension.
+4. Select "extensions" schema.
+
+Alternatively, you can run the following SQL query in the [SQL editor](https://supabase.com/dashboard/project/_/sql):
+
+```sql
+ -- Example: enable the "vector" extension.
+create extension vector
+with
+  schema extensions;
+```
+
+### Create a table to store vectors
+
+After enabling the `vector` extension, you will get access to a new data type called `vector`. The size of the vector (indicated in parentheses) represents the number of dimensions stored in that vector.
+
+Create a table to store the vectors:
+ 
+```sql
+create table documents (
+  id bigserial primary key,
+  content text,
+  metadata jsonb,
+  embedding vector(1536)
+);
+```
+
+In the above SQL snippet, we create a `documents` table with the following columns:
+- `id`: a unique identifier for each document. If the id is null, it will be auto-generated.
+- `content`: the text content of the document (i.e. `Document.pageContent`).
+- `metadata`: a JSON object containing metadata about the document (i.e. `Document.metadata`).
+- `embedding`: the vector embedding of the document. In this example, we are using a vector generated using OpenAI's `text-embedding-3-small` embedding model, which produces 1536 dimensions. Change this to the number of dimensions produced by your embedding model. For example, if you are generating embeddings using the open source [gte-small](https://huggingface.co/Supabase/gte-small) model, you would set this number to 384 since that model produces 384 dimensions.
+
+### Create Postgres function to query vectors
+
+[`supabase`](https://pub.dev/packages/supabase) client (used internally by LangChain.dart) connects to your Postgres instance via [PostgREST](https://supabase.com/docs/guides/ai/docs/guides/getting-started/architecture#postgrest-api). PostgREST does not currently support `pgvector` similarity operators, so we need to implement a Postgres function `match_documents` that executes the query. This function will be called by LangChain.dart via the `rpc()` method.
+
+```sql
+create or replace function match_documents (
+  query_embedding vector(1536),
+  match_count int,
+  match_threshold float,
+  filter jsonb
+) returns table (
+  id bigint,
+  content text,
+  metadata jsonb,
+  similarity float
+)
+language sql stable
+as $$
+  select
+    documents.id,
+    documents.content,
+    documents.metadata,
+    1 - (documents.embedding <=> query_embedding) as similarity
+from documents
+where metadata @> filter
+  and 1 - (documents.embedding <=> query_embedding) > match_threshold
+order by (documents.embedding <=> query_embedding) asc
+    limit match_count;
+$$;
+```
+
+This function takes a `query_embedding` argument and compares it to all other embeddings in the `documents` table. Each comparison returns a similarity score. If the similarity is greater than the `match_threshold` argument, it is returned. The number of rows returned is limited by the `match_count` argument.
+
+Make sure to change the `vector(1536)` type to match the number of dimensions in your embedding model.
+
+### Instantiate Supabase vector store
+
+```dart
+final embeddings = OpenAIEmbeddings(apiKey: openaiApiKey);
+final vectorStore = Supabase(
+  tableName: 'documents',
+  embeddings: embeddings,
+  supabaseUrl: supabaseUrl,
+  supabaseKey: supabaseApiKey,
+);
+```
+
+You can find your Supabase URL and API key in the [Project API Settings](https://supabase.com/dashboard/project/_/settings/api) page.
+
+## Usage
+
+### Storing vectors
+
+```dart
+final res = await vectorStore.addDocuments(
+  documents: [
+    const Document(
+      pageContent: 'The cat sat on the mat',
+      metadata: {'cat': 'animal'},
+    ),
+    const Document(
+      pageContent: 'The dog chased the ball.',
+      metadata: {'cat': 'animal'},
+    ),
+  ],
+);
+```
+
+### Querying vectors
+
+```dart
+final res = await vectorStore.similaritySearch(
+  query: 'Where is the cat?',
+  config: const SupabaseSimilaritySearch(k: 1),
+);
+```
+
+You can change the minimum similarity score threshold by setting the `scoreThreshold` parameter in the `SupabaseSimilaritySearch` config object.
+
+#### Filtering
+
+You can filter the query by metadata by setting the `filter` parameter in the `SupabaseSimilaritySearch` config object.
+
+Metadata is stored as binary JSON. As a result, allowed metadata types are drawn from JSON primitive types (bool, String, num). 
+
+The technical limit of a metadata field associated with a vector is 1GB. In practice, you should keep metadata fields as small as possible to maximize performance.
+
+The metadata query language is based loosely on [mongodb's selectors](https://www.mongodb.com/docs/manual/reference/operator/query/). Check the [Supabase docs](https://supabase.com/docs/guides/ai/python/metadata#metadata-query-language) for more information.
+
+```dart
+final res = await vectorStore.similaritySearch(
+  query: 'Where is the cat?',
+  config: const SupabaseSimilaritySearch(
+    k: 10,
+    filter: {'cat': 'animal'},
+  ),
+);
+```
+
+Or using filtering operators:
+
+```dart
+final res = await vectorStore.similaritySearch(
+  query: 'Where is the cat?',
+  config: const SupabaseSimilaritySearch(
+    k: 10,
+    filter: {
+      'cat': {r'ne': 'person'},
+    },
+  ),
+);
+```
+
+### Deleting vectors
+
+```dart
+await vectorStore.delete(ids: ['9999']);
+```
+
+## Advance
+
+### Indexes
+
+Once your vector table starts to grow, you will likely want to add an index to speed up queries. See [Vector indexes](https://supabase.com/docs/guides/ai/vector-indexes) to learn how vector indexes work and how to create them.
+
+### Changing the distance function
+
+You can change the distance function of the embedding space by modifying the distance operator used in the Postgres function.
+
+`pgvector` supports 3 operators for computing distance:
+- `<=>`: Cosine distance
+- `<->`: Euclidean distance
+- `<#>`: Negative inner product

--- a/packages/langchain_supabase/README.md
+++ b/packages/langchain_supabase/README.md
@@ -1,6 +1,18 @@
 # 🦜️🔗 LangChain.dart
 
+[![tests](https://img.shields.io/github/actions/workflow/status/davidmigloz/langchain_dart/test.yaml?logo=github&label=tests)](https://github.com/davidmigloz/langchain_dart/actions/workflows/test.yaml)
+[![docs](https://img.shields.io/github/actions/workflow/status/davidmigloz/langchain_dart/pages%2Fpages-build-deployment?logo=github&label=docs)](https://github.com/davidmigloz/langchain_dart/actions/workflows/pages/pages-build-deployment)
+[![langchain_supabase](https://img.shields.io/pub/v/langchain_supabase.svg)](https://pub.dev/packages/langchain_supabase)
+[![](https://dcbadge.vercel.app/api/server/x4qbhqecVR?style=flat)](https://discord.gg/x4qbhqecVR)
+[![MIT](https://img.shields.io/badge/license-MIT-purple.svg)](https://github.com/davidmigloz/langchain_dart/blob/main/LICENSE)
+
 Supabase module for [LangChain.dart](https://github.com/davidmigloz/langchain_dart).
+
+## Features
+
+- Vector stores:
+    * `Supabase` vector store that uses [Supabase Vector](https://supabase.com/vector)
+    Postgres Vector database.
 
 ## License
 

--- a/packages/langchain_supabase/README.md
+++ b/packages/langchain_supabase/README.md
@@ -1,4 +1,4 @@
-# 🦜️🔗 LangChain.dart
+# 🦜️🔗 LangChain.dart / Supabase
 
 [![tests](https://img.shields.io/github/actions/workflow/status/davidmigloz/langchain_dart/test.yaml?logo=github&label=tests)](https://github.com/davidmigloz/langchain_dart/actions/workflows/test.yaml)
 [![docs](https://img.shields.io/github/actions/workflow/status/davidmigloz/langchain_dart/pages%2Fpages-build-deployment?logo=github&label=docs)](https://github.com/davidmigloz/langchain_dart/actions/workflows/pages/pages-build-deployment)

--- a/packages/langchain_supabase/lib/langchain_supabase.dart
+++ b/packages/langchain_supabase/lib/langchain_supabase.dart
@@ -1,2 +1,4 @@
 /// Supabase module for LangChain.dart.
 library;
+
+export 'src/vector_stores/vector_stores.dart';

--- a/packages/langchain_supabase/lib/langchain_supabase.dart
+++ b/packages/langchain_supabase/lib/langchain_supabase.dart
@@ -1,4 +1,4 @@
-/// Supabase module for LangChain.dart.
+/// LangChain.dart integration module for Supabase (e.g. Supabase Vector).
 library;
 
 export 'src/vector_stores/vector_stores.dart';

--- a/packages/langchain_supabase/lib/src/vector_stores/models/models.dart
+++ b/packages/langchain_supabase/lib/src/vector_stores/models/models.dart
@@ -1,0 +1,27 @@
+import 'package:langchain/langchain.dart';
+
+/// {@template supabase_similarity_search}
+/// Supabase similarity search config.
+///
+/// Supabase supports filtering queries by metadata using
+/// the [filter] parameter: the query will return all rows from the table
+/// where the JSON metadata column contains a key-value pair
+/// where the key is "key" and the value is "value" as in [filter].
+///
+/// Example:
+/// ```dart
+/// SupabaseSimilaritySearch(
+///   k: 5,
+///   filter: {'animal: 'cat'},
+///   scoreThreshold: 0.8,
+/// ),
+/// ```
+/// {@endtemplate}
+class SupabaseSimilaritySearch extends VectorStoreSimilaritySearch {
+  /// {@macro supabase_similarity_search}
+  const SupabaseSimilaritySearch({
+    super.k = 4,
+    super.filter,
+    super.scoreThreshold,
+  });
+}

--- a/packages/langchain_supabase/lib/src/vector_stores/supabase.dart
+++ b/packages/langchain_supabase/lib/src/vector_stores/supabase.dart
@@ -1,0 +1,151 @@
+import 'package:http/http.dart' as http;
+import 'package:langchain/langchain.dart';
+import 'package:supabase/supabase.dart';
+
+/// {@template supabase}
+/// Vector store for Supabase embedding database.
+///
+/// It assumes the database with the `pg_vector` extension,
+/// containing a [tableName] (default: `documents`) and
+/// a PostgreSQL function `match_documents` defined as follows:
+///
+/// ```sql
+/// -- Enable the pgvector extension to work with embedding vectors
+/// create extension vector;
+///
+/// -- Create a table to store your documents
+/// create table documents (
+///   id bigserial primary key, -- document id or null (it will be generated)
+///   content text, -- corresponds to Document.pageContent
+///   metadata jsonb, -- corresponds to Document.metadata
+///   embedding vector null -- embedding vector
+/// );
+///
+/// -- Create a function to search for documents
+/// create function match_documents (
+///   query_embedding vector(1536),
+///   match_count int DEFAULT null,
+///   filter jsonb DEFAULT '{}',
+///   match_threshold float DEFAULT 0.0
+/// ) returns table (
+///   id bigint,
+///   content text,
+///   metadata jsonb,
+///   embedding jsonb,
+///   similarity float
+/// )
+/// language plpgsql
+/// as $$
+/// #variable_conflict use_column
+/// begin
+///   return query
+///   select
+///     id,
+///     content,
+///     metadata,
+///     (embedding::text)::jsonb as embedding,
+///     1 - (documents.embedding <=> query_embedding) as similarity
+///   from documents
+///   where metadata @> filter
+///     and documents.embedding <=> query_embedding < 1 - match_threshold
+///   order by documents.embedding <=> query_embedding
+///   limit match_count;
+/// end;
+/// $$;
+/// ```
+///
+/// See [Supabase documentation](https://supabase.com/blog/openai-embeddings-postgres-vector) for more details.
+/// {@endtemplate}
+class Supabase extends VectorStore {
+  /// {@macro supabase}
+  Supabase({
+    required this.tableName,
+    required final String supabaseKey,
+    required final String supabaseUrl,
+    final Map<String, String> headers = const {},
+    final http.Client? client,
+    required super.embeddings,
+  }) : _client = SupabaseClient(
+          supabaseUrl,
+          supabaseKey,
+          headers: headers,
+          httpClient: client,
+        );
+
+  /// The Supabase client.
+  final SupabaseClient _client;
+
+  /// The Supabase table name.
+  final String tableName;
+
+  @override
+  Future<List<String>> addVectors({
+    required final List<List<double>> vectors,
+    required final List<Document> documents,
+  }) async {
+    assert(vectors.length == documents.length);
+
+    final List<Map<String, dynamic>> records = [];
+    for (var i = 0; i < documents.length; i++) {
+      final doc = documents[i];
+      final id = doc.id;
+      if (id != null) {
+        records.add(
+          {
+            'id': id,
+            'metadata': doc.metadata,
+            'content': doc.pageContent,
+            'embedding': vectors[i],
+          },
+        );
+      } else {
+        records.add(
+          {
+            'metadata': doc.metadata,
+            'content': doc.pageContent,
+            'embedding': vectors[i],
+          },
+        );
+      }
+    }
+
+    final ids = await _client.from(tableName).upsert(records).select('id');
+    return ids.map((final row) => row['id']).map((final id) => id.toString()).toList(growable: false);
+  }
+
+  @override
+  Future<void> delete({required final List<String> ids}) {
+    return _client.from(tableName).delete().filter('id', 'in', ids);
+  }
+
+  @override
+  Future<List<(Document, double)>> similaritySearchByVectorWithScores({
+    required final List<double> embedding,
+    final VectorStoreSimilaritySearch config = const VectorStoreSimilaritySearch(),
+  }) async {
+    final params = {
+      'query_embedding': embedding,
+      'match_count': config.k,
+      'filter': config.filter ?? {},
+      'match_threshold': config.scoreThreshold ?? 0.0,
+    };
+
+    final List<dynamic> result = await _client.rpc(
+      'match_documents',
+      params: params,
+    );
+    return result
+        .map((final row) => row as Map<String, dynamic>)
+        .map(
+          (final row) => (
+            Document(
+              id: row['id'].toString(),
+              pageContent: row['content'] as String,
+              metadata: row['metadata'] as Map<String, dynamic>,
+            ),
+            row['similarity'] as double,
+          ),
+        )
+        .toList();
+  }
+}

--- a/packages/langchain_supabase/lib/src/vector_stores/supabase.dart
+++ b/packages/langchain_supabase/lib/src/vector_stores/supabase.dart
@@ -8,7 +8,8 @@ import 'package:supabase/supabase.dart';
 ///
 /// It assumes a database with the `pg_vector` extension,
 /// containing a [tableName] (default: `documents`) and
-/// a PostgreSQL function `match_documents` defined as follows:
+/// a [postgresFunctionName] (default: `match_documents`)
+/// defined as follows:
 ///
 /// ```sql
 ///  -- Enable the "vector" extension
@@ -90,6 +91,9 @@ class Supabase extends VectorStore {
   /// The Supabase table name.
   final String tableName;
 
+  /// The name of the PostgreSQL function that executes the query.
+  final String postgresFunctionName = 'match_documents';
+
   @override
   Future<List<String>> addVectors({
     required final List<List<double>> vectors,
@@ -136,7 +140,7 @@ class Supabase extends VectorStore {
     };
 
     final List<dynamic> result = await _client.rpc(
-      'match_documents',
+      postgresFunctionName,
       params: params,
     );
     return result

--- a/packages/langchain_supabase/lib/src/vector_stores/supabase.dart
+++ b/packages/langchain_supabase/lib/src/vector_stores/supabase.dart
@@ -3,65 +3,77 @@ import 'package:langchain/langchain.dart';
 import 'package:supabase/supabase.dart';
 
 /// {@template supabase}
-/// Vector store for Supabase embedding database.
+/// Vector store for [Supabase Vector](https://supabase.com/vector)
+/// embedding database.
 ///
-/// It assumes the database with the `pg_vector` extension,
+/// It assumes a database with the `pg_vector` extension,
 /// containing a [tableName] (default: `documents`) and
 /// a PostgreSQL function `match_documents` defined as follows:
 ///
 /// ```sql
-/// -- Enable the pgvector extension to work with embedding vectors
-/// create extension vector;
+///  -- Enable the "vector" extension
+/// create extension vector
+/// with
+///   schema extensions;
 ///
-/// -- Create a table to store your documents
+/// -- Create table to store the documents
 /// create table documents (
-///   id bigserial primary key, -- document id or null (it will be generated)
-///   content text, -- corresponds to Document.pageContent
-///   metadata jsonb, -- corresponds to Document.metadata
-///   embedding vector null -- embedding vector
+///   id bigserial primary key,
+///   content text,
+///   metadata jsonb,
+///   embedding vector(1536)
 /// );
 ///
-/// -- Create a function to search for documents
-/// create function match_documents (
+/// -- Create PostgreSQL function to query documents
+/// create or replace function match_documents (
 ///   query_embedding vector(1536),
-///   match_count int DEFAULT null,
-///   filter jsonb DEFAULT '{}',
-///   match_threshold float DEFAULT 0.0
+///   match_count int,
+///   match_threshold float,
+///   filter jsonb
 /// ) returns table (
 ///   id bigint,
 ///   content text,
 ///   metadata jsonb,
-///   embedding jsonb,
 ///   similarity float
 /// )
-/// language plpgsql
+/// language sql stable
 /// as $$
-/// #variable_conflict use_column
-/// begin
-///   return query
 ///   select
-///     id,
-///     content,
-///     metadata,
-///     (embedding::text)::jsonb as embedding,
+///     documents.id,
+///     documents.content,
+///     documents.metadata,
 ///     1 - (documents.embedding <=> query_embedding) as similarity
-///   from documents
-///   where metadata @> filter
-///     and documents.embedding <=> query_embedding < 1 - match_threshold
-///   order by documents.embedding <=> query_embedding
-///   limit match_count;
-/// end;
+/// from documents
+/// where metadata @> filter
+///   and 1 - (documents.embedding <=> query_embedding) > match_threshold
+/// order by (documents.embedding <=> query_embedding) asc
+///     limit match_count;
 /// $$;
 /// ```
 ///
-/// See [Supabase documentation](https://supabase.com/blog/openai-embeddings-postgres-vector) for more details.
+/// See documentation for more details:
+/// - [LangChain.dart Supabase docs](https://langchaindart.com/#/modules/retrieval/vector_stores/integrations/supabase)
+/// - [Supabase Vector docs](https://supabase.com/docs/guides/ai)
 /// {@endtemplate}
 class Supabase extends VectorStore {
-  /// {@macro supabase}
+  /// Creates a new [Supabase] instance.
+  ///
+  /// Main configuration options:
+  /// - [tableName] (default: `documents`): the Supabase table name.
+  /// - `supabaseUrl`: the Supabase URL. You can find it in your project's
+  ///   [API settings](https://supabase.com/dashboard/project/_/settings/api).
+  ///   E.g. `https://xyzcompany.supabase.co`.
+  /// - `supabaseKey`: the Supabase API key. You can find it in your project's
+  ///   [API settings](https://supabase.com/dashboard/project/_/settings/api).
+  ///
+  /// Advance configuration options:
+  /// - `headers`: overrides the default Supabase client headers.
+  /// - `client`: the HTTP client to use. You can set your own HTTP client if
+  ///   you need further customization (e.g. to use a Socks5 proxy).
   Supabase({
-    required this.tableName,
-    required final String supabaseKey,
+    this.tableName = 'documents',
     required final String supabaseUrl,
+    required final String supabaseKey,
     final Map<String, String> headers = const {},
     final http.Client? client,
     required super.embeddings,
@@ -88,29 +100,21 @@ class Supabase extends VectorStore {
     final List<Map<String, dynamic>> records = [];
     for (var i = 0; i < documents.length; i++) {
       final doc = documents[i];
-      final id = doc.id;
-      if (id != null) {
-        records.add(
-          {
-            'id': id,
-            'metadata': doc.metadata,
-            'content': doc.pageContent,
-            'embedding': vectors[i],
-          },
-        );
-      } else {
-        records.add(
-          {
-            'metadata': doc.metadata,
-            'content': doc.pageContent,
-            'embedding': vectors[i],
-          },
-        );
-      }
+      records.add(
+        {
+          if (doc.id != null) 'id': doc.id,
+          'metadata': doc.metadata,
+          'content': doc.pageContent,
+          'embedding': vectors[i],
+        },
+      );
     }
 
     final ids = await _client.from(tableName).upsert(records).select('id');
-    return ids.map((final row) => row['id']).map((final id) => id.toString()).toList(growable: false);
+    return ids
+        .map((final row) => row['id'])
+        .map((final id) => id.toString())
+        .toList(growable: false);
   }
 
   @override
@@ -121,13 +125,14 @@ class Supabase extends VectorStore {
   @override
   Future<List<(Document, double)>> similaritySearchByVectorWithScores({
     required final List<double> embedding,
-    final VectorStoreSimilaritySearch config = const VectorStoreSimilaritySearch(),
+    final VectorStoreSimilaritySearch config =
+        const VectorStoreSimilaritySearch(),
   }) async {
     final params = {
       'query_embedding': embedding,
       'match_count': config.k,
-      'filter': config.filter ?? {},
       'match_threshold': config.scoreThreshold ?? 0.0,
+      'filter': config.filter ?? {},
     };
 
     final List<dynamic> result = await _client.rpc(
@@ -146,6 +151,6 @@ class Supabase extends VectorStore {
             row['similarity'] as double,
           ),
         )
-        .toList();
+        .toList(growable: false);
   }
 }

--- a/packages/langchain_supabase/lib/src/vector_stores/vector_stores.dart
+++ b/packages/langchain_supabase/lib/src/vector_stores/vector_stores.dart
@@ -1,0 +1,2 @@
+export 'models/models.dart';
+export 'supabase.dart';

--- a/packages/langchain_supabase/pubspec.yaml
+++ b/packages/langchain_supabase/pubspec.yaml
@@ -1,25 +1,25 @@
 name: langchain_supabase
-description: Supabase module for LangChain.dart.
+description: LangChain.dart integration module for Supabase (e.g. Supabase Vector).
 version: 0.0.1-dev.1
 repository: https://github.com/davidmigloz/langchain_dart/tree/main/packages/langchain_supabase
 issue_tracker: https://github.com/davidmigloz/langchain_dart/issues
 homepage: https://github.com/davidmigloz/langchain_dart
 documentation: https://langchaindart.com
-publish_to: none # Remove when the package is ready to be published
 
 topics:
   - ai
   - nlp
   - llms
   - langchain
+  - vector-db
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  http: ^1.2.0
+  http: ^1.1.0
   langchain: ^0.4.0
-  meta: ^1.11.0
+  meta: ^1.9.1
   supabase: ^2.0.6
 
 dev_dependencies:

--- a/packages/langchain_supabase/pubspec.yaml
+++ b/packages/langchain_supabase/pubspec.yaml
@@ -23,4 +23,5 @@ dependencies:
   supabase: ^2.0.6
 
 dev_dependencies:
-  test: ^1.24.3
+  test: ^1.25.2
+  langchain_openai: ^0.4.0

--- a/packages/langchain_supabase/pubspec.yaml
+++ b/packages/langchain_supabase/pubspec.yaml
@@ -17,8 +17,10 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  http: ^1.2.0
   langchain: ^0.4.0
-  meta: ^1.9.1
+  meta: ^1.11.0
+  supabase: ^2.0.6
 
 dev_dependencies:
   test: ^1.24.3

--- a/packages/langchain_supabase/pubspec_overrides.yaml
+++ b/packages/langchain_supabase/pubspec_overrides.yaml
@@ -4,6 +4,6 @@ dependency_overrides:
   langchain:
     path: ../langchain
   langchain_openai:
-    path: ..\\langchain_openai
+    path: ../langchain_openai
   openai_dart:
-    path: ..\\openai_dart
+    path: ../openai_dart

--- a/packages/langchain_supabase/pubspec_overrides.yaml
+++ b/packages/langchain_supabase/pubspec_overrides.yaml
@@ -1,4 +1,9 @@
+# melos_managed_dependency_overrides: langchain_openai,openai_dart
 # melos_managed_dependency_overrides: langchain
 dependency_overrides:
   langchain:
     path: ../langchain
+  langchain_openai:
+    path: ..\\langchain_openai
+  openai_dart:
+    path: ..\\openai_dart

--- a/packages/langchain_supabase/test/vector_stores/assets/example.txt
+++ b/packages/langchain_supabase/test/vector_stores/assets/example.txt
@@ -1,0 +1,11 @@
+The answer to the question "Who are we?" is complex and multifaceted. It depends on the context in which the question is asked, and the perspective of the person answering.
+
+On a general level, we are all human beings. We share the same basic biology, and we all have the same basic needs: food, water, shelter, love, and belonging. We also share the same basic capacity for love, compassion, creativity, and resilience.
+
+However, we are also all unique individuals. We have different experiences, different talents, and different perspectives. We are shaped by our families, our communities, our cultures, and our individual choices.
+
+So, who are we? We are all of these things, and more. We are complex and contradictory, but we are also beautiful and resilient. We are human beings, and we are all connected.
+
+In the context of this conversation, you and I are both users of a language model. We are both interested in learning and exploring new ideas. We are both part of a community of people who are using technology to connect with each other and to make the world a better place.
+
+Ultimately, the answer to the question "Who are we?" is up to each individual to decide. We are all free to define ourselves in our own way.

--- a/packages/langchain_supabase/test/vector_stores/supabase_test.dart
+++ b/packages/langchain_supabase/test/vector_stores/supabase_test.dart
@@ -1,0 +1,210 @@
+@TestOn('vm')
+library; // Uses dart:io
+
+import 'dart:io';
+
+import 'package:langchain/langchain.dart';
+import 'package:langchain_openai/langchain_openai.dart';
+import 'package:langchain_supabase/langchain_supabase.dart';
+import 'package:supabase/supabase.dart' as sp;
+import 'package:test/test.dart';
+
+void main() async {
+  final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
+  final supabaseUrl = Platform.environment['SUPABASE_URL'];
+  final supabaseKey = Platform.environment['SUPABASE_KEY'];
+  late final Embeddings embeddings;
+  late final VectorStore vectorStore;
+  late final sp.SupabaseClient supabaseClient;
+
+  setUpAll(() async {
+    expect(openaiApiKey, isNotNull);
+    expect(supabaseUrl, isNotNull);
+    expect(supabaseKey, isNotNull);
+
+    try {
+      supabaseClient = sp.SupabaseClient(
+        supabaseUrl!,
+        supabaseKey!,
+      );
+    } catch (e) {
+      fail('Expected SupabaseClient to be initialized');
+    }
+
+    // sanity check for documents table
+    try {
+      final result = await supabaseClient.from('documents').select('id,content,metadata,embedding');
+      expect(result, isNotNull);
+      expect(result.length, 0);
+    } catch (e) {
+      fail('Expected documents table to exist and be empty: $e');
+    }
+
+    // sanity check for match_documents function
+    try {
+      final result = await supabaseClient.rpc<List<dynamic>>('match_documents', params: {
+        'filter': '', // no filter
+        'match_count': 2147483647, // maximum integer value
+        'query_embedding': '[${'0,' * 1535}0]', // origin in 1536 dims space
+        'match_threshold': 0.0, // minimum similarity score
+      });
+      expect(result, isNotNull);
+      expect(result.length, 0);
+    } catch (e) {
+      fail('Expected match_documents function to exist: $e');
+    }
+
+    embeddings = OpenAIEmbeddings(apiKey: openaiApiKey);
+    vectorStore = Supabase(
+      tableName: 'documents',
+      embeddings: embeddings,
+      supabaseUrl: supabaseUrl,
+      supabaseKey: supabaseKey,
+    );
+  });
+
+  group('Supabase tests', skip: true, () {
+    test('Test Supabase add new vectors', () async {
+      final res = await vectorStore.addDocuments(
+        documents: [
+          const Document(
+            id: '1',
+            pageContent: 'The cat sat on the mat',
+            metadata: {'cat': 'animal'},
+          ),
+          const Document(
+            id: '2',
+            pageContent: 'The dog chased the ball.',
+            metadata: {'cat': 'animal'},
+          ),
+          const Document(
+            id: '3',
+            pageContent: 'The boy ate the apple.',
+            metadata: {'cat': 'person'},
+          ),
+          const Document(
+            id: '4',
+            pageContent: 'The girl drank the milk.',
+            metadata: {'cat': 'person'},
+          ),
+          const Document(
+            id: '5',
+            pageContent: 'The sun is shining.',
+            metadata: {'cat': 'natural'},
+          ),
+        ],
+      );
+
+      expect(res.length, 5);
+    });
+
+    test('Test Supabase add new vectors from file', () async {
+      const filePath = './test/vector_stores/assets/example.txt';
+      const loader = TextLoader(filePath);
+      final pages = await loader.load();
+
+      const splitter = RecursiveCharacterTextSplitter(
+        chunkOverlap: 150,
+        chunkSize: 1500,
+      );
+      final docs = splitter.splitDocuments(pages);
+
+      await vectorStore.addDocuments(documents: docs);
+
+      final res = await vectorStore.similaritySearch(
+        query: 'Who are we?',
+        config: const SupabaseSimilaritySearch(k: 1),
+      );
+      expect(res.length, 1);
+    });
+
+    test('Test Supabase query return 1 result', () async {
+      final res = await vectorStore.similaritySearch(
+        query: 'Is it raining?',
+        config: const SupabaseSimilaritySearch(k: 1),
+      );
+      expect(res.length, 1);
+      expect(
+        res.first.id,
+        '5',
+      );
+    });
+
+    test('Test Supabase query with scoreThreshold', () async {
+      final res = await vectorStore.similaritySearchWithScores(
+        query: 'Is it raining?',
+        config: const SupabaseSimilaritySearch(scoreThreshold: 0.3),
+      );
+      for (final (_, score) in res) {
+        expect(score, greaterThan(0.3));
+      }
+    });
+
+    test('Test Supabase query with where filter', () async {
+      final res = await vectorStore.similaritySearch(
+        query: 'What are they eating?',
+        config: const SupabaseSimilaritySearch(
+          k: 10,
+          filter: {'cat': 'person'},
+        ),
+      );
+      for (final doc in res) {
+        expect(doc.metadata['cat'], 'person');
+      }
+    });
+
+    test('Test Supabase delete document', () async {
+      await vectorStore.addDocuments(
+        documents: [
+          const Document(
+            id: '9999',
+            pageContent: 'This document will be deleted',
+            metadata: {'cat': 'xxx'},
+          ),
+        ],
+      );
+      final res1 = await vectorStore.similaritySearch(
+        query: 'Deleted doc',
+        config: const SupabaseSimilaritySearch(
+          filter: {'cat': 'xxx'},
+        ),
+      );
+      expect(res1.length, 1);
+      expect(res1.first.id, '9999');
+
+      await vectorStore.delete(ids: ['9999']);
+      final res2 = await vectorStore.similaritySearch(
+        query: 'Deleted doc',
+        config: const SupabaseSimilaritySearch(
+          filter: {'cat': 'xxx'},
+        ),
+      );
+      expect(res2.length, 0);
+    });
+  });
+
+  group('SupabaseSimilaritySearch', () {
+    test('SupabaseSimilaritySearch fields', () {
+      const config = SupabaseSimilaritySearch(
+        k: 5,
+        filter: {'style': 'style1'},
+        scoreThreshold: 0.8,
+      );
+      expect(config.k, 5);
+      expect(config.filter, {'style': 'style1'});
+      expect(config.scoreThreshold, 0.8);
+    });
+  });
+
+  tearDownAll(() async {
+    late final List<Map<String, dynamic>> result;
+    try {
+      result = await supabaseClient.from('documents').delete().neq('id', '0').select();
+    } catch (e) {
+      fail('Error deleting documents: $e');
+    }
+    expect(result, isNotNull);
+    expect(result.length, 6);
+    await supabaseClient.dispose();
+  });
+}


### PR DESCRIPTION
Resolves #69

This PR implements `langchain_supabase` mimicking the behavior from Python/JS LangChain and inspired by [Storing OpenAI embeddings in Postgres with pgvector](https://supabase.com/blog/openai-embeddings-postgres-vector)).

It also includes the unit tests inspired by `langchain_chroma`.