### PR TITLE
refactor!: Simplify LLMResult and ChatResult classes

### DIFF
--- a/docs/expression_language/get_started.md
+++ b/docs/expression_language/get_started.md
@@ -59,7 +59,7 @@ The `PromptValue` is then passed to `model`. In this case our `model` is a `Chat
 
 ```dart
 final chatOutput = await model.invoke(promptValue);
-print(chatOutput.firstOutput);
+print(chatOutput.output);
 // AIChatMessage{
 //   content: Why did the ice cream truck break down? 
 //   Because it couldn't make it over the rocky road!,
@@ -71,7 +71,7 @@ If our model was an `LLM`, it would output a `String`.
 ```dart
 final llm = OpenAI(apiKey: openaiApiKey);
 final llmOutput = await llm.invoke(promptValue);
-print(llmOutput.firstOutput);
+print(llmOutput.output);
 // Why did the ice cream go to therapy?
 // Because it had a rocky road!
 ```

--- a/docs/get_started/quickstart.md
+++ b/docs/get_started/quickstart.md
@@ -90,11 +90,11 @@ const text = 'What would be a good company name for a company that makes colorfu
 final messages = [ChatMessage.humanText(text)];
 
 final res1 = await llm.invoke(PromptValue.string(text));
-print(res1.firstOutput);
+print(res1.output);
 // 'Feetful of Fun'
 
 final res2 = await chatModel.invoke(PromptValue.chat(messages));
-print(res2.firstOutput);
+print(res2.output);
 // AIChatMessage(content='RainbowSock Co.')
 ```
 

--- a/docs/modules/model_io/models/chat_models/integrations/googleai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/googleai.md
@@ -70,7 +70,7 @@ final res = await chatModel.invoke(
     ),
   ]),
 );
-print(res.firstOutputAsString);
+print(res.output.content);
 // -> 'A Red and Green Apple'
 ```
 

--- a/docs/modules/model_io/models/chat_models/integrations/ollama.md
+++ b/docs/modules/model_io/models/chat_models/integrations/ollama.md
@@ -97,7 +97,7 @@ final chain = promptTemplate.pipe(chat);
 final res = await chain.invoke(
   {'question': 'What color is the sky at different times of the day?'},
 );
-print(res.firstOutputAsString);
+print(res.output.content);
 // {"morning": {"sky": "pink", "sun": "rise"}, "daytime": {"sky": "blue", "sun": "high"}, "afternoon": ...}
 ```
 
@@ -125,7 +125,7 @@ final prompt = ChatMessage.human(
   ]),
 );
 final res = await chatModel.invoke(PromptValue.chat([prompt]));
-print(res.firstOutputAsString);
+print(res.output.content);
 // -> 'An Apple'
 ```
 

--- a/docs/modules/model_io/models/chat_models/integrations/openai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/openai.md
@@ -147,7 +147,7 @@ final llm = ChatOpenAI(
   ),
 );
 final res = await llm.invoke(prompt);
-final outputMsg = res.firstOutputAsString;
+final outputMsg = res.output.content;
 print(outputMsg);
 // {
 //   "companies": [

--- a/examples/docs_examples/bin/expression_language/get_started.dart
+++ b/examples/docs_examples/bin/expression_language/get_started.dart
@@ -44,7 +44,7 @@ Future<void> _promptModelOutputParser() async {
   // 2. Model
 
   final chatOutput = await model.invoke(promptValue);
-  print(chatOutput.firstOutput);
+  print(chatOutput.output);
   // AIChatMessage{
   //   content: Why did the ice cream truck break down?
   //   Because it couldn't make it over the rocky road!,
@@ -52,7 +52,7 @@ Future<void> _promptModelOutputParser() async {
 
   final llm = OpenAI(apiKey: openaiApiKey);
   final llmOutput = await llm.invoke(promptValue);
-  print(llmOutput.firstOutput);
+  print(llmOutput.output);
   // Why did the ice cream go to therapy?
   // Because it had a rocky road!
 

--- a/examples/docs_examples/bin/get_started/quickstart.dart
+++ b/examples/docs_examples/bin/get_started/quickstart.dart
@@ -23,11 +23,11 @@ Future<void> _llmChatModel() async {
   final messages = [ChatMessage.humanText(text)];
 
   final res1 = await llm.invoke(PromptValue.string(text));
-  print(res1.firstOutput);
+  print(res1.output);
   // 'Feetful of Fun'
 
   final res2 = await chatModel.invoke(PromptValue.chat(messages));
-  print(res2.firstOutput);
+  print(res2.output);
   // AIChatMessage(content='RainbowSock Co.')
 }
 

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/googleai.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/googleai.dart
@@ -69,7 +69,7 @@ Future<void> _chatGoogleGenerativeAIMultiModal() async {
       ),
     ]),
   );
-  print(res.firstOutputAsString);
+  print(res.output.content);
   // -> 'A Red and Green Apple'
 
   chatModel.close();

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/ollama.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/ollama.dart
@@ -84,7 +84,7 @@ Future<void> _chatOllamaJsonMode() async {
   final res = await chain.invoke(
     {'question': 'What color is the sky at different times of the day?'},
   );
-  print(res.firstOutputAsString);
+  print(res.output.content);
   // {"morning": {"sky": "pink", "sun": "rise"}, "daytime": {"sky": "blue", "sun": "high"}, "afternoon": ...}
 }
 
@@ -106,7 +106,7 @@ Future<void> _chatOllamaMultimodal() async {
     ]),
   );
   final res = await chatModel.invoke(PromptValue.chat([prompt]));
-  print(res.firstOutputAsString);
+  print(res.output.content);
   // -> 'An Apple'
 }
 

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/openai.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/openai.dart
@@ -146,7 +146,7 @@ Future<void> _chatOpenAIJsonMode() async {
     ),
   );
   final res = await llm.invoke(prompt);
-  final outputMsg = res.firstOutputAsString;
+  final outputMsg = res.output.content;
   print(outputMsg);
   // {
   //   "companies": [

--- a/packages/langchain_core/lib/src/chains/llm_chain.dart
+++ b/packages/langchain_core/lib/src/chains/llm_chain.dart
@@ -89,15 +89,12 @@ class LLMChain<
     final response = await llm.invoke(promptValue, options: llmOptions);
 
     final res = outputParser == null
-        ? response.generations.firstOrNull?.output
-        : await outputParser!.parseResultWithPrompt(
-            response.generations,
-            promptValue,
-          );
+        ? response.output
+        : await outputParser!.parseResultWithPrompt(response, promptValue);
 
     return {
       outputKey: res,
-      if (!returnFinalOnly) fullGenerationOutputKey: response.generations.first,
+      if (!returnFinalOnly) fullGenerationOutputKey: response,
     };
   }
 }

--- a/packages/langchain_core/lib/src/chat_models/base.dart
+++ b/packages/langchain_core/lib/src/chat_models/base.dart
@@ -1,6 +1,6 @@
 import 'package:meta/meta.dart';
 
-import '../language_models/base.dart';
+import '../language_models/language_models.dart';
 import '../prompts/types.dart';
 import 'types.dart';
 
@@ -45,14 +45,14 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
     final Options? options,
   }) async {
     final result = await invoke(PromptValue.chat(messages), options: options);
-    return result.generations[0].output;
+    return result.output;
   }
 }
 
 /// {@template simple_chat_model}
 /// [SimpleChatModel] provides a simplified interface for working with chat
 /// models, rather than expecting the user to implement the full
-/// [SimpleChatModel.generate] method.
+/// [SimpleChatModel.invoke] method.
 /// {@endtemplate}
 abstract class SimpleChatModel<Options extends ChatModelOptions>
     extends BaseChatModel<Options> {
@@ -67,7 +67,11 @@ abstract class SimpleChatModel<Options extends ChatModelOptions>
     final text = await callInternal(input.toChatMessages(), options: options);
     final message = AIChatMessage(content: text);
     return ChatResult(
-      generations: [ChatGeneration(message)],
+      id: '1',
+      output: message,
+      finishReason: FinishReason.unspecified,
+      metadata: const {},
+      usage: const LanguageModelUsage(),
     );
   }
 

--- a/packages/langchain_core/lib/src/chat_models/fake.dart
+++ b/packages/langchain_core/lib/src/chat_models/fake.dart
@@ -1,3 +1,4 @@
+import '../../language_models.dart';
 import '../prompts/types.dart';
 import 'base.dart';
 import 'types.dart';
