### PR TITLE
refactor!: Remove deprecated generate and predict APIs

### DIFF
--- a/docs/modules/model_io/model_io.md
+++ b/docs/modules/model_io/model_io.md
@@ -1,7 +1,6 @@
 # Model I/O
 
-The core element of any language model application is... the model. LangChain 
-gives you the building blocks to interface with any language model.
+The core element of any language model application is...the model. LangChain gives you the building blocks to interface with any language model.
 
 - [Prompts](/modules/model_io/prompts/prompts.md): templatize, dynamically 
   select, and manage model inputs.

--- a/docs/modules/model_io/models/chat_models/chat_models.md
+++ b/docs/modules/model_io/models/chat_models/chat_models.md
@@ -31,7 +31,7 @@ import 'package:langchain_openai/langchain_openai.dart';
 
 We can then instantiate the chat model:
 ```dart
-final chat = final chat = ChatOpenAI(
+final chatModel = final chat = ChatOpenAI(
   apiKey: openaiApiKey,
   defaultOptions: const ChatOpenAIOptions(
     temperature: 0,
@@ -48,10 +48,9 @@ types of messages currently supported in LangChain are `AIChatMessage`,
 you’ll just be dealing with `HumanChatMessage`, `AIChatMessage`, and 
 `SystemChatMessage`.
 
-### `call`: messages in -> message out
+### LCEL
 
-You can get chat completions by passing one or more messages to the chat model. 
-The response will be a message.
+LLMs implement the `Runnable` interface, the basic building block of the LangChain Expression Language (LCEL). This means they support `invoke`, `stream`, and `batch` calls.
 
 ```dart
 final messages = [
@@ -59,27 +58,29 @@ final messages = [
     'Translate this sentence from English to French. I love programming.',
   ),
 ];
-final chatRes = await chat(messages);
-// -> AIChatMessage{content: J'aime programmer., example: false}
+final prompt = PromptValue.chat(messages);
+final chatRes = await chatModel.invoke(prompt);
+// -> [ChatGeneration{
+//       output: AIChatMessage{content: J'adore la programmation., example: false},
+//       generationInfo: {index: 0, finish_reason: stop}}]
 ```
 
-OpenAI’s chat model supports multiple messages as input.
-See [here](https://platform.openai.com/docs/guides/gpt/chat-completions-vs-completions) for more
-information. Here is an example of sending a system and user message to the chat model:
+OpenAI’s chat model supports multiple messages as input. See [here](https://platform.openai.com/docs/guides/gpt/chat-completions-vs-completions) for more information. Here is an example of sending a system and user message to the chat model:
 
 ```dart
 final messages = [
   ChatMessage.system('You are a helpful assistant that translates English to French.'),
   ChatMessage.humanText('I love programming.')
 ];
-final chatRes = await chat(messages);
+final prompt = PromptValue.chat(messages);
+final chatRes = await chatModel.invoke(prompt);
 print(chatRes);
-// -> AIChatMessage{content: J'adore la programmation., example: false}
+// -> [ChatGeneration{
+//       output: AIChatMessage{content: J'adore la programmation., example: false},
+//       generationInfo: {index: 0, finish_reason: stop}}]
 ```
 
-### `generate`: richer outputs
-
-The `generate` APIs return an `ChatResult` which contains a `ChatGeneration`
+The `invoke` API return an `ChatResult` which contains a `ChatGeneration`
 object with the `output` messages and some metadata about the generation. It 
 also contains some additional information like `usage` and `modelOutput`.
 
@@ -93,13 +94,4 @@ print(chatRes1.usage?.totalTokens);
 // -> 36
 print(chatRes1.modelOutput);
 // -> {id: chatcmpl-7QHTjpTCELFuGbxRaazFqvYtepXOc, created: 2023-06-11 17:41:11.000, model: gpt-3.5-turbo}
-```
-
-### `generatePrompt`: generate from a `PromptValue`
-
-```dart
-final chatRes2 = await chat.generatePrompt(ChatPromptValue(messages));
-print(chatRes2.generations);
-print(chatRes2.usage);
-print(chatRes2.modelOutput);
 ```

--- a/docs/modules/model_io/models/chat_models/how_to/llm_chain.md
+++ b/docs/modules/model_io/models/chat_models/how_to/llm_chain.md
@@ -1,5 +1,7 @@
 # LLMChain
 
+> DEPRECATED: `LLMChain` is deprecated in favour of LangChain Expression Language (LCEL).
+
 You can use the existing `LLMChain` in a very similar way as 
 [with LLMs](/modules/chains/chains?id=get-started) - provide a prompt and a 
 model.

