### PR TITLE
feat: Add Ollama keep_alive param to control how long models stay loaded

### DIFF
--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
@@ -231,6 +231,7 @@ class ChatOllama extends BaseChatModel<ChatOllamaOptions> {
       model: options?.model ?? defaultOptions.model ?? throwNullModelError(),
       messages: messages.toMessages(),
       format: options?.format?.toResponseFormat(),
+      keepAlive: options?.keepAlive,
       stream: stream,
       options: RequestOptions(
         numKeep: options?.numKeep ?? defaultOptions.numKeep,

--- a/packages/langchain_ollama/lib/src/chat_models/models/models.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/models/models.dart
@@ -10,6 +10,7 @@ class ChatOllamaOptions extends ChatModelOptions {
   const ChatOllamaOptions({
     this.model = 'llama2',
     this.format,
+    this.keepAlive,
     this.numKeep,
     this.seed,
     this.numPredict,
@@ -57,6 +58,14 @@ class ChatOllamaOptions extends ChatModelOptions {
   /// Note: it's important to instruct the model to use JSON in the prompt.
   /// Otherwise, the model may generate large amounts whitespace.
   final OllamaResponseFormat? format;
+
+  /// How long (in minutes) to keep the model loaded in memory.
+  ///
+  /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+  /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+  /// - If set to 0, the model will be unloaded immediately once finished.
+  /// - If not set, the model will stay loaded for 5 minutes by default
+  final int? keepAlive;
 
   /// Number of tokens to keep from the prompt.
   /// (Default: 0)

--- a/packages/langchain_ollama/lib/src/llms/models/models.dart
+++ b/packages/langchain_ollama/lib/src/llms/models/models.dart
@@ -12,6 +12,7 @@ class OllamaOptions extends LLMOptions {
     this.context,
     this.format,
     this.raw,
+    this.keepAlive,
     this.numKeep,
     this.seed,
     this.numPredict,
@@ -79,6 +80,14 @@ class OllamaOptions extends LLMOptions {
   /// templated prompt in your request to the API, and are managing history
   /// yourself.
   final bool? raw;
+
+  /// How long (in minutes) to keep the model loaded in memory.
+  ///
+  /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+  /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+  /// - If set to 0, the model will be unloaded immediately once finished.
+  /// - If not set, the model will stay loaded for 5 minutes by default
+  final int? keepAlive;
 
   /// Number of tokens to keep from the prompt.
   /// (Default: 0)

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -223,6 +223,7 @@ class Ollama extends BaseLLM<OllamaOptions> {
       context: options?.context,
       format: options?.format?.toResponseFormat(),
       raw: options?.raw,
+      keepAlive: options?.keepAlive,
       stream: stream,
       options: RequestOptions(
         numKeep: options?.numKeep ?? defaultOptions.numKeep,

--- a/packages/ollama_dart/lib/src/generated/schema/generate_chat_completion_request.dart
+++ b/packages/ollama_dart/lib/src/generated/schema/generate_chat_completion_request.dart
@@ -39,6 +39,14 @@ class GenerateChatCompletionRequest with _$GenerateChatCompletionRequest {
 
     /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.
     @Default(false) bool stream,
+
+    /// How long (in minutes) to keep the model loaded in memory.
+    ///
+    /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+    /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+    /// - If set to 0, the model will be unloaded immediately once finished.
+    /// - If not set, the model will stay loaded for 5 minutes by default
+    @JsonKey(name: 'keep_alive', includeIfNull: false) int? keepAlive,
   }) = _GenerateChatCompletionRequest;
 
   /// Object construction from a JSON representation
@@ -51,7 +59,8 @@ class GenerateChatCompletionRequest with _$GenerateChatCompletionRequest {
     'messages',
     'format',
     'options',
-    'stream'
+    'stream',
+    'keep_alive'
   ];
 
   /// Perform validations on the schema property values
@@ -67,6 +76,7 @@ class GenerateChatCompletionRequest with _$GenerateChatCompletionRequest {
       'format': format,
       'options': options,
       'stream': stream,
+      'keep_alive': keepAlive,
     };
   }
 }

--- a/packages/ollama_dart/lib/src/generated/schema/generate_completion_request.dart
+++ b/packages/ollama_dart/lib/src/generated/schema/generate_completion_request.dart
@@ -56,6 +56,14 @@ class GenerateCompletionRequest with _$GenerateCompletionRequest {
 
     /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.
     @Default(false) bool stream,
+
+    /// How long (in minutes) to keep the model loaded in memory.
+    ///
+    /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+    /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+    /// - If set to 0, the model will be unloaded immediately once finished.
+    /// - If not set, the model will stay loaded for 5 minutes by default
+    @JsonKey(name: 'keep_alive', includeIfNull: false) int? keepAlive,
   }) = _GenerateCompletionRequest;
 
   /// Object construction from a JSON representation
@@ -73,7 +81,8 @@ class GenerateCompletionRequest with _$GenerateCompletionRequest {
     'options',
     'format',
     'raw',
-    'stream'
+    'stream',
+    'keep_alive'
   ];
 
   /// Perform validations on the schema property values
@@ -94,6 +103,7 @@ class GenerateCompletionRequest with _$GenerateCompletionRequest {
       'format': format,
       'raw': raw,
       'stream': stream,
+      'keep_alive': keepAlive,
     };
   }
 }

--- a/packages/ollama_dart/lib/src/generated/schema/schema.freezed.dart
+++ b/packages/ollama_dart/lib/src/generated/schema/schema.freezed.dart
@@ -67,6 +67,15 @@ mixin _$GenerateCompletionRequest {
   /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.
   bool get stream => throw _privateConstructorUsedError;
 
+  /// How long (in minutes) to keep the model loaded in memory.
+  ///
+  /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+  /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+  /// - If set to 0, the model will be unloaded immediately once finished.
+  /// - If not set, the model will stay loaded for 5 minutes by default
+  @JsonKey(name: 'keep_alive', includeIfNull: false)
+  int? get keepAlive => throw _privateConstructorUsedError;
+
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $GenerateCompletionRequestCopyWith<GenerateCompletionRequest> get copyWith =>
@@ -92,7 +101,8 @@ abstract class $GenerateCompletionRequestCopyWith<$Res> {
           unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
       ResponseFormat? format,
       @JsonKey(includeIfNull: false) bool? raw,
-      bool stream});
+      bool stream,
+      @JsonKey(name: 'keep_alive', includeIfNull: false) int? keepAlive});
 
   $RequestOptionsCopyWith<$Res>? get options;
 }
@@ -121,6 +131,7 @@ class _$GenerateCompletionRequestCopyWithImpl<$Res,
     Object? format = freezed,
     Object? raw = freezed,
     Object? stream = null,
+    Object? keepAlive = freezed,
   }) {
     return _then(_value.copyWith(
       model: null == model
@@ -163,6 +174,10 @@ class _$GenerateCompletionRequestCopyWithImpl<$Res,
           ? _value.stream
           : stream // ignore: cast_nullable_to_non_nullable
               as bool,
+      keepAlive: freezed == keepAlive
+          ? _value.keepAlive
+          : keepAlive // ignore: cast_nullable_to_non_nullable
+              as int?,
     ) as $Val);
   }
 
