### PR TITLE
feat: Support tuned models in ChatGoogleGenerativeAI

### DIFF
--- a/packages/langchain_google/test/chat_models/chat_google_generative_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/chat_google_generative_ai_test.dart
@@ -45,6 +45,20 @@ void main() {
       );
     });
 
+    test('Test models prefix', () async {
+      final res = await chatModel.invoke(
+        PromptValue.string(
+          'List the numbers from 1 to 9 in order '
+          'without any spaces, commas or additional explanations.',
+        ),
+        options: const ChatGoogleGenerativeAIOptions(
+          model: 'models/gemini-pro',
+          temperature: 0,
+        ),
+      );
+      expect(res.firstOutputAsString, isNotEmpty);
+    });
+
     test('Text-and-image input with gemini-pro-vision', () async {
       final res = await chatModel.invoke(
         PromptValue.chat([


### PR DESCRIPTION
You can specify a tuned model by setting the `model` parameter to
`tunedModels/{your-model-name}`. For example:
```dart
final chatModel = ChatGoogleGenerativeAI(
  defaultOptions: ChatGoogleGenerativeAIOptions(
    model: 'tunedModels/my-tuned-model',
  ),
);
```