--- a/docs/modules/model_io/models/chat_models/how_to/streaming.md
+++ b/docs/modules/model_io/models/chat_models/how_to/streaming.md
@@ -2,9 +2,6 @@
 
 Some chat models provide a streaming response. This means that instead of waiting for the entire response to be returned, you can start processing it as soon as it's available. This is useful if you want to display the response to the user as it's being generated, or if you want to process the response as it's being generated.
 
-Currently, it is supported for the following chat models:
-- `ChatOpenAI`
-
 Example usage:
 
 ```dart

--- a/docs/modules/model_io/models/llms/how_to/llm_streaming.md
+++ b/docs/modules/model_io/models/llms/how_to/llm_streaming.md
@@ -2,9 +2,6 @@
 
 Some LLMs provide a streaming response. This means that instead of waiting for the entire response to be returned, you can start processing it as soon as it's available. This is useful if you want to display the response to the user as it's being generated, or if you want to process the response as it's being generated.
 
-Currently, it is supported for the following LLMs:
-- `OpenAI`
-
 Example usage:
 
 ```dart

--- a/docs/modules/model_io/models/llms/how_to/token_usage_tracking.md
+++ b/docs/modules/model_io/models/llms/how_to/token_usage_tracking.md
@@ -8,7 +8,8 @@ final openai = OpenAI(
   apiKey: openaiApiKey,
   defaultOptions: const OpenAIOptions(temperature: 0.9),
 );
-final result = await openai.generate('Tell me a joke');
+final prompt = PromptValue.string('Tell me a joke');
+final result = await llm.invoke(prompt);
 final usage = result.usage;
 print(usage?.promptTokens);   // 4
 print(usage?.responseTokens); // 20

--- a/docs/modules/model_io/models/llms/llms.md
+++ b/docs/modules/model_io/models/llms/llms.md
@@ -49,33 +49,20 @@ import 'package:langchain_openai/langchain_openai.dart';
 final llm = OpenAI(apiKey: openaiApiKey);
 ```
 
-### `call`: string in -> string out
+### LCEL
 
-The simplest way to use an LLM is a callable: pass in a string, get a string 
-completion.
+LLMs implement the `Runnable` interface, the basic building block of the LangChain Expression Language (LCEL). This means they support `invoke`, `stream`, and `batch` calls.
 
 ```dart
-final llmRes = await llm('Tell me a joke');
-print(llmRes); // '\n\nWhy did the chicken cross the road?\n\nTo get to the other side.'
+final prompt = PromptValue.string('Tell me a joke');
+final result = await llm.invoke(prompt);
+// LLMGeneration(output='\n\nWhy did the chicken cross the road?\n\nTo get to the other side!')
 ```
 
-### `generate`: batch calls, richer outputs
-
-`generate` lets you can call the model with a list of strings, getting back a 
-more complete response than just the text. This complete response can include 
-things like multiple top responses and other LLM provider-specific information:
+The response is a `LLMGeneration` object, which contains the output of the model, as well as other useful information like the amount of tokens used for the generation.
 
 ```dart
-final llmRes = await llm.generate('Tell me a joke');
-print(llmRes.generations.first);
-// [LLMGeneration(output='\n\nWhy did the chicken cross the road?\n\nTo get to the other side!')]
-```
-
-`usage` field contains the amount of tokens used for the generation. This is useful for
-tracking usage and billing.
-
-```dart
-print(llmRes.usage?.totalUsage); // 641
+print(result.usage?.totalUsage); // 641
 ```
 
 You can also access provider specific information that is returned.
@@ -88,10 +75,4 @@ print(llmRes.modelOutput);
 //   created: 2023-06-09 18:30:40.000,
 //   model: text-ada-001
 // }
-```
-
-### `generatePrompt`: generate from a `PromptValue`
-
-```dart
-final llmRes = await llm.generatePrompt(const StringPromptValue('Tell me a joke.'));
 ```

--- a/examples/docs_examples/bin/expression_language/get_started.dart
+++ b/examples/docs_examples/bin/expression_language/get_started.dart
@@ -2,7 +2,6 @@
 import 'dart:io';
 
 import 'package:langchain/langchain.dart';
-import 'package:langchain_chroma/langchain_chroma.dart';
 import 'package:langchain_openai/langchain_openai.dart';
 
 void main(final List<String> arguments) async {
@@ -76,7 +75,8 @@ Future<void> _ragSearch() async {
     documents: [
       const Document(pageContent: 'LangChain was created by Harrison'),
       const Document(
-          pageContent: 'David ported LangChain to Dart in LangChain.dart'),
+        pageContent: 'David ported LangChain to Dart in LangChain.dart',
+      ),
     ],
   );
 