@@ -201,7 +216,8 @@ abstract class _$$GenerateCompletionRequestImplCopyWith<$Res>
           unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
       ResponseFormat? format,
       @JsonKey(includeIfNull: false) bool? raw,
-      bool stream});
+      bool stream,
+      @JsonKey(name: 'keep_alive', includeIfNull: false) int? keepAlive});
 
   @override
   $RequestOptionsCopyWith<$Res>? get options;
@@ -230,6 +246,7 @@ class __$$GenerateCompletionRequestImplCopyWithImpl<$Res>
     Object? format = freezed,
     Object? raw = freezed,
     Object? stream = null,
+    Object? keepAlive = freezed,
   }) {
     return _then(_$GenerateCompletionRequestImpl(
       model: null == model
@@ -272,6 +289,10 @@ class __$$GenerateCompletionRequestImplCopyWithImpl<$Res>
           ? _value.stream
           : stream // ignore: cast_nullable_to_non_nullable
               as bool,
+      keepAlive: freezed == keepAlive
+          ? _value.keepAlive
+          : keepAlive // ignore: cast_nullable_to_non_nullable
+              as int?,
     ));
   }
 }
@@ -292,7 +313,8 @@ class _$GenerateCompletionRequestImpl extends _GenerateCompletionRequest {
           unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
       this.format,
       @JsonKey(includeIfNull: false) this.raw,
-      this.stream = false})
+      this.stream = false,
+      @JsonKey(name: 'keep_alive', includeIfNull: false) this.keepAlive})
       : _images = images,
         _context = context,
         super._();