@@ -71,7 +72,11 @@ class FakeEchoChatModel extends SimpleChatModel {
         final prompt = input.toChatMessages().first.contentAsString.split('');
         return Stream.fromIterable(prompt).map(
           (final char) => ChatResult(
-            generations: [ChatGeneration(AIChatMessage(content: char))],
+            id: 'fake-echo-chat-model',
+            output: AIChatMessage(content: char),
+            finishReason: FinishReason.stop,
+            metadata: const {},
+            usage: const LanguageModelUsage(),
             streaming: true,
           ),
         );

--- a/packages/langchain_core/lib/src/chat_models/types.dart
+++ b/packages/langchain_core/lib/src/chat_models/types.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
-import '../language_models/types.dart';
+import '../language_models/language_models.dart';
 
 /// {@template chat_model_options}
 /// Generation options to pass into the Chat Model.
@@ -11,43 +11,38 @@ class ChatModelOptions extends LanguageModelOptions {
   const ChatModelOptions();
 }
 
+/// {@template chat_result}
 /// Result returned by the Chat Model.
-typedef ChatResult = LanguageModelResult<AIChatMessage>;
-
-/// {@template chat_generation}
-/// Output of a single generation.
 /// {@endtemplate}
-@immutable
-class ChatGeneration extends LanguageModelGeneration<AIChatMessage> {
-  /// {@macro chat_generation}
-  const ChatGeneration(
-    super.output, {
-    super.generationInfo,
+class ChatResult extends LanguageModelResult<AIChatMessage> {
+  /// {@macro chat_result}
+  const ChatResult({
+    required super.id,
+    required super.output,
+    required super.finishReason,
+    required super.metadata,
+    required super.usage,
+    super.streaming = false,
   });
 
   @override
   String get outputAsString => output.content;
 
   @override
-  LanguageModelGeneration<AIChatMessage> concat(
-    final LanguageModelGeneration<AIChatMessage> other,
+  LanguageModelResult<AIChatMessage> concat(
+    final LanguageModelResult<AIChatMessage> other,
   ) {
-    return ChatGeneration(
-      output.concat(other.output),
-      generationInfo: {
-        ...?generationInfo,
-        ...?other.generationInfo,
+    return ChatResult(
+      id: other.id ?? id,
+      output: output.concat(other.output),
+      finishReason: other.finishReason,
+      metadata: {
+        ...metadata,
+        ...other.metadata,
       },
+      usage: usage.concat(other.usage),
+      streaming: other.streaming,
     );
-  }
-
-  @override
-  String toString() {
-    return '''
-ChatGeneration{
-  output: $output, 
-  generationInfo: $generationInfo, 
-''';
   }
 }
 

--- a/packages/langchain_core/lib/src/llms/base.dart
+++ b/packages/langchain_core/lib/src/llms/base.dart
@@ -1,6 +1,6 @@
 import 'package:meta/meta.dart';
 
-import '../language_models/base.dart';
+import '../language_models/language_models.dart';
 import '../prompts/types.dart';
 import 'types.dart';
 
@@ -47,14 +47,14 @@ abstract class BaseLLM<Options extends LLMOptions>
     final Options? options,
   }) async {
     final result = await invoke(PromptValue.string(prompt), options: options);
-    return result.firstOutputAsString;
+    return result.output;
   }
 }
 
 /// {@template simple_llm}
-/// [SimpleLLM] provides a simplified interface for working with LLMs,
-/// rather than expecting the user to implement the full [SimpleLLM.generate]
-/// method.
+/// [SimpleLLM] provides a simplified interface for working with LLMs.
+/// Rather than expecting the user to implement the full [SimpleLLM.invoke]
+/// method, the user only needs to implement [SimpleLLM.callInternal].
 /// {@endtemplate}
 abstract class SimpleLLM<Options extends LLMOptions> extends BaseLLM<Options> {
   /// {@macro simple_llm}
@@ -66,7 +66,13 @@ abstract class SimpleLLM<Options extends LLMOptions> extends BaseLLM<Options> {
     final Options? options,
   }) async {
     final output = await callInternal(input.toString(), options: options);
-    return LLMResult(generations: [LLMGeneration(output)]);
+    return LLMResult(
+      id: '1',
+      output: output,
+      finishReason: FinishReason.unspecified,
+      metadata: const {},
+      usage: const LanguageModelUsage(),
+    );
   }
 
   /// Method which should be implemented by subclasses to run the model.

--- a/packages/langchain_core/lib/src/llms/fake.dart
+++ b/packages/langchain_core/lib/src/llms/fake.dart
@@ -1,3 +1,4 @@
+import '../../language_models.dart';
 import '../prompts/types.dart';
 import 'base.dart';
 import 'types.dart';
@@ -45,7 +46,7 @@ class FakeListLLM extends SimpleLLM {
 /// Fake LLM for testing.
 /// It just returns the prompt or streams it char by char.
 /// {@endtemplate}
-class FakeEchoLLM extends SimpleLLM {
+class FakeEchoLLM extends BaseLLM {
   /// {@macro fake_echo_llm}
   const FakeEchoLLM();
 
@@ -53,11 +54,19 @@ class FakeEchoLLM extends SimpleLLM {
   String get modelType => 'fake-echo';
 
   @override
-  Future<String> callInternal(
-    final String prompt, {
+  Future<LLMResult> invoke(
+    final PromptValue input, {
     final LLMOptions? options,
   }) {
-    return Future<String>.value(prompt);
+    return Future<LLMResult>.value(
+      LLMResult(
+        id: 'fake-echo',
+        output: input.toString(),
+        finishReason: FinishReason.stop,
+        metadata: const {},
+        usage: const LanguageModelUsage(),
+      ),
+    );
   }
 
   @override
@@ -70,7 +79,11 @@ class FakeEchoLLM extends SimpleLLM {
         final promptChars = prompt.toString().split('');
         return Stream.fromIterable(promptChars).map(
           (final item) => LLMResult(
-            generations: [LLMGeneration(item)],
+            id: 'fake-echo',
+            output: item,
+            finishReason: FinishReason.unspecified,
+            metadata: const {},
+            usage: const LanguageModelUsage(),
             streaming: true,
           ),
         );

--- a/packages/langchain_core/lib/src/llms/types.dart
+++ b/packages/langchain_core/lib/src/llms/types.dart
@@ -1,5 +1,3 @@
-import 'package:meta/meta.dart';
-
 import '../language_models/types.dart';
 
 /// {@template llm_options}
@@ -10,42 +8,37 @@ class LLMOptions extends LanguageModelOptions {
   const LLMOptions();
 }
 
-/// Class that contains all relevant information for an LLM Result.
-typedef LLMResult = LanguageModelResult<String>;
-
-/// {@template llm_generation}
-/// Output of a single generation.
+/// {@template llm_result}
+/// Result returned by the LLM.
 /// {@endtemplate}
-@immutable
-class LLMGeneration extends LanguageModelGeneration<String> {
-  /// {@macro llm_generation}
-  const LLMGeneration(
-    super.output, {
-    super.generationInfo,
+class LLMResult extends LanguageModelResult<String> {
+  /// {@macro llm_result}
+  const LLMResult({
+    required super.id,
+    required super.output,
+    required super.finishReason,
+    required super.metadata,
+    required super.usage,
+    super.streaming = false,
   });
 
   @override
   String get outputAsString => output;
 
   @override
-  LanguageModelGeneration<String> concat(
-    final LanguageModelGeneration<String> other,
+  LanguageModelResult<String> concat(
+    final LanguageModelResult<String> other,
   ) {
-    return LLMGeneration(
-      output + other.output,
-      generationInfo: {
-        ...?generationInfo,
-        ...?other.generationInfo,
+    return LLMResult(
+      id: other.id ?? id,
+      output: output + other.output,
+      finishReason: other.finishReason,
+      metadata: {
+        ...metadata,
+        ...other.metadata,
       },
+      usage: usage.concat(other.usage),
+      streaming: other.streaming,
     );
-  }
-
-  @override
-  String toString() {
-    return '''
-LLMGeneration{
-  output: $output, 
-  generationInfo: $generationInfo, 
-''';
   }
 }

--- a/packages/langchain_core/lib/src/output_parsers/base.dart
+++ b/packages/langchain_core/lib/src/output_parsers/base.dart
@@ -21,7 +21,7 @@ abstract class BaseLLMOutputParser<LLMOutput extends Object,
   ///
   /// - [result] - The result of an LLM call.
   Future<ParserOutput> parseResult(
-    final List<LanguageModelGeneration<LLMOutput>> result,
+    final LanguageModelResult<LLMOutput> result,
   );
 
   /// Optional method to parse the output of an LLM call with a prompt.
@@ -33,7 +33,7 @@ abstract class BaseLLMOutputParser<LLMOutput extends Object,
   /// - [result] - The result of an LLM call.
   /// - [prompt] - Prompt used to generate the output.
   Future<ParserOutput> parseResultWithPrompt(
-    final List<LanguageModelGeneration<LLMOutput>> result,
+    final LanguageModelResult<LLMOutput> result,
     final PromptValue prompt,
   ) async {
     return parseResult(result);
@@ -48,7 +48,7 @@ abstract class BaseLLMOutputParser<LLMOutput extends Object,
     final LanguageModelResult<LLMOutput> input, {
     final BaseLangChainOptions? options,
   }) {
-    return parseResult(input.generations);
+    return parseResult(input);
   }
 }
 
@@ -63,9 +63,9 @@ abstract class BaseOutputParser<LLMOutput extends Object,
 
   @override
   Future<ParserOutput> parseResult(
-    final List<LanguageModelGeneration<LLMOutput>> result,
+    final LanguageModelResult<LLMOutput> result,
   ) {
-    return parse(result.first.outputAsString);
+    return parse(result.outputAsString);
   }
 
   /// Parse the output of an LLM call.

--- a/packages/langchain_core/lib/src/output_parsers/functions.dart
+++ b/packages/langchain_core/lib/src/output_parsers/functions.dart
@@ -23,10 +23,9 @@ abstract class BaseOutputFunctionsParser<
 
   @override
   Future<O> parseResult(
-    final List<LanguageModelGeneration<ChatMessage>> result,
+    final LanguageModelResult<ChatMessage> result,
   ) async {
-    final generation = result.first;
-    return _parseChatMessage(generation.output);
+    return _parseChatMessage(result.output);
   }
 
   @override
@@ -37,8 +36,7 @@ abstract class BaseOutputFunctionsParser<
     return inputStream.asyncMap((final input) async {
       final mergedResult = _lastResult?.concat(input) ?? input;
       _lastResult = mergedResult;
-      final generation = mergedResult.generations.first;
-      return _parseChatMessage(generation.output);
+      return _parseChatMessage(mergedResult.output);
     });
   }
 

--- a/packages/langchain_core/test/chat_models/fake_test.dart
+++ b/packages/langchain_core/test/chat_models/fake_test.dart
@@ -9,11 +9,11 @@ void main() {
       final res1 = await chatModel.invoke(
         PromptValue.chat([ChatMessage.humanText('Hello')]),
       );
-      expect(res1.firstOutputAsString, 'foo');
+      expect(res1.outputAsString, 'foo');
       final res2 = await chatModel.invoke(
         PromptValue.chat([ChatMessage.humanText('World')]),
       );
-      expect(res2.firstOutputAsString, 'bar');
+      expect(res2.outputAsString, 'bar');
     });
   });
 }

--- a/packages/langchain_core/test/output_parsers/functions_test.dart
+++ b/packages/langchain_core/test/output_parsers/functions_test.dart
@@ -1,47 +1,48 @@
 import 'dart:convert';
 
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:test/test.dart';
 
 void main() {
   const result = ChatResult(
-    generations: [
-      ChatGeneration(
-        AIChatMessage(
-          content: '',
-          functionCall: AIChatMessageFunctionCall(
-            name: 'test',
-            argumentsRaw: '{"foo":"bar","bar":"foo"}',
-            arguments: {
-              'foo': 'bar',
-              'bar': 'foo',
-            },
-          ),
-        ),
+    id: 'id',
+    output: AIChatMessage(
+      content: '',
+      functionCall: AIChatMessageFunctionCall(
+        name: 'test',
+        argumentsRaw: '{"foo":"bar","bar":"foo"}',
+        arguments: {
+          'foo': 'bar',
+          'bar': 'foo',
+        },
       ),
-    ],
+    ),
+    finishReason: FinishReason.stop,
+    metadata: {},
+    usage: LanguageModelUsage(),
   );
 
   const streamingResult = ChatResult(
-    streaming: true,
-    generations: [
-      ChatGeneration(
-        AIChatMessage(
-          content: '',
-          functionCall: AIChatMessageFunctionCall(
-            name: 'test',
-            argumentsRaw: '{"foo":"bar"',
-            arguments: {},
-          ),
-        ),
+    id: 'id',
+    output: AIChatMessage(
+      content: '',
+      functionCall: AIChatMessageFunctionCall(
+        name: 'test',
+        argumentsRaw: '{"foo":"bar"',
+        arguments: {},
       ),
-    ],
+    ),
+    finishReason: FinishReason.stop,
+    metadata: {},
+    usage: LanguageModelUsage(),
+    streaming: true,
   );
 
   group('OutputFunctionsParser tests', () {
     test('OutputFunctionsParser from ChatResult', () async {
-      final res = await OutputFunctionsParser().parseResult(result.generations);
+      final res = await OutputFunctionsParser().parseResult(result);
       expect(res, '{"foo":"bar","bar":"foo"}');
     });
 
@@ -51,8 +52,8 @@ void main() {
     });
 
     test('OutputFunctionsParser from ChatResult argsOnly=false', () async {
-      final res = await OutputFunctionsParser(argsOnly: false)
-          .parseResult(result.generations);
+      final res =
+          await OutputFunctionsParser(argsOnly: false).parseResult(result);
       expect(
         res,
         json.encode({
@@ -84,8 +85,7 @@ void main() {
 
   group('JsonOutputFunctionsParser tests', () {
     test('JsonOutputFunctionsParser from ChatResult', () async {
-      final res =
-          await JsonOutputFunctionsParser().parseResult(result.generations);
+      final res = await JsonOutputFunctionsParser().parseResult(result);
       expect(res, {'foo': 'bar', 'bar': 'foo'});
     });
 
@@ -99,7 +99,7 @@ void main() {
   group('JsonKeyOutputFunctionsParser tests', () {
     test('JsonKeyOutputFunctionsParser from ChatResult', () async {
       final res = await JsonKeyOutputFunctionsParser(keyName: 'foo')
-          .parseResult(result.generations);
+          .parseResult(result);
       expect(res, 'bar');
     });
 

--- a/packages/langchain_core/test/output_parsers/string_test.dart
+++ b/packages/langchain_core/test/output_parsers/string_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unused_element
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/llms.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:test/test.dart';
@@ -7,18 +8,26 @@ import 'package:test/test.dart';
 void main() {
   group('StringOutputParser tests', () {
     test('StringOutputParser from LLMResult', () async {
-      const result = LLMResult(generations: [LLMGeneration('Hello world!')]);
-      final res =
-          await const StringOutputParser().parseResult(result.generations);
+      const result = LLMResult(
+        id: 'id',
+        output: 'Hello world!',
+        finishReason: FinishReason.stop,
+        metadata: {},
+        usage: LanguageModelUsage(),
+      );
+      final res = await const StringOutputParser().parseResult(result);
       expect(res, 'Hello world!');
     });
 
     test('StringOutputParser from ChatResult', () async {
       const result = ChatResult(
-        generations: [ChatGeneration(AIChatMessage(content: 'Hello world!'))],
+        id: 'id',
+        output: AIChatMessage(content: 'Hello world!'),
+        finishReason: FinishReason.stop,
+        metadata: {},
+        usage: LanguageModelUsage(),
       );
-      final res =
-          await const StringOutputParser().parseResult(result.generations);
+      final res = await const StringOutputParser().parseResult(result);
       expect(res, 'Hello world!');
     });
   });

--- a/packages/langchain_core/test/runnables/binding_test.dart
+++ b/packages/langchain_core/test/runnables/binding_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unused_element
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_core/runnables.dart';
@@ -71,7 +72,11 @@ class _FakeOptionsChatModel
             .split('');
         return Stream.fromIterable(prompt).map(
           (final char) => ChatResult(
-            generations: [ChatGeneration(AIChatMessage(content: char))],
+            id: 'fake-options-chat-model',
+            output: AIChatMessage(content: char),
+            finishReason: FinishReason.stop,
+            metadata: const {},
+            usage: const LanguageModelUsage(),
           ),
         );
       },

--- a/packages/langchain_core/test/runnables/invoke_test.dart
+++ b/packages/langchain_core/test/runnables/invoke_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: unused_element
 import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/documents.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/llms.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:langchain_core/prompts.dart';
@@ -49,20 +50,24 @@ void main() {
     test('LLM as Runnable', () async {
       const run = FakeEchoLLM();
       final res = await run.invoke(PromptValue.string('Hello world!'));
-      expect(res.firstOutputAsString, 'Hello world!');
+      expect(res.output, 'Hello world!');
     });
 
     test('ChatModel as Runnable', () async {
       const run = FakeEchoChatModel();
       final res = await run.invoke(PromptValue.string('Hello world!'));
-      expect(res.firstOutputAsString, 'Hello world!');
+      expect(res.output.content, 'Hello world!');
     });
 
     test('OutputParser as Runnable', () async {
       const run = StringOutputParser();
       final res = await run.invoke(
         const LLMResult(
-          generations: [LLMGeneration('Hello world!')],
+          id: 'id',
+          output: 'Hello world!',
+          finishReason: FinishReason.stop,
+          metadata: {},
+          usage: LanguageModelUsage(),
         ),
       );
       expect(res, 'Hello world!');

--- a/packages/langchain_core/test/runnables/stream_test.dart
+++ b/packages/langchain_core/test/runnables/stream_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: unused_element
 import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/documents.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/llms.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:langchain_core/prompts.dart';
@@ -69,7 +70,7 @@ void main() {
       expect(streamList.length, 12);
       expect(streamList, isA<List<LLMResult>>());
 
-      final res = streamList.map((final i) => i.firstOutputAsString).join();
+      final res = streamList.map((final i) => i.output).join();
 
       expect(res, 'Hello world!');
     });
@@ -82,7 +83,7 @@ void main() {
       expect(streamList.length, 12);
       expect(streamList, isA<List<ChatResult>>());
 
-      final res = streamList.map((final i) => i.firstOutputAsString).join();
+      final res = streamList.map((final i) => i.output.content).join();
       expect(res, 'Hello world!');
     });
 
@@ -90,7 +91,11 @@ void main() {
       const run = StringOutputParser();
       final stream = run.stream(
         const LLMResult(
-          generations: [LLMGeneration('Hello world!')],
+          id: 'id',
+          output: 'Hello world!',
+          finishReason: FinishReason.stop,
+          metadata: {},
+          usage: LanguageModelUsage(),
         ),
       );
 

--- a/packages/langchain_google/lib/src/llms/vertex_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai/mappers.dart
@@ -1,46 +1,33 @@
+// ignore_for_file: public_member_api_docs
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/llms.dart';
 import 'package:vertex_ai/vertex_ai.dart';
 
-/// Mapper for [VertexAITextModelResponse] to [LLMResult].
 extension VertexAITextModelResponseMapper on VertexAITextModelResponse {
-  /// Converts a [VertexAITextModelResponse] to a [LLMResult].
-  LLMResult toLLMResult(final String model) {
+  LLMResult toLLMResult(final String id, final String model) {
+    final prediction = predictions.first;
     return LLMResult(
-      generations: predictions
-          .map((final prediction) => prediction.toLLMGeneration())
-          .toList(growable: false),
-      usage: metadata.token.toLanguageModelUsage(),
-      modelOutput: {
+      id: id,
+      output: prediction.content,
+      finishReason: FinishReason.unspecified,
+      metadata: {
         'model': model,
+        'citations': prediction.citations.firstOrNull?.toMap(),
+        'safety_attributes': prediction.safetyAttributes.toMap(),
       },
+      usage: _mapUsage(metadata.token),
     );
   }
-}
 
-/// Mapper for [VertexAITextModelPrediction] to [LLMGeneration].
-extension _VertexAITextModelPredictionMapper on VertexAITextModelPrediction {
-  LLMGeneration toLLMGeneration() {
-    return LLMGeneration(
-      content,
-      generationInfo: {
-        'citations': citations,
-        'safety_attributes': safetyAttributes,
-      },
-    );
-  }
-}
-
-/// Mapper for [_VertexAIResponseMetadataTokenMapper] to [LanguageModelUsage].
-extension _VertexAIResponseMetadataTokenMapper
-    on VertexAITextModelResponseMetadataToken {
-  LanguageModelUsage toLanguageModelUsage() {
+  LanguageModelUsage _mapUsage(
+    final VertexAITextModelResponseMetadataToken usage,
+  ) {
     return LanguageModelUsage(
-      promptTokens: inputTotalTokens,
-      promptBillableCharacters: inputTotalBillableCharacters,
-      responseTokens: outputTotalTokens,
-      responseBillableCharacters: outputTotalBillableCharacters,
-      totalTokens: inputTotalTokens + outputTotalTokens,
+      promptTokens: usage.inputTotalTokens,
+      promptBillableCharacters: usage.inputTotalBillableCharacters,
+      responseTokens: usage.outputTotalTokens,
+      responseBillableCharacters: usage.outputTotalBillableCharacters,
+      totalTokens: usage.inputTotalTokens + usage.outputTotalTokens,
     );
   }
 }

--- a/packages/langchain_google/lib/src/llms/vertex_ai/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai/vertex_ai.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain_core/llms.dart';
 import 'package:langchain_core/prompts.dart';
+import 'package:uuid/uuid.dart';
 import 'package:vertex_ai/vertex_ai.dart';
 
 import 'mappers.dart';
@@ -141,6 +142,9 @@ class VertexAI extends BaseLLM<VertexAIOptions> {
   /// Scope required for Vertex AI API calls.
   static const cloudPlatformScope = VertexAIGenAIClient.cloudPlatformScope;
 
+  /// A UUID generator.
+  late final Uuid _uuid = const Uuid();
+
   @override
   String get modelType => 'vertex-ai';
 
@@ -149,6 +153,7 @@ class VertexAI extends BaseLLM<VertexAIOptions> {
     final PromptValue input, {
     final VertexAIOptions? options,
   }) async {
+    final id = _uuid.v4();
     final model =
         options?.model ?? defaultOptions.model ?? throwNullModelError();
     final result = await client.text.predict(
@@ -171,7 +176,7 @@ class VertexAI extends BaseLLM<VertexAIOptions> {
             options?.candidateCount ?? defaultOptions.candidateCount ?? 1,
       ),
     );
-    return result.toLLMResult(model);
+    return result.toLLMResult(id, model);
   }
 
   @override

--- a/packages/langchain_google/test/chat_models/vertex_ai/chat_vertex_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai/chat_vertex_ai_test.dart
@@ -82,7 +82,7 @@ void main() async {
           ChatMessage.humanText('Good, what is your name?'),
         ]),
       );
-      expect(res.generations.first.output.content, isNotEmpty);
+      expect(res.output.content, isNotEmpty);
     });
 
     test('Test model output contains metadata', () async {
@@ -98,12 +98,12 @@ void main() async {
       final res = await chat.invoke(
         PromptValue.chat([ChatMessage.humanText('Hello, how are you?')]),
       );
-      expect(res.modelOutput, isNotNull);
-      expect(res.modelOutput!['model'], chat.defaultOptions.model);
-      expect(res.usage?.promptTokens, isNotNull);
-      expect(res.usage?.promptBillableCharacters, isNotNull);
-      expect(res.usage?.responseTokens, isNotNull);
-      expect(res.usage?.responseBillableCharacters, isNotNull);
+      expect(res.metadata, isNotEmpty);
+      expect(res.metadata['model'], chat.defaultOptions.model);
+      expect(res.usage.promptTokens, isNotNull);
+      expect(res.usage.promptBillableCharacters, isNotNull);
+      expect(res.usage.responseTokens, isNotNull);
+      expect(res.usage.responseBillableCharacters, isNotNull);
     });
 
     test('Test ChatVertexAI wrapper with system message', () async {
@@ -137,8 +137,8 @@ void main() async {
         ]),
         options: const ChatVertexAIOptions(stopSequences: ['4']),
       );
-      expect(res.firstOutputAsString, contains('123'));
-      expect(res.firstOutputAsString, isNot(contains('456789')));
+      expect(res.output.content, contains('123'));
+      expect(res.output.content, isNot(contains('456789')));
 
       // call options should override defaults
       final res2 = await chat.invoke(
@@ -151,39 +151,8 @@ void main() async {
           stopSequences: ['5'],
         ),
       );
-      expect(res2.firstOutputAsString, contains('1234'));
-      expect(res2.firstOutputAsString, isNot(contains('56789')));
-    });
-
-    test('Test model candidates count', skip: true, () async {
-      // It seems that the Vertex AI Chat API ignores the candidateCount
-      // parameter at the moment
-      final chat = ChatVertexAI(
-        httpClient: authHttpClient,
-        project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
-        defaultOptions: const ChatVertexAIOptions(
-          temperature: 1,
-          candidateCount: 3,
-        ),
-      );
-      final res = await chat.invoke(
-        PromptValue.chat([
-          ChatMessage.humanText('Suggest a name for a LLM framework for Dart'),
-        ]),
-      );
-      expect(res.generations.length, 3);
-
-      // call options should override defaults
-      final res2 = await chat.invoke(
-        PromptValue.chat([
-          ChatMessage.humanText('Suggest a name for a LLM framework for Dart'),
-        ]),
-        options: const ChatVertexAIOptions(
-          temperature: 1,
-          candidateCount: 5,
-        ),
-      );
-      expect(res2.generations.length, 5);
+      expect(res2.output.content, contains('1234'));
+      expect(res2.output.content, isNot(contains('56789')));
     });
 
     test('Test countTokens string', () async {
@@ -195,7 +164,7 @@ void main() async {
 
       final numTokens = await chat.countTokens(prompt);
       final generation = await chat.invoke(prompt);
-      expect(numTokens, generation.usage!.promptTokens);
+      expect(numTokens, generation.usage.promptTokens);
     });
 
     test('Test countTokens messages', () async {

--- a/packages/langchain_google/test/llms/vertex_ai_test.dart
+++ b/packages/langchain_google/test/llms/vertex_ai_test.dart
@@ -72,7 +72,7 @@ Future<void> main() async {
       final res = await llm.invoke(
         PromptValue.string('Hello, how are you?'),
       );
-      expect(res.generations.length, 1);
+      expect(res.output, isNotEmpty);
     });
 
     test('Test model output contains metadata', () async {
@@ -88,12 +88,12 @@ Future<void> main() async {
       final res = await llm.invoke(
         PromptValue.string('Hello, how are you?'),
       );
-      expect(res.modelOutput, isNotNull);
-      expect(res.modelOutput!['model'], llm.defaultOptions.model);
-      expect(res.usage?.promptTokens, isNotNull);
-      expect(res.usage?.promptBillableCharacters, isNotNull);
-      expect(res.usage?.responseTokens, isNotNull);
-      expect(res.usage?.responseBillableCharacters, isNotNull);
+      expect(res.metadata, isNotEmpty);
+      expect(res.metadata['model'], llm.defaultOptions.model);
+      expect(res.usage.promptTokens, isNotNull);
+      expect(res.usage.promptBillableCharacters, isNotNull);
+      expect(res.usage.responseTokens, isNotNull);
+      expect(res.usage.responseBillableCharacters, isNotNull);
     });
 
     test('Test model stop sequence', () async {
@@ -111,8 +111,8 @@ Future<void> main() async {
           'List the numbers from 1 to 9 in order without any spaces or commas',
         ),
       );
-      expect(res.firstOutputAsString, contains('123'));
-      expect(res.firstOutputAsString, isNot(contains('456789')));
+      expect(res.output, contains('123'));
+      expect(res.output, isNot(contains('456789')));
 
       // call options should override defaults
       final res2 = await llm.invoke(
@@ -123,35 +123,8 @@ Future<void> main() async {
           stopSequences: ['5'],
         ),
       );
-      expect(res2.firstOutputAsString, contains('1234'));
-      expect(res2.firstOutputAsString, isNot(contains('56789')));
-    });
-
-    test('Test model candidates count', skip: true, () async {
-      final llm = VertexAI(
-        httpClient: authHttpClient,
-        project: Platform.environment['VERTEX_AI_PROJECT_ID']!,
-        defaultOptions: const VertexAIOptions(
-          publisher: defaultPublisher,
-          model: defaultModel,
-          temperature: 1,
-          candidateCount: 3,
-        ),
-      );
-      final res = await llm.invoke(
-        PromptValue.string('Suggest a name for a LLM framework for Dart'),
-      );
-      expect(res.generations.length, 3);
-
-      // call options should override defaults
-      final res2 = await llm.invoke(
-        PromptValue.string('Suggest a name for a LLM framework for Python'),
-        options: const VertexAIOptions(
-          temperature: 1,
-          candidateCount: 5,
-        ),
-      );
-      expect(res2.generations.length, 5);
+      expect(res2.output, contains('1234'));
+      expect(res2.output, isNot(contains('56789')));
     });
 
     test('Test countTokens', () async {

--- a/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
+++ b/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
@@ -4,6 +4,7 @@ library; // Uses dart:io
 import 'dart:io';
 
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_mistralai/langchain_mistralai.dart';
@@ -53,7 +54,7 @@ void main() {
           [ChatMessage.humanText('Hello, how are you?')],
         ),
       );
-      expect(res.generations.length, 1);
+      expect(res.output.content, isNotEmpty);
     });
 
     test('Test model output contains metadata', () async {
@@ -67,17 +68,14 @@ void main() {
         ]),
       );
       expect(
-        res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
+        res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('123456789'),
       );
-      expect(res.modelOutput, isNotNull);
-      expect(res.modelOutput!['id'], isNotEmpty);
-      expect(res.modelOutput!['created'], greaterThan(0));
-      expect(res.modelOutput!['model'], isNotEmpty);
-      final generation = res.generations.first;
-      expect(generation.generationInfo, isNotNull);
-      expect(generation.generationInfo!['index'], 0);
-      expect(generation.generationInfo!['finish_reason'], isNotNull);
+      expect(res.id, isNotEmpty);
+      expect(res.finishReason, isNot(FinishReason.unspecified));
+      expect(res.metadata, isNotNull);
+      expect(res.metadata['created'], greaterThan(0));
+      expect(res.metadata['model'], isNotEmpty);
     });
 
     test('Test tokenize', () async {
@@ -130,26 +128,25 @@ void main() {
       expect(content, contains('123456789'));
     });
 
-    test('Test response seed', () async {
+    test('Test response seed', skip: true, () async {
       final prompt = PromptValue.string(
         'Why is the sky blue? Reply in one sentence.',
       );
-      const options = ChatMistralAIOptions(randomSeed: 9999);
+      const options = ChatMistralAIOptions(
+        temperature: 0,
+        randomSeed: 9999,
+      );
 
       final res1 = await chatModel.invoke(
         prompt,
         options: options,
       );
-      expect(res1.generations, hasLength(1));
-      final generation1 = res1.generations.first;
 
       final res2 = await chatModel.invoke(
         prompt,
         options: options,
       );
-      expect(res2.generations, hasLength(1));
-      final generation2 = res2.generations.first;
-      expect(generation1.output, generation2.output);
+      expect(res1.output, res2.output);
     });
   });
 }

--- a/packages/langchain_ollama/lib/src/llms/mappers.dart
+++ b/packages/langchain_ollama/lib/src/llms/mappers.dart
@@ -1,30 +1,23 @@
+// ignore_for_file: public_member_api_docs
+import 'dart:convert';
+
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/llms.dart';
 import 'package:ollama_dart/ollama_dart.dart';
 
 import 'types.dart';
 
-/// Mapper for [GenerateCompletionResponse].
 extension LLMResultMapper on GenerateCompletionResponse {
-  /// Converts a [GenerateCompletionResponse] to a [LLMResult].
-  LLMResult toLLMResult({final bool streaming = false}) {
+  LLMResult toLLMResult(final String id, {final bool streaming = false}) {
     return LLMResult(
-      generations: [_toLLMGeneration()],
-      usage: _toLanguageModelUsage(),
-      modelOutput: {
-        'created_at': createdAt,
+      id: id,
+      output: response ?? '',
+      finishReason: FinishReason.unspecified,
+      metadata: {
         'model': model,
-      },
-      streaming: streaming,
-    );
-  }
-
-  LLMGeneration _toLLMGeneration() {
-    return LLMGeneration(
-      response ?? '',
-      generationInfo: {
+        'created_at': createdAt,
         'done': done,
-        'context': context,
+        'context': json.encode(context),
         'total_duration': totalDuration,
         'load_duration': loadDuration,
         'prompt_eval_count': promptEvalCount,
@@ -32,10 +25,12 @@ extension LLMResultMapper on GenerateCompletionResponse {
         'eval_count': evalCount,
         'eval_duration': evalDuration,
       },
+      usage: _mapUsage(),
+      streaming: streaming,
     );
   }
 
-  LanguageModelUsage _toLanguageModelUsage() {
+  LanguageModelUsage _mapUsage() {
     return LanguageModelUsage(
       promptTokens: promptEvalCount,
       responseTokens: evalCount,
@@ -46,9 +41,7 @@ extension LLMResultMapper on GenerateCompletionResponse {
   }
 }
 
-/// Mapper for [OllamaResponseFormat] to [ResponseFormat].
 extension OllamaResponseFormatMapper on OllamaResponseFormat {
-  /// Converts a [OllamaResponseFormat] to a [ResponseFormat].
   ResponseFormat? toResponseFormat() => ResponseFormat.values
       .where((final f) => f.name.toLowerCase() == name.toLowerCase())
       .firstOrNull;

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -3,6 +3,7 @@ import 'package:langchain_core/llms.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:ollama_dart/ollama_dart.dart';
+import 'package:uuid/uuid.dart';
 
 import 'mappers.dart';
 import 'types.dart';
@@ -173,6 +174,9 @@ class Ollama extends BaseLLM<OllamaOptions> {
   /// to get an estimation of the number of tokens in a prompt.
   String encoding;
 
+  /// A UUID generator.
+  late final Uuid _uuid = const Uuid();
+
   @override
   String get modelType => 'ollama';
 
@@ -181,10 +185,11 @@ class Ollama extends BaseLLM<OllamaOptions> {
     final PromptValue input, {
     final OllamaOptions? options,
   }) async {
+    final id = _uuid.v4();
     final completion = await _client.generateCompletion(
       request: _generateCompletionRequest(input.toString(), options: options),
     );
-    return completion.toLLMResult();
+    return completion.toLLMResult(id);
   }
 
   @override
@@ -192,12 +197,13 @@ class Ollama extends BaseLLM<OllamaOptions> {
     final PromptValue input, {
     final OllamaOptions? options,
   }) {
+    final id = _uuid.v4();
     return _client
         .generateCompletionStream(
           request:
               _generateCompletionRequest(input.toString(), options: options),
         )
-        .map((final completion) => completion.toLLMResult(streaming: true));
+        .map((final completion) => completion.toLLMResult(id, streaming: true));
   }
 
   @override

--- a/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
+++ b/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
@@ -116,20 +116,18 @@ void main() {
         ]),
       );
       expect(
-        res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
+        res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('123456789'),
       );
-      expect(res.modelOutput, isNotNull);
-      expect(res.modelOutput!['model'], defaultModel);
-      expect(res.modelOutput!['created_at'], isNotNull);
-      final generation = res.generations.first;
-      expect(generation.generationInfo, isNotNull);
-      expect(generation.generationInfo!['done'], isTrue);
-      expect(generation.generationInfo!['total_duration'], greaterThan(0));
-      expect(generation.generationInfo!['load_duration'], greaterThan(0));
-      expect(generation.generationInfo!['prompt_eval_count'], greaterThan(0));
-      expect(generation.generationInfo!['eval_count'], greaterThan(0));
-      expect(generation.generationInfo!['eval_duration'], greaterThan(0));
+      expect(res.metadata, isNotNull);
+      expect(res.metadata['model'], defaultModel);
+      expect(res.metadata['created_at'], isNotNull);
+      expect(res.metadata['done'], isTrue);
+      expect(res.metadata['total_duration'], greaterThan(0));
+      expect(res.metadata['load_duration'], greaterThan(0));
+      expect(res.metadata['prompt_eval_count'], greaterThan(0));
+      expect(res.metadata['eval_count'], greaterThan(0));
+      expect(res.metadata['eval_duration'], greaterThan(0));
     });
 
     test('Test stop logic on valid configuration', () async {
@@ -205,16 +203,12 @@ void main() {
         prompt,
         options: options,
       );
-      expect(res1.generations, hasLength(1));
-      final generation1 = res1.generations.first;
 
       final res2 = await chatModel.invoke(
         prompt,
         options: options,
       );
-      expect(res2.generations, hasLength(1));
-      final generation2 = res2.generations.first;
-      expect(generation1.output, generation2.output);
+      expect(res1.output, res2.output);
     });
 
     test('Test Multi-turn conversations', () async {
@@ -236,7 +230,7 @@ void main() {
         ),
       );
       expect(
-        res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
+        res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('12356789'),
       );
     });
@@ -263,9 +257,7 @@ void main() {
         ),
       );
 
-      expect(res.generations, hasLength(1));
-      final outputMsg = res.generations.first.output;
-      expect(outputMsg.content.toLowerCase(), contains('apple'));
+      expect(res.output.content.toLowerCase(), contains('apple'));
     });
   });
 }

--- a/packages/langchain_ollama/test/llms/ollama_test.dart
+++ b/packages/langchain_ollama/test/llms/ollama_test.dart
@@ -122,7 +122,7 @@ void main() {
       final res = await llm.invoke(
         PromptValue.string('Hello, how are you?'),
       );
-      expect(res.generations.length, 1);
+      expect(res.output, isNotEmpty);
     });
 
     test('Test model output contains metadata', () async {
@@ -134,21 +134,19 @@ void main() {
         ),
       );
       expect(
-        res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
+        res.output.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('123456789'),
       );
-      expect(res.modelOutput, isNotNull);
-      expect(res.modelOutput!['model'], defaultModel);
-      expect(res.modelOutput!['created_at'], isNotNull);
-      final generation = res.generations.first;
-      expect(generation.generationInfo, isNotNull);
-      expect(generation.generationInfo!['done'], isTrue);
-      expect(generation.generationInfo!['context'], isNotEmpty);
-      expect(generation.generationInfo!['total_duration'], greaterThan(0));
-      expect(generation.generationInfo!['load_duration'], greaterThan(0));
-      expect(generation.generationInfo!['prompt_eval_count'], greaterThan(0));
-      expect(generation.generationInfo!['eval_count'], greaterThan(0));
-      expect(generation.generationInfo!['eval_duration'], greaterThan(0));
+      expect(res.metadata, isNotNull);
+      expect(res.metadata['model'], defaultModel);
+      expect(res.metadata['created_at'], isNotNull);
+      expect(res.metadata['done'], isTrue);
+      expect(res.metadata['context'], isNotEmpty);
+      expect(res.metadata['total_duration'], greaterThan(0));
+      expect(res.metadata['load_duration'], greaterThan(0));
+      // expect(res.metadata['prompt_eval_count'], greaterThan(0)); // TODO check why it's null
+      expect(res.metadata['eval_count'], greaterThan(0));
+      expect(res.metadata['eval_duration'], greaterThan(0));
     });
 
     test('Test stop logic on valid configuration', () async {
@@ -218,7 +216,7 @@ void main() {
         options: const OllamaOptions(raw: true),
       );
       expect(
-        res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
+        res.output.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('123456789'),
       );
     });
@@ -231,7 +229,7 @@ void main() {
         options: const OllamaOptions(format: OllamaResponseFormat.json),
       );
       expect(
-        res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
+        res.output.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('[1,2,3,4,5,6,7,8,9]'),
       );
     });
@@ -246,16 +244,13 @@ void main() {
         prompt,
         options: options,
       );
-      expect(res1.generations, hasLength(1));
-      final generation1 = res1.generations.first;
 
       final res2 = await llm.invoke(
         prompt,
         options: options,
       );
-      expect(res2.generations, hasLength(1));
-      final generation2 = res2.generations.first;
-      expect(generation1.output, generation2.output);
+
+      expect(res1.output, res2.output);
     });
   });
 }

--- a/packages/langchain_openai/example/langchain_openai_example.dart
+++ b/packages/langchain_openai/example/langchain_openai_example.dart
@@ -12,13 +12,15 @@ void main() async {
 
 /// The most basic building block of LangChain is calling an LLM on some input.
 Future<void> _example1() async {
-  final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
-  final openai = OpenAI(
-    apiKey: openaiApiKey,
+  final openAiApiKey = Platform.environment['OPENAI_API_KEY'];
+  final llm = OpenAI(
+    apiKey: openAiApiKey,
     defaultOptions: const OpenAIOptions(temperature: 0.9),
   );
-  final result = await openai('Tell me a joke');
-  print(result);
+  final LLMResult res = await llm.invoke(
+    PromptValue.string('Tell me a joke'),
+  );
+  print(res);
 }
 
 /// The most frequent use case is to create a chat-bot.

--- a/packages/langchain_openai/lib/src/agents/functions.dart
+++ b/packages/langchain_openai/lib/src/agents/functions.dart
@@ -261,11 +261,9 @@ class OpenAIFunctionsAgentOutputParser extends BaseLLMOutputParser<
 
   @override
   Future<List<BaseAgentAction>> parseResult(
-    final List<LanguageModelGeneration<AIChatMessage>> result,
+    final LanguageModelResult<AIChatMessage> result,
   ) async {
-    final generation = result.first;
-    final message = generation.output;
-    return parseMessage(message);
+    return parseMessage(result.output);
   }
 
   /// Parses the [message] and returns the corresponding [BaseAgentAction].

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -238,7 +238,7 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     final completion = await _client.createCompletion(
       request: _createCompletionRequest(input.toString(), options: options),
     );
-    return completion.toLLMResult();
+    return completion.toLLMResult(completion.id);
   }
 
   @override
@@ -250,7 +250,12 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
         .createCompletionStream(
           request: _createCompletionRequest(input.toString(), options: options),
         )
-        .map((final completion) => completion.toLLMResult(streaming: true));
+        .map(
+          (final completion) => completion.toLLMResult(
+            completion.id,
+            streaming: true,
+          ),
+        );
   }
 
   @override

--- a/packages/langchain_openai/test/chat_models/anyscale_test.dart
+++ b/packages/langchain_openai/test/chat_models/anyscale_test.dart
@@ -4,6 +4,7 @@ library; // Uses dart:io
 import 'dart:io';
 
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_openai/langchain_openai.dart';
 import 'package:test/test.dart';
@@ -44,21 +45,18 @@ void main() {
 
         expect(res.id, isNotEmpty);
         expect(
-          res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
+          res.finishReason,
+          isNot(FinishReason.unspecified),
+          reason: model,
+        );
+        expect(
+          res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
           contains('123456789'),
           reason: model,
         );
-        expect(res.modelOutput, isNotNull, reason: model);
-        expect(res.modelOutput!['created'], greaterThan(0), reason: model);
-        expect(res.modelOutput!['model'], isNotEmpty, reason: model);
-        final generation = res.generations.first;
-        expect(generation.generationInfo, isNotNull, reason: model);
-        expect(generation.generationInfo!['index'], 0, reason: model);
-        expect(
-          generation.generationInfo!['finish_reason'],
-          isNotNull,
-          reason: model,
-        );
+        expect(res.metadata, isNotNull, reason: model);
+        expect(res.metadata['created'], greaterThan(0), reason: model);
+        expect(res.metadata['model'], isNotEmpty, reason: model);
         await Future<void>.delayed(const Duration(seconds: 1)); // Rate limit
       }
     });
@@ -85,7 +83,7 @@ void main() {
         String content = '';
         int count = 0;
         await for (final res in stream) {
-          content += res.firstOutputAsString.replaceAll(RegExp(r'[\s\n,]'), '');
+          content += res.output.content.replaceAll(RegExp(r'[\s\n,]'), '');
           count++;
         }
         expect(count, greaterThan(1), reason: model);

--- a/packages/langchain_openai/test/chat_models/open_router_test.dart
+++ b/packages/langchain_openai/test/chat_models/open_router_test.dart
@@ -44,20 +44,12 @@ void main() {
 
         expect(res.id, isNotEmpty);
         expect(
-          res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
+          res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
           contains('123456789'),
         );
-        expect(res.modelOutput, isNotNull, reason: model);
-        expect(res.modelOutput!['created'], greaterThan(0), reason: model);
-        expect(res.modelOutput!['model'], isNotEmpty, reason: model);
-        final generation = res.generations.first;
-        expect(generation.generationInfo, isNotNull, reason: model);
-        expect(generation.generationInfo!['index'], 0, reason: model);
-        expect(
-          generation.generationInfo!['finish_reason'],
-          isNotNull,
-          reason: model,
-        );
+        expect(res.metadata, isNotEmpty, reason: model);
+        expect(res.metadata['created'], greaterThan(0), reason: model);
+        expect(res.metadata['model'], isNotEmpty, reason: model);
       }
     });
 
@@ -84,7 +76,7 @@ void main() {
         String content = '';
         int count = 0;
         await for (final res in stream) {
-          content += res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), '');
+          content += res.output.content.replaceAll(RegExp(r'[\s\n]'), '');
           count++;
         }
         expect(count, greaterThan(1), reason: model);

--- a/packages/langchain_openai/test/chat_models/together_ai_test.dart
+++ b/packages/langchain_openai/test/chat_models/together_ai_test.dart
@@ -43,20 +43,12 @@ void main() {
 
         expect(res.id, isNotEmpty);
         expect(
-          res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), ''),
+          res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
           contains('123456789'),
         );
-        expect(res.modelOutput, isNotNull, reason: model);
-        expect(res.modelOutput!['created'], greaterThan(0), reason: model);
-        expect(res.modelOutput!['model'], isNotEmpty, reason: model);
-        final generation = res.generations.first;
-        expect(generation.generationInfo, isNotNull, reason: model);
-        expect(generation.generationInfo!['index'], 0, reason: model);
-        expect(
-          generation.generationInfo!['finish_reason'],
-          isNotNull,
-          reason: model,
-        );
+        expect(res.metadata, isNotEmpty, reason: model);
+        expect(res.metadata['created'], greaterThan(0), reason: model);
+        expect(res.metadata['model'], isNotEmpty, reason: model);
         await Future<void>.delayed(const Duration(seconds: 1)); // Rate limit
       }
     });
@@ -82,7 +74,7 @@ void main() {
         String content = '';
         int count = 0;
         await for (final res in stream) {
-          content += res.firstOutputAsString.replaceAll(RegExp(r'[\s\n]'), '');
+          content += res.output.content.replaceAll(RegExp(r'[\s\n]'), '');
           count++;
         }
         expect(count, greaterThan(1), reason: model);

--- a/packages/langchain_openai/test/llms/openai_test.dart
+++ b/packages/langchain_openai/test/llms/openai_test.dart
@@ -78,7 +78,7 @@ void main() {
       final res = await llm.invoke(
         PromptValue.string('Hello, how are you?'),
       );
-      expect(res.generations.length, 1);
+      expect(res.output, isNotEmpty);
     });
 
     test('Test model output contains metadata', () async {
@@ -92,10 +92,10 @@ void main() {
       final res = await llm.invoke(
         PromptValue.string('Hello, how are you?'),
       );
-      expect(res.modelOutput, isNotNull);
-      expect(res.modelOutput!['id'], isNotEmpty);
-      expect(res.modelOutput!['created'], isNotNull);
-      expect(res.modelOutput!['model'], llm.defaultOptions.model);
+      expect(res.id, isNotEmpty);
+      expect(res.metadata, isNotNull);
+      expect(res.metadata['created'], isNotNull);
+      expect(res.metadata['model'], llm.defaultOptions.model);
     });
 
     test('Test stop logic on valid configuration', () async {
@@ -110,24 +110,6 @@ void main() {
       final res = await llm(query, options: const OpenAIOptions(stop: ['3']));
       expect(res.contains('2.'), isTrue);
       expect(res.contains('3.'), isFalse);
-    });
-
-    test('Test OpenAI wrapper with multiple completions', () async {
-      final llm = OpenAI(
-        apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(
-          model: defaultModel,
-          n: 5,
-          bestOf: 5,
-        ),
-      );
-      final res = await llm.invoke(
-        PromptValue.string('Hello, how are you?'),
-      );
-      expect(res.generations.length, 5);
-      for (final generation in res.generations) {
-        expect(generation.output, isNotEmpty);
-      }
     });
 
     test('Test tokenize', () async {
@@ -187,18 +169,13 @@ void main() {
       );
 
       final res1 = await llm.invoke(prompt);
-      expect(res1.generations, hasLength(1));
-      final generation1 = res1.generations.first;
-
       final res2 = await llm.invoke(prompt);
-      expect(res2.generations, hasLength(1));
-      final generation2 = res2.generations.first;
 
       expect(
-        res1.modelOutput?['system_fingerprint'],
-        res2.modelOutput?['system_fingerprint'],
+        res1.metadata['system_fingerprint'],
+        res2.metadata['system_fingerprint'],
       );
-      expect(generation1.output, generation2.output);
+      expect(res1.output, res2.output);
     });
   });
 }

--- a/packages/vertex_ai/lib/src/gen_ai/models/model.dart
+++ b/packages/vertex_ai/lib/src/gen_ai/models/model.dart
@@ -56,6 +56,18 @@ class VertexAIPredictionCitation {
     );
   }
 
+  /// Converts this [VertexAIPredictionCitation] to a JSON map.
+  Map<String, dynamic> toMap() {
+    return {
+      'startIndex': startIndex,
+      'endIndex': endIndex,
+      'url': url,
+      'title': title,
+      'license': license,
+      'publicationDate': publicationDate?.toIso8601String(),
+    };
+  }
+
   @override
   bool operator ==(covariant final VertexAIPredictionCitation other) =>
       identical(this, other) ||
@@ -145,6 +157,44 @@ class VertexAIPredictionSafetyAttributes {
           (safetyAttributesJson['scores'] as List<dynamic>? ?? const []).cast(),
       blocked: safetyAttributesJson['blocked'] as bool? ?? false,
     );
+  }
+
+  /// Converts this [VertexAIPredictionSafetyAttributes] to a JSON map.
+  Map<String, dynamic> toMap() {
+    return {
+      'categories': categories
+          .map(
+            (final category) => switch (category) {
+              VertexAIPredictionSafetyAttributesCategory.derogatory =>
+                'Derogatory',
+              VertexAIPredictionSafetyAttributesCategory.toxic => 'Toxic',
+              VertexAIPredictionSafetyAttributesCategory.sexual => 'Sexual',
+              VertexAIPredictionSafetyAttributesCategory.violent => 'Violent',
+              VertexAIPredictionSafetyAttributesCategory.insult => 'Insult',
+              VertexAIPredictionSafetyAttributesCategory.profanity =>
+                'Profanity',
+              VertexAIPredictionSafetyAttributesCategory.deathHarmAndTragedy =>
+                'Death, Harm & Tragedy',
+              VertexAIPredictionSafetyAttributesCategory.firearmsAndWeapons =>
+                'Firearms & Weapons',
+              VertexAIPredictionSafetyAttributesCategory.publicSafety =>
+                'Public Safety',
+              VertexAIPredictionSafetyAttributesCategory.health => 'Health',
+              VertexAIPredictionSafetyAttributesCategory.religionAndBelief =>
+                'Religion & Belief',
+              VertexAIPredictionSafetyAttributesCategory.drugs => 'Drugs',
+              VertexAIPredictionSafetyAttributesCategory.warAndConflict =>
+                'War & Conflict',
+              VertexAIPredictionSafetyAttributesCategory.finance => 'Finance',
+              VertexAIPredictionSafetyAttributesCategory.politics => 'Politics',
+              VertexAIPredictionSafetyAttributesCategory.legal => 'Legal',
+              VertexAIPredictionSafetyAttributesCategory.unknown => 'Unknown',
+            },
+          )
+          .toList(growable: false),
+      'scores': scores,
+      'blocked': blocked,
+    };
   }
 
   @override


### PR DESCRIPTION
Relates to https://github.com/davidmigloz/langchain_dart/issues/266

We've updated the `LanguageModelResult` class structure, along with its subclasses `LLMResult` and `ChatResult`, to simplify their design. Previously, these classes contained a list of `generations` for each model's outputs, complicating single-output access since users often require only one generation.

**Key Changes:**

1. **Simplified design**: each `LanguageModelResult` now stores a single output directly. To generate multiple outputs, use the new `.batch` method (instead of `.invoke` or `.stream`), which returns a list of `LanguageModelResult` instances.

2. **Unified finish reason**: we've standardized the finish reason across all providers, simplifying the process of switching between providers for users who have logic dependent on the finish reason.

**Result class details:**

LLMs like `OpenAI` returns an `LLMResult`, chat models like `ChatOpenAI` returns a `ChatResult`. Both classes inherit from `LanguageModelResult` and contain:
   - `id`: Identifier for the generation.
   - `output`: The text output (a `String` for LLMs) or an `AIChatMessage` for chat models.
   - `finishReason`: Enum specifying why the model ceased token generation.
   - `metadata`: A map containing provider-specific details about the generation (such as model info, block reason, citations, etc.).
   - `usage`: Token usage statistics, provided by the model.
   - `streaming`: Indicates if the result is streamed.

## Migration guide

### LLM output

To get the String output from an LLM (e.g. `OpenAI`):

```dart
final res = await llm.invoke(promptValue);
```

**Before:** The following options were available to get the String output
```dart
final output1 = res.generations.first.output;
final output2 = res.firstOutput;
final output3 = res.firstOutputAsString;
```

**After:**
```dart
final output1 = res.output; // The output is already a String
final output2 = res.outputAsString; // You can also use `outputAsString` which is available in both LLMs and ChatModels
```

### Chat model output

To get the String output from a Chat Model (e.g. `ChatOpenAI`):

```dart
final res = await chatModel.invoke(promptValue);
```

**Before:** The following options were available to get the String output
```dart
final output1 = res.generations.first.output.content;
final output2 = res.firstOutput.content;
final output3 = res.firstOutputAsString;
```

**After:**
```dart
final output1 = res.output.content; // The output of a Chat Models is an AIChatMessage, so we need to get the `content`
final output2 = res.outputAsString; // You can also use `outputAsString` which is available in both LLMs and ChatModels
```

### StringOutputParser

If you are using a `StringOutputParser` in a chain to get the output as String you don't have to change anything.

```dart
final chain = promptTemplate.pipe(llm).pipe(StringOutputParser());
final outptut = await chain.invoke({'foo': 'bar'});
```

### Finish reason

To get the finish reason of a generation:

**Before:** It was part of the `generationInfo` metadata, and it was of type String with different values for different providers
```dart
final finishReason = res.generations.first.generationInfo?['finish_reason'];
```

**After:** It is now an enum with standardized values for all the providers. If a providers doesn't return a finish reason, `FinishReason.unspecified` is returned.
```dart
final finishReason = res.finishReason;
```

Unified finish reasons:
```dart
enum FinishReason {
  /// The model hit a natural stop point or a provided stop sequence.
  stop,
  /// The maximum number of tokens specified in the request was reached.
  length,
  /// The content was flagged for content filter reasons.
  contentFilter,
  /// The content content was flagged for recitation reasons.
  recitation,
  /// The model called a tool.
  toolCalls,
  /// The finish reason is unspecified.
  unspecified,
}
```

### ID

Before not every provider was returning a generation id, now all of them do.

```dart
final id = res.id;
```

### Token usage

You can still access the number of tokens consumed for the generation (not every provider returns it).

```dart
final usage = res.usage;
```

### Other metadata

To access other provider-specific metadata:

**Before:**
```dart
final metadata1 = res.modelOutput;
final metadata2 = res.generations.first.generationInfo;
```

**After:**
```dart
final metadata = res.metadata;
```

### Batch generation 

Some providers (e.g. `OpenAI`) used to allow generating multiple outputs for the same prompt in a single request:

**Before:**
```dart
final chatModel = ChatOpenAI();
final res = await chatModel.invoke(
  PromptValue.string('prompt'),
  options: const ChatOpenAIOptions(
    n: 3,
  ),
);
final output1 = res.generations[0].output.content;
final output2 = res.generations[1].output.content;
final output3 = res.generations[2].output.content;
```

The same functionality can now be achieved with the new standard `.bach` method that every `Runnable` supports.

**After:**
```dart
TODO
```