--- a/packages/langchain/lib/src/chains/llm_chain.dart
+++ b/packages/langchain/lib/src/chains/llm_chain.dart
@@ -79,7 +79,7 @@ class LLMChain<
   Future<ChainValues> callInternal(final ChainValues inputs) async {
     final promptValue = prompt.formatPrompt(inputs);
 
-    final response = await llm.generatePrompt(promptValue, options: llmOptions);
+    final response = await llm.invoke(promptValue, options: llmOptions);
 
     final res = outputParser == null
         ? response.generations.firstOrNull?.output

--- a/packages/langchain/lib/src/model_io/chat_models/base.dart
+++ b/packages/langchain/lib/src/model_io/chat_models/base.dart
@@ -28,45 +28,9 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
   Future<ChatResult> invoke(
     final PromptValue input, {
     final Options? options,
-  }) async {
-    return generatePrompt(input, options: options);
-  }
-
-  /// Runs the chat model on the given messages.
-  ///
-  /// - [messages] The messages to pass into the model.
-  /// - [options] Generation options to pass into the Chat Model.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await chat.generate([ChatMessage.humanText('say hi!')]);
-  /// ```
-  @override
-  Future<ChatResult> generate(
-    final List<ChatMessage> messages, {
-    final Options? options,
   });
 
-  /// Runs the chat model on the given prompt value.
-  ///
-  /// - [promptValue] The prompt value to pass into the model.
-  /// - [options] Generation options to pass into the Chat Model.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await chat.generatePrompt(
-  ///   PromptValue.chat([ChatMessage.humanText('say hi!')]),
-  /// );
-  /// ```
-  @override
-  Future<ChatResult> generatePrompt(
-    final PromptValue promptValue, {
-    final Options? options,
-  }) {
-    return generate(promptValue.toChatMessages(), options: options);
-  }
-
-  /// Runs the chat model on the given messages.
+  /// Runs the chat model on the given messages and returns a chat message.
   ///
   /// - [messages] The messages to pass into the model.
   /// - [options] Generation options to pass into the Chat Model.
@@ -80,47 +44,8 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
     final List<ChatMessage> messages, {
     final Options? options,
   }) async {
-    final result = await generate(messages, options: options);
+    final result = await invoke(PromptValue.chat(messages), options: options);
     return result.generations[0].output;
-  }
-
-  /// Runs the chat model on the given text as a human message and returns the
-  /// content of the AI message.
-  ///
-  /// - [text] The text to pass into the model.
-  /// - [options] Generation options to pass into the Chat Model.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await predict('say hi!');
-  /// ```
-  @override
-  Future<String> predict(
-    final String text, {
-    final Options? options,
-  }) async {
-    final res = await call(
-      [ChatMessage.humanText(text)],
-      options: options,
-    );
-    return res.content;
-  }
-
-  /// Runs the chat model on the given messages (same as [call] method).
-  ///
-  /// - [messages] The messages to pass into the model.
-  /// - [options] Generation options to pass into the Chat Model.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await chat.predictMessages([ChatMessage.humanText('say hi!')]);
-  /// );
-  @override
-  Future<ChatMessage> predictMessages(
-    final List<ChatMessage> messages, {
-    final Options? options,
-  }) async {
-    return call(messages, options: options);
   }
 }
 
@@ -135,11 +60,11 @@ abstract class SimpleChatModel<Options extends ChatModelOptions>
   const SimpleChatModel();
 
   @override