@@ -375,13 +397,23 @@ class _$GenerateCompletionRequestImpl extends _GenerateCompletionRequest {
   @JsonKey()
   final bool stream;
 
+  /// How long (in minutes) to keep the model loaded in memory.
+  ///
+  /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+  /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+  /// - If set to 0, the model will be unloaded immediately once finished.
+  /// - If not set, the model will stay loaded for 5 minutes by default
+  @override
+  @JsonKey(name: 'keep_alive', includeIfNull: false)
+  final int? keepAlive;
+
   @override
   String toString() {
-    return 'GenerateCompletionRequest(model: $model, prompt: $prompt, images: $images, system: $system, template: $template, context: $context, options: $options, format: $format, raw: $raw, stream: $stream)';
+    return 'GenerateCompletionRequest(model: $model, prompt: $prompt, images: $images, system: $system, template: $template, context: $context, options: $options, format: $format, raw: $raw, stream: $stream, keepAlive: $keepAlive)';
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$GenerateCompletionRequestImpl &&
@@ -395,7 +427,9 @@ class _$GenerateCompletionRequestImpl extends _GenerateCompletionRequest {
             (identical(other.options, options) || other.options == options) &&
             (identical(other.format, format) || other.format == format) &&
             (identical(other.raw, raw) || other.raw == raw) &&
-            (identical(other.stream, stream) || other.stream == stream));
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.keepAlive, keepAlive) ||
+                other.keepAlive == keepAlive));
   }
 
   @JsonKey(ignore: true)
@@ -411,7 +445,8 @@ class _$GenerateCompletionRequestImpl extends _GenerateCompletionRequest {
       options,
       format,
       raw,
-      stream);
+      stream,
+      keepAlive);
 
   @JsonKey(ignore: true)
   @override
@@ -442,7 +477,9 @@ abstract class _GenerateCompletionRequest extends GenerateCompletionRequest {
           unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
       final ResponseFormat? format,
       @JsonKey(includeIfNull: false) final bool? raw,
-      final bool stream}) = _$GenerateCompletionRequestImpl;
+      final bool stream,
+      @JsonKey(name: 'keep_alive', includeIfNull: false)
+      final int? keepAlive}) = _$GenerateCompletionRequestImpl;
   const _GenerateCompletionRequest._() : super._();
 
   factory _GenerateCompletionRequest.fromJson(Map<String, dynamic> json) =
@@ -504,6 +541,16 @@ abstract class _GenerateCompletionRequest extends GenerateCompletionRequest {
 
   /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.
   bool get stream;
+  @override
+
+  /// How long (in minutes) to keep the model loaded in memory.
+  ///
+  /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+  /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+  /// - If set to 0, the model will be unloaded immediately once finished.
+  /// - If not set, the model will stay loaded for 5 minutes by default
+  @JsonKey(name: 'keep_alive', includeIfNull: false)
+  int? get keepAlive;
   @override
   @JsonKey(ignore: true)
   _$$GenerateCompletionRequestImplCopyWith<_$GenerateCompletionRequestImpl>
@@ -1348,7 +1395,7 @@ class _$RequestOptionsImpl extends _RequestOptions {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RequestOptionsImpl &&
@@ -2034,7 +2081,7 @@ class _$GenerateCompletionResponseImpl extends _GenerateCompletionResponse {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$GenerateCompletionResponseImpl &&
@@ -2208,6 +2255,15 @@ mixin _$GenerateChatCompletionRequest {
   /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.
   bool get stream => throw _privateConstructorUsedError;
 
+  /// How long (in minutes) to keep the model loaded in memory.
+  ///
+  /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+  /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+  /// - If set to 0, the model will be unloaded immediately once finished.
+  /// - If not set, the model will stay loaded for 5 minutes by default
+  @JsonKey(name: 'keep_alive', includeIfNull: false)
+  int? get keepAlive => throw _privateConstructorUsedError;
+
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $GenerateChatCompletionRequestCopyWith<GenerateChatCompletionRequest>
@@ -2230,7 +2286,8 @@ abstract class $GenerateChatCompletionRequestCopyWith<$Res> {
           unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
       ResponseFormat? format,
       @JsonKey(includeIfNull: false) RequestOptions? options,
-      bool stream});
+      bool stream,
+      @JsonKey(name: 'keep_alive', includeIfNull: false) int? keepAlive});
 
   $RequestOptionsCopyWith<$Res>? get options;
 }
@@ -2254,6 +2311,7 @@ class _$GenerateChatCompletionRequestCopyWithImpl<$Res,
     Object? format = freezed,
     Object? options = freezed,
     Object? stream = null,
+    Object? keepAlive = freezed,
   }) {
     return _then(_value.copyWith(
       model: null == model
@@ -2276,6 +2334,10 @@ class _$GenerateChatCompletionRequestCopyWithImpl<$Res,
           ? _value.stream
           : stream // ignore: cast_nullable_to_non_nullable
               as bool,
+      keepAlive: freezed == keepAlive
+          ? _value.keepAlive
+          : keepAlive // ignore: cast_nullable_to_non_nullable
+              as int?,
     ) as $Val);
   }
 
@@ -2309,7 +2371,8 @@ abstract class _$$GenerateChatCompletionRequestImplCopyWith<$Res>
           unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
       ResponseFormat? format,
       @JsonKey(includeIfNull: false) RequestOptions? options,
-      bool stream});
+      bool stream,
+      @JsonKey(name: 'keep_alive', includeIfNull: false) int? keepAlive});
 
   @override
   $RequestOptionsCopyWith<$Res>? get options;
@@ -2333,6 +2396,7 @@ class __$$GenerateChatCompletionRequestImplCopyWithImpl<$Res>
     Object? format = freezed,
     Object? options = freezed,
     Object? stream = null,
+    Object? keepAlive = freezed,
   }) {
     return _then(_$GenerateChatCompletionRequestImpl(
       model: null == model
@@ -2355,6 +2419,10 @@ class __$$GenerateChatCompletionRequestImplCopyWithImpl<$Res>
           ? _value.stream
           : stream // ignore: cast_nullable_to_non_nullable
               as bool,
+      keepAlive: freezed == keepAlive
+          ? _value.keepAlive
+          : keepAlive // ignore: cast_nullable_to_non_nullable
+              as int?,
     ));
   }
 }
@@ -2371,7 +2439,8 @@ class _$GenerateChatCompletionRequestImpl
           unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
       this.format,
       @JsonKey(includeIfNull: false) this.options,
-      this.stream = false})
+      this.stream = false,
+      @JsonKey(name: 'keep_alive', includeIfNull: false) this.keepAlive})
       : _messages = messages,
         super._();
 
@@ -2416,13 +2485,23 @@ class _$GenerateChatCompletionRequestImpl
   @JsonKey()
   final bool stream;
 
+  /// How long (in minutes) to keep the model loaded in memory.
+  ///
+  /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+  /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+  /// - If set to 0, the model will be unloaded immediately once finished.
+  /// - If not set, the model will stay loaded for 5 minutes by default
+  @override
+  @JsonKey(name: 'keep_alive', includeIfNull: false)
+  final int? keepAlive;
+
   @override
   String toString() {
-    return 'GenerateChatCompletionRequest(model: $model, messages: $messages, format: $format, options: $options, stream: $stream)';
+    return 'GenerateChatCompletionRequest(model: $model, messages: $messages, format: $format, options: $options, stream: $stream, keepAlive: $keepAlive)';
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$GenerateChatCompletionRequestImpl &&
@@ -2430,13 +2509,21 @@ class _$GenerateChatCompletionRequestImpl
             const DeepCollectionEquality().equals(other._messages, _messages) &&
             (identical(other.format, format) || other.format == format) &&
             (identical(other.options, options) || other.options == options) &&
-            (identical(other.stream, stream) || other.stream == stream));
+            (identical(other.stream, stream) || other.stream == stream) &&
+            (identical(other.keepAlive, keepAlive) ||
+                other.keepAlive == keepAlive));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, model,
-      const DeepCollectionEquality().hash(_messages), format, options, stream);
+  int get hashCode => Object.hash(
+      runtimeType,
+      model,
+      const DeepCollectionEquality().hash(_messages),
+      format,
+      options,
+      stream,
+      keepAlive);
 
   @JsonKey(ignore: true)
   @override
@@ -2464,7 +2551,9 @@ abstract class _GenerateChatCompletionRequest
           unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
       final ResponseFormat? format,
       @JsonKey(includeIfNull: false) final RequestOptions? options,