-  Future<ChatResult> generate(
-    final List<ChatMessage> messages, {
+  Future<ChatResult> invoke(
+    final PromptValue input, {
     final Options? options,
   }) async {
-    final text = await callInternal(messages, options: options);
+    final text = await callInternal(input.toChatMessages(), options: options);
     final message = AIChatMessage(content: text);
     return ChatResult(
       generations: [ChatGeneration(message)],

--- a/packages/langchain/lib/src/model_io/language_models/base.dart
+++ b/packages/langchain/lib/src/model_io/language_models/base.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../../core/core.dart';
-import '../chat_models/models/models.dart';
 import '../prompts/models/models.dart';
 import 'models/models.dart';
 
@@ -22,33 +21,22 @@ abstract class BaseLanguageModel<Input extends Object,
   /// Return type of language model.
   String get modelType;
 
-  /// Runs the language model on the given input.
-  Future<LanguageModelResult<Output>> generate(
-    final Input input, {
-    final Options? options,
-  });
-
-  /// Runs the language model on the given prompt value.
-  Future<LanguageModelResult<Output>> generatePrompt(
-    final PromptValue promptValue, {
+  /// Runs the Language Model on the given prompt value.
+  ///
+  /// - [input] The prompt value to pass into the model.
+  /// - [options] Generation options to pass into the model.
+  @override
+  Future<LanguageModelResult<Output>> invoke(
+    final PromptValue input, {
     final Options? options,
   });
 
   /// Runs the language model on the given input.
+  ///
+  /// - [input] The prompt to pass into the model.
+  /// - [options] Generation options to pass into the model.
   Future<Output> call(
     final Input input, {
-    final Options? options,
-  });
-
-  /// Predicts text from text.
-  Future<String> predict(
-    final String text, {
-    final Options? options,
-  });
-
-  /// Predicts a chat message from chat messages.
-  Future<ChatMessage> predictMessages(
-    final List<ChatMessage> messages, {
     final Options? options,
   });
 

--- a/packages/langchain/lib/src/model_io/llms/base.dart
+++ b/packages/langchain/lib/src/model_io/llms/base.dart
@@ -1,14 +1,13 @@
 import 'package:meta/meta.dart';
 
-import '../chat_models/models/models.dart';
-import '../chat_models/utils.dart';
 import '../language_models/language_models.dart';
 import '../prompts/models/models.dart';
 import 'models/models.dart';
 
 /// {@template base_llm}
 /// Large Language Models base class.
-/// It should take in a prompt and return a string.
+///
+/// LLMs take in a String and returns a String.
 /// {@endtemplate}
 abstract class BaseLLM<Options extends LLMOptions>
     extends BaseLanguageModel<String, Options, String> {
@@ -27,48 +26,13 @@ abstract class BaseLLM<Options extends LLMOptions>
   /// );
   /// ```
   @override
-  Future<LanguageModelResult<String>> invoke(
+  Future<LLMResult> invoke(
     final PromptValue input, {
-    final Options? options,
-  }) async {
-    return generatePrompt(input, options: options);
-  }
-
-  /// Runs the LLM on the given prompt.
-  ///
-  /// - [prompt] The prompt to pass into the model.
-  /// - [options] Generation options to pass into the LLM.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await openai.generate('Tell me a joke.');
-  /// ```
-  @override
-  Future<LLMResult> generate(
-    final String prompt, {
     final Options? options,
   });
 
-  /// Runs the LLM on the given prompt value.
-  ///
-  /// - [promptValue] The prompt value to pass into the model.
-  /// - [options] Generation options to pass into the LLM.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await openai.generatePrompt(
-  ///   PromptValue.string('Tell me a joke.'),
-  /// );
-  /// ```
-  @override
-  Future<LLMResult> generatePrompt(
-    final PromptValue promptValue, {
-    final Options? options,
-  }) {
-    return generate(promptValue.toString(), options: options);
-  }
-
-  /// Runs the LLM on the given prompt.
+  /// Runs the LLM on the given String prompt and returns a String with the
+  /// generated text.
   ///
   /// - [prompt] The prompt to pass into the model.
   /// - [options] Generation options to pass into the LLM.
@@ -82,51 +46,8 @@ abstract class BaseLLM<Options extends LLMOptions>
     final String prompt, {
     final Options? options,
   }) async {
-    final result = await generate(prompt, options: options);
+    final result = await invoke(PromptValue.string(prompt), options: options);
     return result.firstOutputAsString;
-  }
-
-  /// Runs the LLM on the given prompt value (same as [call] method).
-  ///
-  /// - [text] The prompt value to pass into the model.
-  /// - [options] Generation options to pass into the LLM.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await openai.predict('Tell me a joke.');
-  /// ```
-  @override
-  Future<String> predict(
-    final String text, {
-    final Options? options,
-  }) {
-    return call(text, options: options);
-  }
-
-  /// Runs the LLM on the given messages. The messages are converted to a
-  /// single string using the format:
-  /// ```
-  /// <role>: <content>
-  /// <role>: <content>
-  /// ...
-  /// ```
-  ///
-  /// - [messages] The messages to pass into the model.
-  /// - [options] Generation options to pass into the LLM.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await openai.predictMessages([
-  ///   ChatMessage.user('Tell me a joke.'),
-  /// ]);
-  /// ```
-  @override
-  Future<ChatMessage> predictMessages(
-    final List<ChatMessage> messages, {
-    final Options? options,
-  }) async {
-    final content = await call(messages.toBufferString(), options: options);
-    return ChatMessage.ai(content);
   }
 }
 
@@ -140,11 +61,11 @@ abstract class SimpleLLM<Options extends LLMOptions> extends BaseLLM<Options> {
   const SimpleLLM();
 
   @override
-  Future<LLMResult> generate(
-    final String prompt, {
+  Future<LLMResult> invoke(
+    final PromptValue input, {
     final Options? options,
   }) async {
-    final output = await callInternal(prompt, options: options);
+    final output = await callInternal(input.toString(), options: options);
     return LLMResult(generations: [LLMGeneration(output)]);
   }
 

--- a/packages/langchain/test/model_io/chat_models/fake_test.dart
+++ b/packages/langchain/test/model_io/chat_models/fake_test.dart
@@ -5,9 +5,13 @@ void main() {
   group('FakeChatModel tests', () {
     test('Test model returns given responses', () async {
       final chatModel = FakeChatModel(responses: ['foo', 'bar']);
-      final res1 = await chatModel.generate([ChatMessage.humanText('Hello')]);
+      final res1 = await chatModel.invoke(
+        PromptValue.chat([ChatMessage.humanText('Hello')]),
+      );
       expect(res1.firstOutputAsString, 'foo');
-      final res2 = await chatModel.generate([ChatMessage.humanText('World')]);
+      final res2 = await chatModel.invoke(
+        PromptValue.chat([ChatMessage.humanText('World')]),
+      );
       expect(res2.firstOutputAsString, 'bar');
     });
   });

--- a/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
@@ -170,8 +170,8 @@ class ChatGoogleGenerativeAI
   String get modelType => 'chat-google-generative-ai';
 
   @override
-  Future<ChatResult> generate(
-    final List<ChatMessage> messages, {
+  Future<ChatResult> invoke(
+    final PromptValue input, {
     final ChatGoogleGenerativeAIOptions? options,
   }) async {
     final id = _uuid.v4();
@@ -179,7 +179,10 @@ class ChatGoogleGenerativeAI
         options?.model ?? defaultOptions.model ?? throwNullModelError();
     final completion = await _client.generateContent(
       modelId: model,
-      request: _generateCompletionRequest(messages, options: options),
+      request: _generateCompletionRequest(
+        input.toChatMessages(),
+        options: options,
+      ),
     );
     return completion.toChatResult(id, model);
   }

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
@@ -142,14 +142,14 @@ class ChatVertexAI extends BaseChatModel<ChatVertexAIOptions> {
   String get modelType => 'vertex-ai-chat';
 
   @override
-  Future<ChatResult> generate(
-    final List<ChatMessage> messages, {
+  Future<ChatResult> invoke(
+    final PromptValue input, {
     final ChatVertexAIOptions? options,
   }) async {
     final id = _uuid.v4();
     String? context;
     final vertexMessages = <VertexAITextChatModelMessage>[];
-    for (final message in messages) {
+    for (final message in input.toChatMessages()) {
       if (message is SystemChatMessage) {
         context = message.content;
         continue;

--- a/packages/langchain_google/lib/src/llms/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai.dart
@@ -144,14 +144,14 @@ class VertexAI extends BaseLLM<VertexAIOptions> {
   String get modelType => 'vertex-ai';
 
   @override
-  Future<LLMResult> generate(
-    final String prompt, {
+  Future<LLMResult> invoke(
+    final PromptValue input, {
     final VertexAIOptions? options,
   }) async {
     final model =
         options?.model ?? defaultOptions.model ?? throwNullModelError();
     final result = await client.text.predict(
-      prompt: prompt,
+      prompt: input.toString(),
       publisher: options?.publisher ??
           ArgumentError.checkNotNull(
             defaultOptions.publisher,

--- a/packages/langchain_google/test/chat_models/chat_vertex_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/chat_vertex_ai_test.dart
@@ -64,7 +64,7 @@ void main() async {
       expect(res.content, isNotEmpty);
     });
 
-    test('Test generate to ChatVertexAI', () async {
+    test('Test invoke to ChatVertexAI', () async {
       final chat = ChatVertexAI(
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
@@ -74,12 +74,12 @@ void main() async {
           maxOutputTokens: 10,
         ),
       );
-      final res = await chat.generate(
-        [
+      final res = await chat.invoke(
+        PromptValue.chat([
           ChatMessage.humanText('Hello, how are you?'),
           ChatMessage.ai('I am fine, thank you.'),
           ChatMessage.humanText('Good, what is your name?'),
-        ],
+        ]),
       );
       expect(res.generations.first.output.content, isNotEmpty);
     });
@@ -94,8 +94,8 @@ void main() async {
           maxOutputTokens: 10,
         ),
       );
-      final res = await chat.generate(
-        [ChatMessage.humanText('Hello, how are you?')],
+      final res = await chat.invoke(
+        PromptValue.chat([ChatMessage.humanText('Hello, how are you?')]),
       );
       expect(res.modelOutput, isNotNull);
       expect(res.modelOutput!['model'], chat.defaultOptions.model);
@@ -128,24 +128,24 @@ void main() async {
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
       );
-      final res = await chat.generate(
-        [
+      final res = await chat.invoke(
+        PromptValue.chat([
           ChatMessage.humanText(
             'List the numbers from 1 to 9 in order without any spaces or commas',
           ),
-        ],
+        ]),
         options: const ChatVertexAIOptions(stopSequences: ['4']),
       );
       expect(res.firstOutputAsString, contains('123'));
       expect(res.firstOutputAsString, isNot(contains('456789')));
 
       // call options should override defaults
-      final res2 = await chat.generate(
-        [
+      final res2 = await chat.invoke(
+        PromptValue.chat([
           ChatMessage.humanText(
             'List the numbers from 1 to 9 in order without any spaces or commas',
           ),
-        ],
+        ]),
         options: const ChatVertexAIOptions(
           stopSequences: ['5'],
         ),
@@ -165,14 +165,18 @@ void main() async {
           candidateCount: 3,
         ),
       );
-      final res = await chat.generate(
-        [ChatMessage.humanText('Suggest a name for a LLM framework for Dart')],
+      final res = await chat.invoke(
+        PromptValue.chat([
+          ChatMessage.humanText('Suggest a name for a LLM framework for Dart'),
+        ]),
       );
       expect(res.generations.length, 3);
 
       // call options should override defaults
-      final res2 = await chat.generate(
-        [ChatMessage.humanText('Suggest a name for a LLM framework for Dart')],
+      final res2 = await chat.invoke(
+        PromptValue.chat([
+          ChatMessage.humanText('Suggest a name for a LLM framework for Dart'),
+        ]),
         options: const ChatVertexAIOptions(
           temperature: 1,
           candidateCount: 5,
@@ -189,7 +193,7 @@ void main() async {
       final prompt = PromptValue.string('Hello, how are you?');
 
       final numTokens = await chat.countTokens(prompt);
-      final generation = await chat.generatePrompt(prompt);
+      final generation = await chat.invoke(prompt);
       expect(numTokens, generation.usage!.promptTokens);
     });
 

--- a/packages/langchain_google/test/llms/vertex_ai_test.dart
+++ b/packages/langchain_google/test/llms/vertex_ai_test.dart
@@ -59,7 +59,7 @@ Future<void> main() async {
       expect(output, isNotEmpty);
     });
 
-    test('Test generate to VertexAI', () async {
+    test('Test invoke to VertexAI', () async {
       final llm = VertexAI(
         httpClient: authHttpClient,
         project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
@@ -69,7 +69,9 @@ Future<void> main() async {
           maxOutputTokens: 10,
         ),
       );
-      final res = await llm.generate('Hello, how are you?');
+      final res = await llm.invoke(
+        PromptValue.string('Hello, how are you?'),
+      );
       expect(res.generations.length, 1);
     });
 
@@ -83,7 +85,9 @@ Future<void> main() async {
           maxOutputTokens: 10,
         ),
       );
-      final res = await llm.generate('Hello, how are you?');
+      final res = await llm.invoke(
+        PromptValue.string('Hello, how are you?'),
+      );
       expect(res.modelOutput, isNotNull);
       expect(res.modelOutput!['model'], llm.defaultOptions.model);
       expect(res.usage?.promptTokens, isNotNull);
@@ -102,15 +106,19 @@ Future<void> main() async {
           stopSequences: ['4'],
         ),
       );
-      final res = await llm.generate(
-        'List the numbers from 1 to 9 in order without any spaces or commas',
+      final res = await llm.invoke(
+        PromptValue.string(
+          'List the numbers from 1 to 9 in order without any spaces or commas',
+        ),
       );
       expect(res.firstOutputAsString, contains('123'));
       expect(res.firstOutputAsString, isNot(contains('456789')));
 
       // call options should override defaults
-      final res2 = await llm.generate(
-        'List the numbers from 1 to 9 in order without any spaces or commas',
+      final res2 = await llm.invoke(
+        PromptValue.string(
+          'List the numbers from 1 to 9 in order without any spaces or commas',
+        ),
         options: const VertexAIOptions(
           stopSequences: ['5'],
         ),
@@ -130,14 +138,14 @@ Future<void> main() async {
           candidateCount: 3,
         ),
       );
-      final res = await llm.generate(
-        'Suggest a name for a LLM framework for Dart',
+      final res = await llm.invoke(
+        PromptValue.string('Suggest a name for a LLM framework for Dart'),
       );
       expect(res.generations.length, 3);
 
       // call options should override defaults
-      final res2 = await llm.generate(
-        'Suggest a name for a LLM framework for Python',
+      final res2 = await llm.invoke(
+        PromptValue.string('Suggest a name for a LLM framework for Python'),
         options: const VertexAIOptions(
           temperature: 1,
           candidateCount: 5,

--- a/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
@@ -182,12 +182,15 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
   String get modelType => 'chat-mistralai';
 
   @override
-  Future<ChatResult> generate(
-    final List<ChatMessage> messages, {
+  Future<ChatResult> invoke(
+    final PromptValue input, {
     final ChatMistralAIOptions? options,
   }) async {
     final completion = await _client.createChatCompletion(
-      request: _generateCompletionRequest(messages, options: options),
+      request: _generateCompletionRequest(
+        input.toChatMessages(),
+        options: options,
+      ),
     );
     return completion.toChatResult();
   }

--- a/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
+++ b/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
@@ -45,9 +45,11 @@ void main() {
       expect(output.content, isNotEmpty);
     });
 
-    test('Test generate to ChatMistralAI', () async {
-      final res = await chatModel.generate(
-        [ChatMessage.humanText('Hello, how are you?')],
+    test('Test invoke to ChatMistralAI', () async {
+      final res = await chatModel.invoke(
+        PromptValue.chat(
+          [ChatMessage.humanText('Hello, how are you?')],
+        ),
       );
       expect(res.generations.length, 1);
     });

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
@@ -179,14 +179,14 @@ class ChatOllama extends BaseChatModel<ChatOllamaOptions> {
   String get modelType => 'chat-ollama';
 
   @override
-  Future<ChatResult> generate(
-    final List<ChatMessage> messages, {
+  Future<ChatResult> invoke(
+    final PromptValue input, {
     final ChatOllamaOptions? options,
   }) async {
     final id = _uuid.v4();
     final completion = await _client.generateChatCompletion(
       request: _generateCompletionRequest(
-        messages,
+        input.toChatMessages(),
         options: options,
       ),
     );

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -176,12 +176,12 @@ class Ollama extends BaseLLM<OllamaOptions> {
   String get modelType => 'ollama';
 
   @override
-  Future<LLMResult> generate(
-    final String prompt, {
+  Future<LLMResult> invoke(
+    final PromptValue input, {
     final OllamaOptions? options,
   }) async {
     final completion = await _client.generateCompletion(
-      request: _generateCompletionRequest(prompt, options: options),
+      request: _generateCompletionRequest(input.toString(), options: options),
     );
     return completion.toLLMResult();
   }

--- a/packages/langchain_ollama/test/llms/ollama_test.dart
+++ b/packages/langchain_ollama/test/llms/ollama_test.dart
@@ -117,8 +117,10 @@ void main() {
       expect(output, isNotEmpty);
     });
 
-    test('Test generate to Ollama', () async {
-      final res = await llm.generate('Hello, how are you?');
+    test('Test invoke to Ollama', () async {
+      final res = await llm.invoke(
+        PromptValue.string('Hello, how are you?'),
+      );
       expect(res.generations.length, 1);
     });
 

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
@@ -239,12 +239,15 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
   String get modelType => 'openai-chat';
 
   @override
-  Future<ChatResult> generate(
-    final List<ChatMessage> messages, {
+  Future<ChatResult> invoke(
+    final PromptValue input, {
     final ChatOpenAIOptions? options,
   }) async {
     final completion = await _client.createChatCompletion(
-      request: _createChatCompletionRequest(messages, options: options),
+      request: _createChatCompletionRequest(
+        input.toChatMessages(),
+        options: options,
+      ),
     );
     return completion.toChatResult(completion.id ?? _uuid.v4());
   }

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -230,12 +230,12 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
   String get modelType => 'openai';
 
   @override
-  Future<LLMResult> generate(
-    final String prompt, {
+  Future<LLMResult> invoke(
+    final PromptValue input, {
     final OpenAIOptions? options,
   }) async {
     final completion = await _client.createCompletion(
-      request: _createCompletionRequest(prompt, options: options),
+      request: _createCompletionRequest(input.toString(), options: options),
     );
     return completion.toLLMResult();
   }

--- a/packages/langchain_openai/test/chat_models/anyscale_test.dart
+++ b/packages/langchain_openai/test/chat_models/anyscale_test.dart
@@ -45,6 +45,7 @@ void main() {
         expect(
           res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
           contains('123456789'),
+          reason: model,
         );
         expect(res.modelOutput, isNotNull, reason: model);
         expect(res.modelOutput!['created'], greaterThan(0), reason: model);

--- a/packages/langchain_openai/test/chat_models/chat_openai_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_test.dart
@@ -53,12 +53,12 @@ void main() {
 
     test('Test generate to ChatOpenAI', () async {
       final chat = ChatOpenAI(apiKey: openaiApiKey);
-      final res = await chat.generate(
-        [
+      final res = await chat.invoke(
+        PromptValue.chat([
           ChatMessage.humanText('Hello, how are you?'),
           ChatMessage.ai('I am fine, thank you.'),
           ChatMessage.humanText('Good, what is your name?'),
-        ],
+        ]),
       );
       expect(res.generations.first.output.content, isNotEmpty);
     });
@@ -71,8 +71,10 @@ void main() {
           maxTokens: 10,
         ),
       );
-      final res = await chat.generate(
-        [ChatMessage.humanText('Hello, how are you?')],
+      final res = await chat.invoke(
+        PromptValue.chat(
+          [ChatMessage.humanText('Hello, how are you?')],
+        ),
       );
       expect(res.modelOutput, isNotNull);
       expect(res.modelOutput!['created'], isNotNull);
@@ -123,7 +125,9 @@ void main() {
         ),
       );
       final humanMessage = ChatMessage.humanText('Hello');
-      final res = await chat.generate([humanMessage]);
+      final res = await chat.invoke(
+        PromptValue.chat([humanMessage]),
+      );
       expect(res.generations.length, 5);
       for (final generation in res.generations) {
         expect(generation.output.content, isNotEmpty);
@@ -157,8 +161,8 @@ void main() {
       final humanMessage = ChatMessage.humanText(
         'What’s the weather like in Boston right now?',
       );
-      final res1 = await chat.generate(
-        [humanMessage],
+      final res1 = await chat.invoke(
+        PromptValue.chat([humanMessage]),
         options: const ChatOpenAIOptions(functions: [function]),
       );
 
@@ -184,8 +188,8 @@ void main() {
         content: json.encode(functionResult),
       );
 
-      final res2 = await chat.generate(
-        [humanMessage, aiMessage1, functionMessage],
+      final res2 = await chat.invoke(
+        PromptValue.chat([humanMessage, aiMessage1, functionMessage]),
         options: const ChatOpenAIOptions(functions: [function]),
       );
 
@@ -218,7 +222,7 @@ void main() {
       final prompt = PromptValue.string('Hello, how are you?');
 
       final numTokens = await chat.countTokens(prompt);
-      final generation = await chat.generatePrompt(prompt);
+      final generation = await chat.invoke(prompt);
       expect(numTokens, generation.usage!.promptTokens);
     });
 
@@ -251,7 +255,7 @@ void main() {
         ];
 
         final numTokens = await chat.countTokens(PromptValue.chat(messages));
-        final generation = await chat.generate(messages);
+        final generation = await chat.invoke(PromptValue.chat(messages));
         expect(numTokens, generation.usage!.promptTokens);
       }
     });
@@ -340,7 +344,7 @@ void main() {
       final llm = ChatOpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const ChatOpenAIOptions(
-          model: defaultModel,
+          model: 'gpt-4-turbo-preview',
           temperature: 0,
           seed: 9999,
         ),

--- a/packages/langchain_openai/test/chat_models/open_router_test.dart
+++ b/packages/langchain_openai/test/chat_models/open_router_test.dart
@@ -30,9 +30,9 @@ void main() {
         'anthropic/claude-2',
         'mistralai/mixtral-8x7b-instruct',
         'mistralai/mistral-small',
-        'haotian-liu/llava-13b',
       ];
       for (final model in models) {
+        print('Testing model: $model');
         final res = await chatModel.invoke(
           PromptValue.string(
             'List the numbers from 1 to 9 in order. '

--- a/packages/langchain_openai/test/llms/openai_test.dart
+++ b/packages/langchain_openai/test/llms/openai_test.dart
@@ -66,7 +66,7 @@ void main() {
       expect(() => llm('Say foo:'), throwsA(isA<OpenAIClientException>()));
     });
 
-    test('Test generate to OpenAI', () async {
+    test('Test invoke to OpenAI', () async {
       final llm = OpenAI(
         apiKey: openaiApiKey,
         defaultOptions: const OpenAIOptions(
@@ -74,7 +74,9 @@ void main() {
           maxTokens: 10,
         ),
       );
-      final res = await llm.generate('Hello, how are you?');
+      final res = await llm.invoke(
+        PromptValue.string('Hello, how are you?'),
+      );
       expect(res.generations.length, 1);
     });
 
@@ -86,7 +88,9 @@ void main() {
           maxTokens: 10,
         ),
       );
-      final res = await llm.generate('Hello, how are you?');
+      final res = await llm.invoke(
+        PromptValue.string('Hello, how are you?'),
+      );
       expect(res.modelOutput, isNotNull);
       expect(res.modelOutput!['id'], isNotEmpty);
       expect(res.modelOutput!['created'], isNotNull);
@@ -116,7 +120,9 @@ void main() {
           bestOf: 5,
         ),
       );
-      final res = await llm.generate('Hello, how are you?');
+      final res = await llm.invoke(
+        PromptValue.string('Hello, how are you?'),
+      );
       expect(res.generations.length, 5);
       for (final generation in res.generations) {
         expect(generation.output, isNotEmpty);

--- a/packages/openai_dart/test/openai_client_chat_test.dart
+++ b/packages/openai_dart/test/openai_client_chat_test.dart
@@ -524,7 +524,7 @@ void main() {
           ),
         ],
         temperature: 0,
-        seed: 9999,
+        seed: 9999999999,
       );
       final res1 = await client.createChatCompletion(request: request);
       expect(res1.choices, hasLength(1));


### PR DESCRIPTION
The following LLM/ChatModel APIs have been removed:

- `generate`
- `generatePrompt`
- `predict`
- `predictMessages`

In favour of the standard `invoke` API, part of [LangChain Expression Language](https://langchaindart.com/#/expression_language/interface).

For simple use cases that don't require composition, `call` can still be used.