-      final bool stream}) = _$GenerateChatCompletionRequestImpl;
+      final bool stream,
+      @JsonKey(name: 'keep_alive', includeIfNull: false)
+      final int? keepAlive}) = _$GenerateChatCompletionRequestImpl;
   const _GenerateChatCompletionRequest._() : super._();
 
   factory _GenerateChatCompletionRequest.fromJson(Map<String, dynamic> json) =
@@ -2499,6 +2588,16 @@ abstract class _GenerateChatCompletionRequest
 
   /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.
   bool get stream;
+  @override
+
+  /// How long (in minutes) to keep the model loaded in memory.
+  ///
+  /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+  /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+  /// - If set to 0, the model will be unloaded immediately once finished.
+  /// - If not set, the model will stay loaded for 5 minutes by default
+  @JsonKey(name: 'keep_alive', includeIfNull: false)
+  int? get keepAlive;
   @override
   @JsonKey(ignore: true)
   _$$GenerateChatCompletionRequestImplCopyWith<
@@ -2845,7 +2944,7 @@ class _$GenerateChatCompletionResponseImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$GenerateChatCompletionResponseImpl &&
@@ -3134,7 +3233,7 @@ class _$MessageImpl extends _Message {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$MessageImpl &&
@@ -3362,7 +3461,7 @@ class _$GenerateEmbeddingRequestImpl extends _GenerateEmbeddingRequest {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$GenerateEmbeddingRequestImpl &&
@@ -3540,7 +3639,7 @@ class _$GenerateEmbeddingResponseImpl extends _GenerateEmbeddingResponse {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$GenerateEmbeddingResponseImpl &&
@@ -3728,7 +3827,7 @@ class _$CreateModelRequestImpl extends _CreateModelRequest {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$CreateModelRequestImpl &&
@@ -3903,7 +4002,7 @@ class _$CreateModelResponseImpl extends _CreateModelResponse {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$CreateModelResponseImpl &&
@@ -4065,7 +4164,7 @@ class _$ModelsResponseImpl extends _ModelsResponse {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ModelsResponseImpl &&
@@ -4262,7 +4361,7 @@ class _$ModelImpl extends _Model {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ModelImpl &&
@@ -4426,7 +4525,7 @@ class _$ModelInfoRequestImpl extends _ModelInfoRequest {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ModelInfoRequestImpl &&
@@ -4642,7 +4741,7 @@ class _$ModelInfoImpl extends _ModelInfo {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ModelInfoImpl &&
@@ -4829,7 +4928,7 @@ class _$CopyModelRequestImpl extends _CopyModelRequest {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$CopyModelRequestImpl &&
@@ -4983,7 +5082,7 @@ class _$DeleteModelRequestImpl extends _DeleteModelRequest {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$DeleteModelRequestImpl &&
@@ -5174,7 +5273,7 @@ class _$PullModelRequestImpl extends _PullModelRequest {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PullModelRequestImpl &&
@@ -5417,7 +5516,7 @@ class _$PullModelResponseImpl extends _PullModelResponse {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PullModelResponseImpl &&
@@ -5631,7 +5730,7 @@ class _$PushModelRequestImpl extends _PushModelRequest {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PushModelRequestImpl &&
@@ -5850,7 +5949,7 @@ class _$PushModelResponseImpl extends _PushModelResponse {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PushModelResponseImpl &&

--- a/packages/ollama_dart/lib/src/generated/schema/schema.g.dart
+++ b/packages/ollama_dart/lib/src/generated/schema/schema.g.dart
@@ -26,6 +26,7 @@ _$GenerateCompletionRequestImpl _$$GenerateCompletionRequestImplFromJson(
           unknownValue: JsonKey.nullForUndefinedEnumValue),
       raw: json['raw'] as bool?,
       stream: json['stream'] as bool? ?? false,
+      keepAlive: json['keep_alive'] as int?,
     );
 
 Map<String, dynamic> _$$GenerateCompletionRequestImplToJson(
@@ -49,6 +50,7 @@ Map<String, dynamic> _$$GenerateCompletionRequestImplToJson(
   writeNotNull('format', _$ResponseFormatEnumMap[instance.format]);
   writeNotNull('raw', instance.raw);
   val['stream'] = instance.stream;
+  writeNotNull('keep_alive', instance.keepAlive);
   return val;
 }
 
@@ -194,6 +196,7 @@ _$GenerateChatCompletionRequestImpl
               : RequestOptions.fromJson(
                   json['options'] as Map<String, dynamic>),
           stream: json['stream'] as bool? ?? false,
+          keepAlive: json['keep_alive'] as int?,
         );
 
 Map<String, dynamic> _$$GenerateChatCompletionRequestImplToJson(
@@ -212,6 +215,7 @@ Map<String, dynamic> _$$GenerateChatCompletionRequestImplToJson(
   writeNotNull('format', _$ResponseFormatEnumMap[instance.format]);
   writeNotNull('options', instance.options?.toJson());
   val['stream'] = instance.stream;
+  writeNotNull('keep_alive', instance.keepAlive);
   return val;
 }
 

--- a/packages/ollama_dart/oas/ollama-curated.yaml
+++ b/packages/ollama_dart/oas/ollama-curated.yaml
@@ -285,6 +285,15 @@ components:
           description: &stream |
             If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.
           default: false
+        keep_alive:
+          type: integer
+          description: &keep_alive |
+            How long (in minutes) to keep the model loaded in memory.
+            
+            - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
+            - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
+            - If set to 0, the model will be unloaded immediately once finished.
+            - If not set, the model will stay loaded for 5 minutes by default
       required:
         - model
         - prompt
@@ -519,6 +528,9 @@ components:
           type: boolean
           description: *stream
           default: false
+        keep_alive:
+          type: integer
+          description: *keep_alive
       required:
         - model
         - messages

--- a/packages/ollama_dart/pubspec.yaml
+++ b/packages/ollama_dart/pubspec.yaml
@@ -30,5 +30,5 @@ dev_dependencies:
   openapi_spec:
     git:
       url: https://github.com/davidmigloz/openapi_spec.git
-      ref: 52bd544753980267da6d4b299cbf1067a0d07131
+      ref: e14c0adaac69e9482e9b57f68fc7964032cdd44c
   test: ^1.24.3

--- a/packages/ollama_dart/test/ollama_dart_chat_test.dart
+++ b/packages/ollama_dart/test/ollama_dart_chat_test.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:ollama_dart/ollama_dart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Ollama Generate Completions API tests', skip: true, () {
+  group('Ollama Generate Completions API tests',
+      skip: Platform.environment.containsKey('CI'), () {
     late OllamaClient client;
     const defaultModel = 'llama2:latest';
     const visionModel = 'llava:latest';
@@ -39,6 +42,7 @@ void main() {
               content: 'Hello!',
             ),
           ],
+          keepAlive: 1,
         ),
       );
       expect(response.model, defaultModel);

--- a/packages/ollama_dart/test/ollama_dart_completions_test.dart
+++ b/packages/ollama_dart/test/ollama_dart_completions_test.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:ollama_dart/ollama_dart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Ollama Generate Completions API tests', skip: true, () {
+  group('Ollama Generate Completions API tests',
+      skip: Platform.environment.containsKey('CI'), () {
     late OllamaClient client;
     const defaultModel = 'llama2:latest';
     const visionModel = 'llava:latest';
@@ -35,6 +38,7 @@ void main() {
         request: const GenerateCompletionRequest(
           model: defaultModel,
           prompt: testPrompt,
+          keepAlive: 1,
         ),
       );
       expect(response.model, defaultModel);

--- a/packages/ollama_dart/test/ollama_dart_embeddings_test.dart
+++ b/packages/ollama_dart/test/ollama_dart_embeddings_test.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:ollama_dart/ollama_dart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Ollama Generate Embeddings API tests', skip: true, () {
+  group('Ollama Generate Embeddings API tests',
+      skip: Platform.environment.containsKey('CI'), () {
     late OllamaClient client;
     const defaultModel = 'llama2:latest';
 

--- a/packages/ollama_dart/test/ollama_dart_models_test.dart
+++ b/packages/ollama_dart/test/ollama_dart_models_test.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:ollama_dart/ollama_dart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Ollama Models API tests', skip: true, () {
+  group('Ollama Models API tests', skip: Platform.environment.containsKey('CI'),
+      () {
     late OllamaClient client;
     const defaultModel = 'llama2:latest';
 


### PR DESCRIPTION
https://github.com/ollama/ollama/releases/tag/v0.1.23

> `keepAlive`: How long (in minutes) to keep the model loaded in memory.
> - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.
> - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.
> - If set to 0, the model will be unloaded immediately once finished.
> - If not set, the model will stay loaded for 5 minutes by default
