### PR TITLE
refactor!: Simplify Output Parsers

### DIFF
--- a/docs/expression_language/cookbook/adding_memory.md
+++ b/docs/expression_language/cookbook/adding_memory.md
@@ -5,7 +5,7 @@ This shows how to add memory to an arbitrary chain. Right now, you can use the m
 ```dart
 final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
 final model = ChatOpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser();
+const stringOutputParser = StringOutputParser<ChatResult>();
 final memory = ConversationBufferMemory(returnMessages: true);
 
 final promptTemplate = ChatPromptTemplate.fromPromptMessages([

--- a/docs/expression_language/cookbook/multiple_chains.md
+++ b/docs/expression_language/cookbook/multiple_chains.md
@@ -5,7 +5,7 @@ Runnables can easily be used to combine multiple Chains:
 ```dart
 final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
 final model = ChatOpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser();
+const stringOutputParser = StringOutputParser<ChatResult>();
 
 final promptTemplate1 = ChatPromptTemplate.fromTemplate(
   'What is the city {person} is from? Only respond with the name of the city.',
@@ -62,7 +62,7 @@ final promptTemplate4 = ChatPromptTemplate.fromTemplate(
   'What is the color of {fruit} and the flag of {country}?',
 );
 
-final modelParser = model | const StringOutputParser();
+final modelParser = model | StringOutputParser();
 
 final colorGenerator = Runnable.getMapFromInput('attribute') |
     promptTemplate1 |
@@ -102,7 +102,7 @@ Let's see an example:
 ```dart
 final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
 final model = ChatOpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser();
+const stringOutputParser = StringOutputParser<ChatResult>();
 
 final planner = Runnable.getMapFromInput() |
     ChatPromptTemplate.fromTemplate('Generate an argument about: {input}') |

--- a/docs/expression_language/cookbook/prompt_llm_parser.md
+++ b/docs/expression_language/cookbook/prompt_llm_parser.md
@@ -148,7 +148,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
   'Tell me a joke about {foo}',
 );
 
-final chain = promptTemplate | model | const StringOutputParser();
+final chain = promptTemplate | model | StringOutputParser();
 
 final res = await chain.invoke({'foo': 'bears'});
 print(res);
@@ -227,7 +227,7 @@ To make invocation even simpler, we can add a `RunnableMap` to take care of crea
 final map = Runnable.fromMap({
   'foo': Runnable.passthrough(),
 });
-final chain = map | promptTemplate | model | const StringOutputParser();
+final chain = map | promptTemplate | model | StringOutputParser();
 ```
 
 *`Runnable.passthrough()` is a convenience method that creates a `RunnablePassthrough` object. This is a `Runnable` that takes the input it receives and passes it through as output.*
@@ -238,7 +238,7 @@ However, this is a bit verbose. We can simplify it by using `Runnable.getItemFro
 final chain = Runnable.getMapFromInput('foo') |
     promptTemplate |
     model |
-    const StringOutputParser();
+    StringOutputParser();
 ```
 
 Now, we can invoke the chain with just the input we care about:

--- a/docs/expression_language/cookbook/retrieval.md
+++ b/docs/expression_language/cookbook/retrieval.md
@@ -32,7 +32,7 @@ Question: {question}''');
 final chain = Runnable.fromMap({
   'context': retriever | Runnable.fromFunction((docs, _) => docs.join('\n')),
   'question': Runnable.passthrough(),
-}) | promptTemplate | model | const StringOutputParser();
+}) | promptTemplate | model | StringOutputParser();
 
 final res1 = await chain.invoke('What payment methods do you accept?');
 print(res1);
@@ -62,7 +62,7 @@ final chain = Runnable.fromMap({
     }) |
     promptTemplate |
     model |
-    const StringOutputParser();
+    StringOutputParser();
 
 final res1 = await chain.invoke({
   'question': 'What payment methods do you accept?',
@@ -88,7 +88,7 @@ Because we can create `Runnable`s from functions we can add in conversation hist
 ```dart
 final retriever = vectorStore.asRetriever();
 final model = ChatOpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser();
+const stringOutputParser = StringOutputParser<ChatResult>();
 
 final condenseQuestionPrompt = ChatPromptTemplate.fromTemplate('''
 Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
@@ -169,7 +169,7 @@ final retriever = vectorStore.asRetriever(
   ),
 );
 final model = ChatOpenAI(apiKey: openaiApiKey);
-final stringOutputParser = const StringOutputParser();
+const stringOutputParser = StringOutputParser<ChatResult>();
 final memory = ConversationBufferMemory(
   inputKey: 'question',
   outputKey: 'answer',

--- a/docs/expression_language/cookbook/tools.md
+++ b/docs/expression_language/cookbook/tools.md
@@ -5,7 +5,7 @@ Tools are also runnables, and can therefore be used within a chain:
 ```dart
 final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
 final model = ChatOpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser();
+const stringOutputParser = StringOutputParser<ChatResult>();
 
 final promptTemplate = ChatPromptTemplate.fromTemplate('''
 Turn the following user input into a math expression for a calculator. 

--- a/docs/expression_language/get_started.md
+++ b/docs/expression_language/get_started.md
@@ -13,7 +13,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
   'Tell me a joke about {topic}',
 );
 final model = ChatOpenAI(apiKey: openaiApiKey);
-const outputParser = StringOutputParser<AIChatMessage>();
+const outputParser = StringOutputParser<ChatResult>();
 
 final chain = promptTemplate.pipe(model).pipe(outputParser);
 

--- a/docs/expression_language/interface.md
+++ b/docs/expression_language/interface.md
@@ -60,7 +60,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
   'Tell me a joke about {topic}',
 );
 
-final chain = promptTemplate | model | const StringOutputParser();
+final chain = promptTemplate | model | StringOutputParser();
 ```
 
 ### Invoke
@@ -135,10 +135,10 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
 );
 
 // The following three chains are equivalent:
-final chain1 = promptTemplate | model | const StringOutputParser();
-final chain2 = promptTemplate.pipe(model).pipe(const StringOutputParser());
+final chain1 = promptTemplate | model | StringOutputParser();
+final chain2 = promptTemplate.pipe(model).pipe(StringOutputParser());
 final chain3 = Runnable.fromList(
-  [promptTemplate, model, const StringOutputParser()],
+  [promptTemplate, model, StringOutputParser()],
 );
 
 final res = await chain1.invoke({'topic': 'bears'});
@@ -169,7 +169,7 @@ final promptTemplate2 = ChatPromptTemplate.fromTemplate(
 final promptTemplate3 = ChatPromptTemplate.fromTemplate(
   'Is {city} a good city for a {age} years old person?',
 );
-const stringOutputParser = StringOutputParser();
+const stringOutputParser = StringOutputParser<ChatResult>();
 
 final chain = Runnable.fromMap({
   'city': promptTemplate1 | model | stringOutputParser,
@@ -201,7 +201,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
 
 final chain = promptTemplate |
     model.bind(const ChatOpenAIOptions(stop: ['\n'])) |
-    const StringOutputParser();
+    StringOutputParser();
 
 final res = await chain.invoke({'foo': 'bears'});
 print(res);
@@ -245,7 +245,7 @@ final chain = Runnable.fromMap({
     }) |
     promptTemplate |
     model |
-    const StringOutputParser();
+    StringOutputParser();
 
 final res = await chain.invoke({'foo': 'foo', 'bar': 'bar'});
 print(res);
@@ -273,7 +273,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
 final map = Runnable.fromMap({
   'foo': Runnable.passthrough(),
 });
-final chain = map | promptTemplate | model | const StringOutputParser();
+final chain = map | promptTemplate | model | StringOutputParser();
 
 final res = await chain.invoke('bears');
 print(res);
@@ -307,7 +307,7 @@ final chain = Runnable.fromMap({
     }) |
     promptTemplate |
     model |
-    const StringOutputParser();
+    StringOutputParser();
 
 final res = await chain.invoke({
   'question': 'What payment methods do you accept?',
@@ -346,7 +346,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
 final chain = Runnable.getMapFromInput('foo') |
     promptTemplate |
     model |
-    const StringOutputParser();
+    StringOutputParser();
 
 final res = await chain.invoke('bears');
 print(res);

--- a/docs/get_started/quickstart.md
+++ b/docs/get_started/quickstart.md
@@ -157,16 +157,33 @@ For full information on this, see the section on [output parsers](/modules/model
 In this getting started guide, we will write our own output parser - one that converts a comma separated list into a list.
 
 ```dart
-class CommaSeparatedListOutputParser extends BaseOutputParser<AIChatMessage, BaseLangChainOptions, List<String>> {
+class CommaSeparatedListOutputParser 
+    extends BaseOutputParser<ChatResult, OutputParserOptions, List<String>> {
+  
+  const CommaSeparatedListOutputParser()
+      : super(defaultOptions: const OutputParserOptions());
+
   @override
-  Future<List<String>> parse(final String text) async {
-    return text.trim().split(',');
+  Future<List<String>> invoke(
+      final ChatResult input, {
+      final OutputParserOptions? options,
+  }) async {
+    final message = input.output;
+    return message.content.trim().split(',');
   }
 }
 ```
 
 ```dart
-final res = await CommaSeparatedListOutputParser().parse('hi, bye');
+final res = await const CommaSeparatedListOutputParser().invoke(
+  const ChatResult(
+    id: 'id',
+    output: AIChatMessage(content: 'hi, bye'),
+    finishReason: FinishReason.stop,
+    metadata: {},
+    usage: LanguageModelUsage(),
+  ),
+);
 print(res);
 // ['hi',  'bye']
 ```

--- a/docs/modules/model_io/models/chat_models/how_to/streaming.md
+++ b/docs/modules/model_io/models/chat_models/how_to/streaming.md
@@ -17,7 +17,7 @@ final promptTemplate = ChatPromptTemplate.fromPromptMessages([
   ),
 ]);
 final chat = ChatOpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser<AIChatMessage>();
+const stringOutputParser = StringOutputParser<ChatResult>();
 
 final chain = promptTemplate.pipe(chat).pipe(stringOutputParser);
 

--- a/docs/modules/model_io/models/chat_models/integrations/anyscale.md
+++ b/docs/modules/model_io/models/chat_models/integrations/anyscale.md
@@ -39,7 +39,7 @@ final chatModel = ChatOpenAI(
   ),
 );
 
-final chain = promptTemplate | chatModel | const StringOutputParser();
+final chain = promptTemplate | chatModel | StringOutputParser();
 
 final res = await chain.invoke({
   'input_language': 'English',
@@ -72,7 +72,7 @@ final chatModel = ChatOpenAI(
   ),
 );
 
-final chain = promptTemplate.pipe(chatModel).pipe(const StringOutputParser());
+final chain = promptTemplate.pipe(chatModel).pipe(StringOutputParser());
 
 final stream = chain.stream({'max_num': '9'});
 await stream.forEach(print);

--- a/docs/modules/model_io/models/chat_models/integrations/open_router.md
+++ b/docs/modules/model_io/models/chat_models/integrations/open_router.md
@@ -55,7 +55,7 @@ final chatModel = ChatOpenAI(
   ),
 );
 
-final chain = promptTemplate | chatModel | const StringOutputParser();
+final chain = promptTemplate | chatModel | StringOutputParser();
 
 final res = await chain.invoke({
   'input_language': 'English',
@@ -88,7 +88,7 @@ final chatModel = ChatOpenAI(
   ),
 );
 
-final chain = promptTemplate.pipe(chatModel).pipe(const StringOutputParser());
+final chain = promptTemplate.pipe(chatModel).pipe(StringOutputParser());
 
 final stream = chain.stream({'max_num': '9'});
 await stream.forEach(print);

--- a/docs/modules/model_io/models/chat_models/integrations/together_ai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/together_ai.md
@@ -39,7 +39,7 @@ final chatModel = ChatOpenAI(
   ),
 );
 
-final chain = promptTemplate | chatModel | const StringOutputParser();
+final chain = promptTemplate | chatModel | StringOutputParser();
 
 final res = await chain.invoke({
   'input_language': 'English',
@@ -72,7 +72,7 @@ final chatModel = ChatOpenAI(
   ),
 );
 
-final chain = promptTemplate.pipe(chatModel).pipe(const StringOutputParser());
+final chain = promptTemplate.pipe(chatModel).pipe(StringOutputParser());
 
 final stream = chain.stream({'max_num': '9'});
 await stream.forEach(print);

--- a/docs/modules/model_io/models/llms/how_to/llm_streaming.md
+++ b/docs/modules/model_io/models/llms/how_to/llm_streaming.md
@@ -11,7 +11,7 @@ final promptTemplate = PromptTemplate.fromTemplate(
   'List the numbers from 1 to {max_num} in order without any spaces or commas',
 );
 final llm = OpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser<String>();
+const stringOutputParser = StringOutputParser<LLMResult>();
 
 final chain = promptTemplate | llm | stringOutputParser;
 

--- a/docs/modules/model_io/models/llms/integrations/ollama.md
+++ b/docs/modules/model_io/models/llms/integrations/ollama.md
@@ -29,7 +29,7 @@ final llm = Ollama(
     model: 'llama2',
   ),
 );
-final chain = prompt | llm | const StringOutputParser();
+final chain = prompt | llm | StringOutputParser();
 final res = await chain.invoke({'product': 'colorful socks'});
 print(res);
 // -> 'SoleMates'
@@ -46,7 +46,7 @@ final llm = Ollama(
     model: 'llama2',
   ),
 );
-const stringOutputParser = StringOutputParser<String>();
+const stringOutputParser = StringOutputParser<LLMResult>();
 final chain = promptTemplate | llm | stringOutputParser;
 final stream = chain.stream({'max_num': '9'});
 await stream.forEach(print);

--- a/docs/modules/model_io/models/llms/integrations/openai.md
+++ b/docs/modules/model_io/models/llms/integrations/openai.md
@@ -17,7 +17,7 @@ final prompt = PromptTemplate.fromTemplate(
 );
 final llm = OpenAI(apiKey: openaiApiKey);
 
-final chain = prompt | llm | const StringOutputParser();
+final chain = prompt | llm | StringOutputParser();
 
 final res = await chain.invoke({'product': 'colorful socks'});
 print(res);
@@ -33,7 +33,7 @@ final promptTemplate = PromptTemplate.fromTemplate(
   'List the numbers from 1 to {max_num} in order without any spaces or commas',
 );
 final llm = OpenAI(apiKey: openaiApiKey);
-const stringOutputParser = StringOutputParser<String>();
+const stringOutputParser = StringOutputParser<LLMResult>();
 
 final chain = promptTemplate | llm | stringOutputParser;
 

--- a/docs/modules/model_io/output_parsers/string.md
+++ b/docs/modules/model_io/output_parsers/string.md
@@ -14,7 +14,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
 'Tell me a joke about {topic}',
 );
 
-final chain = promptTemplate.pipe(model).pipe(const StringOutputParser());
+final chain = promptTemplate.pipe(model).pipe(StringOutputParser());
 
 final res = await chain.invoke({'topic': 'bears'});
 print(res);
@@ -31,7 +31,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplate(
   'Tell me a joke about {topic}',
 );
 
-final chain = promptTemplate | model | const StringOutputParser();
+final chain = promptTemplate | model | StringOutputParser();
 
 final stream = chain.stream({'topic': 'bears'});
 

--- a/examples/docs_examples/bin/expression_language/cookbook/adding_memory.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/adding_memory.dart
@@ -11,7 +11,7 @@ void main(final List<String> arguments) async {
 Future<void> _chatbotWithMemory() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
   final model = ChatOpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser();
+  const stringOutputParser = StringOutputParser<ChatResult>();
 
   final promptTemplate = ChatPromptTemplate.fromPromptMessages([
     SystemChatMessagePromptTemplate.fromTemplate(

--- a/examples/docs_examples/bin/expression_language/cookbook/multiple_chains.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/multiple_chains.dart
@@ -13,7 +13,7 @@ void main(final List<String> arguments) async {
 Future<void> _multipleChains1() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
   final model = ChatOpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser();
+  const stringOutputParser = StringOutputParser<ChatResult>();
 
   final promptTemplate1 = ChatPromptTemplate.fromTemplate(
     'What is the city {person} is from? Only respond with the name of the city.',
@@ -87,7 +87,7 @@ Future<void> _multipleChains2() async {
 Future<void> _branchingAndMerging() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
   final model = ChatOpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser();
+  const stringOutputParser = StringOutputParser<ChatResult>();
 
   final planner = Runnable.getMapFromInput() |
       ChatPromptTemplate.fromTemplate('Generate an argument about: {input}') |

--- a/examples/docs_examples/bin/expression_language/cookbook/retrieval.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/retrieval.dart
@@ -111,7 +111,7 @@ Future<void> _conversationalRetrievalChain() async {
 
   final retriever = vectorStore.asRetriever();
   final model = ChatOpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser();
+  const stringOutputParser = StringOutputParser<ChatResult>();
 
   final condenseQuestionPrompt = ChatPromptTemplate.fromTemplate('''
 Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
@@ -195,7 +195,7 @@ Future<void> _conversationalRetrievalChainMemoryAndDocs() async {
     ),
   );
   final model = ChatOpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser();
+  const stringOutputParser = StringOutputParser<ChatResult>();
   final memory = ConversationBufferMemory(
     inputKey: 'question',
     outputKey: 'answer',

--- a/examples/docs_examples/bin/expression_language/cookbook/tools.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/tools.dart
@@ -12,7 +12,7 @@ void main(final List<String> arguments) async {
 Future<void> _calculator() async {
   final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
   final model = ChatOpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser();
+  const stringOutputParser = StringOutputParser<ChatResult>();
 
   final promptTemplate = ChatPromptTemplate.fromTemplate('''
 Turn the following user input into a math expression for a calculator. 

--- a/examples/docs_examples/bin/expression_language/get_started.dart
+++ b/examples/docs_examples/bin/expression_language/get_started.dart
@@ -16,7 +16,7 @@ Future<void> _promptModelOutputParser() async {
     'Tell me a joke about {topic}',
   );
   final model = ChatOpenAI(apiKey: openaiApiKey);
-  const outputParser = StringOutputParser<AIChatMessage>();
+  const outputParser = StringOutputParser<ChatResult>();
 
   final chain = promptTemplate.pipe(model).pipe(outputParser);
 

--- a/examples/docs_examples/bin/expression_language/interface.dart
+++ b/examples/docs_examples/bin/expression_language/interface.dart
@@ -84,7 +84,7 @@ Future<void> _runnableTypesRunnableSequence() async {
   final chain1 = promptTemplate | model | const StringOutputParser();
   // final chain2 = promptTemplate.pipe(model).pipe(const StringOutputParser());
   // final chain3 = Runnable.fromList(
-  //   [promptTemplate, model, const StringOutputParser()],
+  //   [promptTemplate, model, StringOutputParser()],
   // );
 
   final res = await chain1.invoke({'topic': 'bears'});
@@ -105,7 +105,7 @@ Future<void> _runnableTypesRunnableMap() async {
   final promptTemplate3 = ChatPromptTemplate.fromTemplate(
     'Is {city} a good city for a {age} years old person?',
   );
-  const stringOutputParser = StringOutputParser();
+  const stringOutputParser = StringOutputParser<ChatResult>();
 
   final chain = Runnable.fromMap({
         'city': promptTemplate1 | model | stringOutputParser,

--- a/examples/docs_examples/bin/get_started/quickstart.dart
+++ b/examples/docs_examples/bin/get_started/quickstart.dart
@@ -63,16 +63,31 @@ Future<void> _chatPromptTemplates() async {
 }
 
 Future<void> _commaSeparatedListOutputParser() async {
-  final res = await CommaSeparatedListOutputParser().parse('hi, bye');
+  final res = await const CommaSeparatedListOutputParser().invoke(
+    const ChatResult(
+      id: 'id',
+      output: AIChatMessage(content: 'hi, bye'),
+      finishReason: FinishReason.stop,
+      metadata: {},
+      usage: LanguageModelUsage(),
+    ),
+  );
   print(res);
   // ['hi',  'bye']
 }
 
-class CommaSeparatedListOutputParser extends BaseOutputParser<AIChatMessage,
-    BaseLangChainOptions, List<String>> {
+class CommaSeparatedListOutputParser
+    extends BaseOutputParser<ChatResult, OutputParserOptions, List<String>> {
+  const CommaSeparatedListOutputParser()
+      : super(defaultOptions: const OutputParserOptions());
+
   @override
-  Future<List<String>> parse(final String text) async {
-    return text.trim().split(',');
+  Future<List<String>> invoke(
+    final ChatResult input, {
+    final OutputParserOptions? options,
+  }) async {
+    final message = input.output;
+    return message.content.trim().split(',');
   }
 }
 
@@ -94,7 +109,7 @@ ONLY return a comma separated list, and nothing more.
   final chatModel = ChatOpenAI(apiKey: openAiApiKey);
 
   final chain =
-      chatPrompt.pipe(chatModel).pipe(CommaSeparatedListOutputParser());
+      chatPrompt.pipe(chatModel).pipe(const CommaSeparatedListOutputParser());
 
   // Alternative syntax:
   // final chain = chatPrompt | chatModel | CommaSeparatedListOutputParser();

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/how_to/streaming.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/how_to/streaming.dart
@@ -21,7 +21,7 @@ Future<void> _chatOpenAIStreaming() async {
   ]);
 
   final chat = ChatOpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser<AIChatMessage>();
+  const stringOutputParser = StringOutputParser<ChatResult>();
   final chain = promptTemplate.pipe(chat).pipe(stringOutputParser);
 
   final stream = chain.stream({'max_num': '9'});

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/mistralai.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/mistralai.dart
@@ -58,7 +58,7 @@ Future<void> _chatMistralAIStreaming(final String apiKey) async {
       temperature: 0,
     ),
   );
-  const stringOutputParser = StringOutputParser<AIChatMessage>();
+  const stringOutputParser = StringOutputParser<ChatResult>();
 
   final chain = promptTemplate.pipe(chat).pipe(stringOutputParser);
 

--- a/examples/docs_examples/bin/modules/model_io/models/llms/how_to/llm_streaming.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/llms/how_to/llm_streaming.dart
@@ -14,7 +14,7 @@ Future<void> _openAIStreaming() async {
     'List the numbers from 1 to {max_num} in order without any spaces or commas',
   );
   final llm = OpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser<String>();
+  const stringOutputParser = StringOutputParser<LLMResult>();
   final chain = promptTemplate | llm | stringOutputParser;
 
   final stream = chain.stream({'max_num': '9'});

--- a/examples/docs_examples/bin/modules/model_io/models/llms/integrations/ollama.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/llms/integrations/ollama.dart
@@ -32,7 +32,7 @@ Future<void> _ollamaStreaming() async {
       model: 'llama2',
     ),
   );
-  const stringOutputParser = StringOutputParser<String>();
+  const stringOutputParser = StringOutputParser<LLMResult>();
   final chain = promptTemplate | llm | stringOutputParser;
 
   final stream = chain.stream({'max_num': '9'});

--- a/examples/docs_examples/bin/modules/model_io/models/llms/integrations/openai.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/llms/integrations/openai.dart
@@ -28,7 +28,7 @@ Future<void> _openAIStreaming() async {
     'List the numbers from 1 to {max_num} in order without any spaces or commas',
   );
   final llm = OpenAI(apiKey: openaiApiKey);
-  const stringOutputParser = StringOutputParser<String>();
+  const stringOutputParser = StringOutputParser<LLMResult>();
   final chain = promptTemplate | llm | stringOutputParser;
 
   final stream = chain.stream({'max_num': '9'});

--- a/packages/langchain_core/lib/src/agents/base.dart
+++ b/packages/langchain_core/lib/src/agents/base.dart
@@ -1,6 +1,5 @@
 import '../exceptions/base.dart';
-import '../langchain/types.dart';
-import '../runnables/runnable.dart';
+import '../runnables/runnables.dart';
 import '../tools/base.dart';
 import 'types.dart';
 
@@ -14,7 +13,7 @@ abstract class Agent {
 
   /// Creates an agent from a [Runnable].
   static BaseMultiActionAgent fromRunnable(
-    final Runnable<AgentPlanInput, BaseLangChainOptions, List<BaseAgentAction>>
+    final Runnable<AgentPlanInput, RunnableOptions, List<BaseAgentAction>>
         runnable, {
     required final List<BaseTool> tools,
   }) {
@@ -100,7 +99,7 @@ class RunnableAgent extends BaseMultiActionAgent {
   const RunnableAgent(this.runnable, {required super.tools});
 
   /// The runnable that implements the agent.
-  final Runnable<AgentPlanInput, BaseLangChainOptions, List<BaseAgentAction>>
+  final Runnable<AgentPlanInput, RunnableOptions, List<BaseAgentAction>>
       runnable;
 
   @override

--- a/packages/langchain_core/lib/src/chains/base.dart
+++ b/packages/langchain_core/lib/src/chains/base.dart
@@ -33,7 +33,8 @@ abstract class BaseChain<MemoryType extends BaseMemory>
   /// {@macro base_chain}
   const BaseChain({
     this.memory,
-  });
+    final ChainOptions? defaultOptions,
+  }) : super(defaultOptions: defaultOptions ?? const ChainOptions());
 
   /// Memory to use for this chain.
   final MemoryType? memory;

--- a/packages/langchain_core/lib/src/chains/llm_chain.dart
+++ b/packages/langchain_core/lib/src/chains/llm_chain.dart
@@ -26,7 +26,6 @@ import 'types.dart';
 class LLMChain<
     LLMType extends BaseLanguageModel,
     LLMOptions extends LanguageModelOptions,
-    OutputParserType extends BaseLLMOutputParser,
     MemoryType extends BaseMemory> extends BaseChain<MemoryType> {
   /// {@macro llm_chain}
   const LLMChain({
@@ -37,7 +36,7 @@ class LLMChain<
     this.outputParser,
     this.outputKey = defaultOutputKey,
     this.returnFinalOnly = true,
-  });
+  }) : super(defaultOptions: const ChainOptions());
 
   /// Language model to call.
   final LLMType llm;
@@ -52,7 +51,7 @@ class LLMChain<
   ///
   /// Defaults to one that takes the most likely string but does not change it
   /// otherwise.
-  final OutputParserType? outputParser;
+  final BaseOutputParser? outputParser;
 
   /// Key to use for output.
   final String outputKey;
@@ -90,7 +89,7 @@ class LLMChain<
 
     final res = outputParser == null
         ? response.output
-        : await outputParser!.parseResultWithPrompt(response, promptValue);
+        : await outputParser!.invoke(response);
 
     return {
       outputKey: res,

--- a/packages/langchain_core/lib/src/chains/types.dart
+++ b/packages/langchain_core/lib/src/chains/types.dart
@@ -9,7 +9,7 @@ typedef ChainValues = Map<String, dynamic>;
 /// Options to pass to a chain.
 /// {@endtemplate}
 @immutable
-abstract class ChainOptions extends BaseLangChainOptions {
+class ChainOptions extends BaseLangChainOptions {
   /// {@macro chain_options}
   const ChainOptions();
 }

--- a/packages/langchain_core/lib/src/chat_models/base.dart
+++ b/packages/langchain_core/lib/src/chat_models/base.dart
@@ -9,9 +9,11 @@ import 'types.dart';
 /// It should take in chat messages and return a chat message.
 /// {@endtemplate}
 abstract class BaseChatModel<Options extends ChatModelOptions>
-    extends BaseLanguageModel<List<ChatMessage>, Options, AIChatMessage> {
+    extends BaseLanguageModel<List<ChatMessage>, Options, ChatResult> {
   /// {@macro base_chat_model}
-  const BaseChatModel();
+  const BaseChatModel({
+    required super.defaultOptions,
+  });
 
   /// Runs the chat model on the given prompt value.
   ///
@@ -39,7 +41,6 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
   /// ```dart
   /// final result = await chat([ChatMessage.humanText('say hi!')]);
   /// ```
-  @override
   Future<AIChatMessage> call(
     final List<ChatMessage> messages, {
     final Options? options,
@@ -57,7 +58,9 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
 abstract class SimpleChatModel<Options extends ChatModelOptions>
     extends BaseChatModel<Options> {
   /// {@macro simple_chat_model}
-  const SimpleChatModel();
+  const SimpleChatModel({
+    required super.defaultOptions,
+  });
 
   @override
   Future<ChatResult> invoke(

--- a/packages/langchain_core/lib/src/chat_models/fake.dart
+++ b/packages/langchain_core/lib/src/chat_models/fake.dart
@@ -11,7 +11,7 @@ class FakeChatModel extends SimpleChatModel {
   /// {@macro fake_list_llm}
   FakeChatModel({
     required this.responses,
-  });
+  }) : super(defaultOptions: const ChatModelOptions());
 
   /// Responses to return in order when called.
   final List<String> responses;
@@ -49,7 +49,7 @@ class FakeChatModel extends SimpleChatModel {
 /// {@endtemplate}
 class FakeEchoChatModel extends SimpleChatModel {
   /// {@macro fake_echo_llm}
-  const FakeEchoChatModel();
+  const FakeEchoChatModel() : super(defaultOptions: const ChatModelOptions());
 
   @override
   String get modelType => 'fake-echo-chat-model';

--- a/packages/langchain_core/lib/src/chat_models/types.dart
+++ b/packages/langchain_core/lib/src/chat_models/types.dart
@@ -33,7 +33,7 @@ class ChatResult extends LanguageModelResult<AIChatMessage> {
     final LanguageModelResult<AIChatMessage> other,
   ) {
     return ChatResult(
-      id: other.id ?? id,
+      id: other.id,
       output: output.concat(other.output),
       finishReason: other.finishReason,
       metadata: {

--- a/packages/langchain_core/lib/src/documents/transformer.dart
+++ b/packages/langchain_core/lib/src/documents/transformer.dart
@@ -8,7 +8,8 @@ import 'document.dart';
 abstract class BaseDocumentTransformer
     extends Runnable<List<Document>, BaseLangChainOptions, List<Document>> {
   /// {@macro base_document_transformer}
-  const BaseDocumentTransformer();
+  const BaseDocumentTransformer()
+      : super(defaultOptions: const BaseLangChainOptions());
 
   /// Transform a list of documents.
   ///

--- a/packages/langchain_core/lib/src/langchain/base.dart
+++ b/packages/langchain_core/lib/src/langchain/base.dart
@@ -1,12 +1,14 @@
 import '../runnables/runnable.dart';
-import 'types.dart';
+import '../runnables/types.dart';
 
 /// {@template base_lang_chain}
 /// Base class for LangChain components (language models, chains, tools, etc.).
 /// {@endtemplate}
 abstract class BaseLangChain<RunInput extends Object,
-        CallOptions extends BaseLangChainOptions, RunOutput extends Object>
+        CallOptions extends RunnableOptions, RunOutput extends Object>
     extends Runnable<RunInput, CallOptions, RunOutput> {
   /// {@macro base_lang_chain}
-  const BaseLangChain();
+  const BaseLangChain({
+    required super.defaultOptions,
+  });
 }

--- a/packages/langchain_core/lib/src/langchain/types.dart
+++ b/packages/langchain_core/lib/src/langchain/types.dart
@@ -1,10 +1,12 @@
 import 'package:meta/meta.dart';
 
+import '../runnables/types.dart';
+
 /// {@template base_lang_chain_options}
-/// Base class for LangChain options.
+/// Base class for LangChain components' options.
 /// {@endtemplate}
 @immutable
-class BaseLangChainOptions {
+class BaseLangChainOptions extends RunnableOptions {
   /// {@macro base_lang_chain_options}
   const BaseLangChainOptions();
 }

--- a/packages/langchain_core/lib/src/language_models/base.dart
+++ b/packages/langchain_core/lib/src/language_models/base.dart
@@ -12,11 +12,15 @@ import 'types.dart';
 /// - ChatModels: these wrap models which take chat messages in and return a
 ///   chat message.
 /// {@endtemplate}
-abstract class BaseLanguageModel<Input extends Object,
-        Options extends LanguageModelOptions, Output extends Object>
-    extends BaseLangChain<PromptValue, Options, LanguageModelResult<Output>> {
+abstract class BaseLanguageModel<
+        Input extends Object,
+        Options extends LanguageModelOptions,
+        Output extends LanguageModelResult>
+    extends BaseLangChain<PromptValue, Options, Output> {
   /// {@macro base_language_model}
-  const BaseLanguageModel();
+  const BaseLanguageModel({
+    required super.defaultOptions,
+  });
 
   /// Return type of language model.
   String get modelType;
@@ -26,17 +30,8 @@ abstract class BaseLanguageModel<Input extends Object,
   /// - [input] The prompt value to pass into the model.
   /// - [options] Generation options to pass into the model.
   @override
-  Future<LanguageModelResult<Output>> invoke(
+  Future<Output> invoke(
     final PromptValue input, {
-    final Options? options,
-  });
-
-  /// Runs the language model on the given input.
-  ///
-  /// - [input] The prompt to pass into the model.
-  /// - [options] Generation options to pass into the model.
-  Future<Output> call(
-    final Input input, {
     final Options? options,
   });
 

--- a/packages/langchain_core/lib/src/language_models/types.dart
+++ b/packages/langchain_core/lib/src/language_models/types.dart
@@ -28,7 +28,7 @@ abstract class LanguageModelResult<O extends Object> {
   });
 
   /// Result id.
-  final String? id;
+  final String id;
 
   /// Generated output.
   final O output;

--- a/packages/langchain_core/lib/src/llms/base.dart
+++ b/packages/langchain_core/lib/src/llms/base.dart
@@ -10,9 +10,11 @@ import 'types.dart';
 /// LLMs take in a String and returns a String.
 /// {@endtemplate}
 abstract class BaseLLM<Options extends LLMOptions>
-    extends BaseLanguageModel<String, Options, String> {
+    extends BaseLanguageModel<String, Options, LLMResult> {
   /// {@macro base_llm}
-  const BaseLLM();
+  const BaseLLM({
+    required super.defaultOptions,
+  });
 
   /// Runs the LLM on the given prompt value.
   ///
@@ -41,7 +43,6 @@ abstract class BaseLLM<Options extends LLMOptions>
   /// ```dart
   /// final result = await openai('Tell me a joke.');
   /// ```
-  @override
   Future<String> call(
     final String prompt, {
     final Options? options,
@@ -58,7 +59,9 @@ abstract class BaseLLM<Options extends LLMOptions>
 /// {@endtemplate}
 abstract class SimpleLLM<Options extends LLMOptions> extends BaseLLM<Options> {
   /// {@macro simple_llm}
-  const SimpleLLM();
+  const SimpleLLM({
+    required super.defaultOptions,
+  });
 
   @override
   Future<LLMResult> invoke(

--- a/packages/langchain_core/lib/src/llms/fake.dart
+++ b/packages/langchain_core/lib/src/llms/fake.dart
@@ -11,7 +11,7 @@ class FakeListLLM extends SimpleLLM {
   /// {@macro fake_list_llm}
   FakeListLLM({
     required this.responses,
-  });
+  }) : super(defaultOptions: const LLMOptions());
 
   /// Responses to return in order when called.
   final List<String> responses;
@@ -48,7 +48,7 @@ class FakeListLLM extends SimpleLLM {
 /// {@endtemplate}
 class FakeEchoLLM extends BaseLLM {
   /// {@macro fake_echo_llm}
-  const FakeEchoLLM();
+  const FakeEchoLLM() : super(defaultOptions: const LLMOptions());
 
   @override
   String get modelType => 'fake-echo';
@@ -108,7 +108,7 @@ class FakeHandlerLLM extends SimpleLLM {
   /// {@macro fake_handler_llm}
   FakeHandlerLLM({
     required this.handler,
-  });
+  }) : super(defaultOptions: const LLMOptions());
 
   /// Function called to generate the response.
   final String Function(

--- a/packages/langchain_core/lib/src/llms/types.dart
+++ b/packages/langchain_core/lib/src/llms/types.dart
@@ -30,7 +30,7 @@ class LLMResult extends LanguageModelResult<String> {
     final LanguageModelResult<String> other,
   ) {
     return LLMResult(
-      id: other.id ?? id,
+      id: other.id,
       output: output + other.output,
       finishReason: other.finishReason,
       metadata: {

--- a/packages/langchain_core/lib/src/output_parsers/base.dart
+++ b/packages/langchain_core/lib/src/output_parsers/base.dart
@@ -1,43 +1,16 @@
-import '../langchain/types.dart';
-import '../language_models/types.dart';
-import '../prompts/types.dart';
 import '../runnables/runnable.dart';
-
-/// Options for formatting instructions.
-interface class FormatInstructionsOptions {}
+import 'types.dart';
 
 /// {@template base_llm_output_parser}
-/// Class to parse the output of an model call.
+/// Class to parse the output of a [Runnable] invocation.
 /// {@endtemplate}
-abstract class BaseLLMOutputParser<LLMOutput extends Object,
-        CallOptions extends BaseLangChainOptions, ParserOutput extends Object?>
-    extends Runnable<LanguageModelResult<LLMOutput>, CallOptions,
-        ParserOutput> {
+abstract class BaseOutputParser<ParserInput extends Object?,
+        CallOptions extends OutputParserOptions, ParserOutput extends Object?>
+    extends Runnable<ParserInput, CallOptions, ParserOutput> {
   /// {@macro base_llm_output_parser}
-  const BaseLLMOutputParser();
-
-  /// Parses the result of an LLM call. This method is meant to be implemented
-  /// by subclasses to define how the output from the LLM should be parsed.
-  ///
-  /// - [result] - The result of an LLM call.
-  Future<ParserOutput> parseResult(
-    final LanguageModelResult<LLMOutput> result,
-  );
-
-  /// Optional method to parse the output of an LLM call with a prompt.
-  ///
-  /// The prompt is largely provided in the event the OutputParser wants to
-  /// retry or fix the output in some way, and needs information from the
-  /// prompt to do so.
-  ///
-  /// - [result] - The result of an LLM call.
-  /// - [prompt] - Prompt used to generate the output.
-  Future<ParserOutput> parseResultWithPrompt(
-    final LanguageModelResult<LLMOutput> result,
-    final PromptValue prompt,
-  ) async {
-    return parseResult(result);
-  }
+  const BaseOutputParser({
+    required super.defaultOptions,
+  });
 
   /// Invokes the output parser on the given input.
   ///
@@ -45,56 +18,7 @@ abstract class BaseLLMOutputParser<LLMOutput extends Object,
   /// - [options] - Not used.
   @override
   Future<ParserOutput> invoke(
-    final LanguageModelResult<LLMOutput> input, {
-    final BaseLangChainOptions? options,
-  }) {
-    return parseResult(input);
-  }
-}
-
-/// {@template base_output_parser}
-/// Class to parse the output of an LLM call.
-/// {@endtemplate}
-abstract class BaseOutputParser<LLMOutput extends Object,
-        CallOptions extends BaseLangChainOptions, ParserOutput extends Object>
-    extends BaseLLMOutputParser<LLMOutput, CallOptions, ParserOutput> {
-  /// {@macro base_output_parser}
-  const BaseOutputParser();
-
-  @override
-  Future<ParserOutput> parseResult(
-    final LanguageModelResult<LLMOutput> result,
-  ) {
-    return parse(result.outputAsString);
-  }
-
-  /// Parse the output of an LLM call.
-  ///
-  /// A method which takes in a string (assumed output of a language model)
-  /// and parses it into some structure.
-  ///
-  /// - [text] - LLM output to parse.
-  Future<ParserOutput> parse(final String text);
-
-  /// Optional method to parse the output of an LLM call with a prompt.
-  ///
-  /// The prompt is largely provided in the event the OutputParser wants to
-  /// retry or fix the output in some way, and needs information from the
-  /// prompt to do so.
-  ///
-  /// [text] - LLM output to parse.
-  /// [prompt] - Prompt used to generate the output.
-  Future<ParserOutput> parseWithPrompt(
-    final String text,
-    final PromptValue prompt,
-  ) async {
-    return parse(text);
-  }
-
-  /// Return a string describing the format of the LLM output.
-  ///
-  /// [options] - Options for formatting instructions.
-  String getFormatInstructions([final FormatInstructionsOptions? options]) {
-    return ''; // Override this method to provide instructions.
-  }
+    final ParserInput input, {
+    final CallOptions? options,
+  });
 }

--- a/packages/langchain_core/lib/src/output_parsers/output_parsers.dart
+++ b/packages/langchain_core/lib/src/output_parsers/output_parsers.dart
@@ -2,3 +2,4 @@ export 'base.dart';
 export 'exceptions.dart';
 export 'functions.dart';
 export 'string.dart';
+export 'types.dart';

--- a/packages/langchain_core/lib/src/output_parsers/string.dart
+++ b/packages/langchain_core/lib/src/output_parsers/string.dart
@@ -1,31 +1,54 @@
-import '../langchain/types.dart';
+import '../../llms.dart';
+import '../chat_models/types.dart';
+import '../documents/document.dart';
+import '../language_models/types.dart';
 import 'base.dart';
+import 'types.dart';
 
 /// {@template string_output_parser}
-/// Output parser that parses the first generation as String.
+/// Output parser that returns the output of the previous [Runnable] as a
+/// `String`.
 ///
-/// - [ModelOutput] - The output of the language model (`String` for LLMs or
-/// `ChatMessage` for chat models).
+/// - [ParserInput] - The type of the input to the parser.
+///
+/// If the input is:
+/// - `null`, the parser returns an empty String.
+/// - A [LLMResult], the parser returns the output String.
+/// - A [ChatResult], the parser returns the content of the output message as a String.
+/// - A [ChatMessage], the parser returns the content of the message as a String.
+/// - A [Document], the parser returns the page content as a String.
+/// - Anything else, the parser returns the String representation of the input.
 ///
 /// Example:
 /// ```dart
-/// final model = ChatOpenAI(apiKey: openaiApiKey);
+/// final model = ChatOpenAI(apiKey: openAiApiKey);
 /// final promptTemplate = ChatPromptTemplate.fromTemplate(
 ///   'Tell me a joke about {topic}',
 /// );
-/// final chain = promptTemplate | model | const StringOutputParser();
+/// final chain = promptTemplate | model | StringOutputParser();
 /// final res = await chain.invoke({'topic': 'bears'});
 /// print(res);
 /// // Why don't bears wear shoes? Because they have bear feet!
 /// ```
 /// {@endtemplate}
-class StringOutputParser<ModelOutput extends Object>
-    extends BaseOutputParser<ModelOutput, BaseLangChainOptions, String> {
+class StringOutputParser<ParserInput extends Object?>
+    extends BaseOutputParser<ParserInput, OutputParserOptions, String> {
   /// {@macro string_output_parser}
-  const StringOutputParser();
+  const StringOutputParser()
+      : super(defaultOptions: const OutputParserOptions());
 
   @override
-  Future<String> parse(final String text) {
-    return Future.value(text);
+  Future<String> invoke(
+    final ParserInput input, {
+    final OutputParserOptions? options,
+  }) {
+    final output = switch (input) {
+      null => '',
+      final LanguageModelResult res => res.outputAsString,
+      final ChatMessage res => res.contentAsString,
+      final Document res => res.pageContent,
+      _ => input.toString(),
+    };
+    return Future.value(output);
   }
 }

--- a/packages/langchain_core/lib/src/output_parsers/types.dart
+++ b/packages/langchain_core/lib/src/output_parsers/types.dart
@@ -1,0 +1,12 @@
+import 'package:meta/meta.dart';
+
+import '../langchain/types.dart';
+
+/// {@template output_parser_options}
+/// Options to pass to an output parser.
+/// {@endtemplate}
+@immutable
+class OutputParserOptions extends BaseLangChainOptions {
+  /// {@macro output_parser_options}
+  const OutputParserOptions();
+}

--- a/packages/langchain_core/lib/src/prompts/base_chat_message_prompt.dart
+++ b/packages/langchain_core/lib/src/prompts/base_chat_message_prompt.dart
@@ -15,7 +15,8 @@ import 'types.dart';
 abstract base class ChatMessagePromptTemplate
     extends Runnable<InputValues, BaseLangChainOptions, List<ChatMessage>> {
   /// {@macro chat_message_prompt_template}
-  const ChatMessagePromptTemplate({required this.prompt});
+  const ChatMessagePromptTemplate({required this.prompt})
+      : super(defaultOptions: const BaseLangChainOptions());
 
   /// The prompt template for the message.
   final BasePromptTemplate prompt;

--- a/packages/langchain_core/lib/src/prompts/base_prompt.dart
+++ b/packages/langchain_core/lib/src/prompts/base_prompt.dart
@@ -20,7 +20,7 @@ abstract base class BasePromptTemplate
   const BasePromptTemplate({
     required this.inputVariables,
     this.partialVariables,
-  });
+  }) : super(defaultOptions: const BaseLangChainOptions());
 
   /// A set of the names of the variables the prompt template expects.
   final Set<String> inputVariables;

--- a/packages/langchain_core/lib/src/retrievers/base.dart
+++ b/packages/langchain_core/lib/src/retrievers/base.dart
@@ -8,7 +8,9 @@ import 'types.dart';
 abstract class Retriever<Options extends RetrieverOptions>
     extends Runnable<String, Options, List<Document>> {
   /// {@macro base_retriever}
-  const Retriever();
+  const Retriever({
+    required super.defaultOptions,
+  });
 
   /// Get the most relevant documents for a given query.
   ///

--- a/packages/langchain_core/lib/src/retrievers/fake.dart
+++ b/packages/langchain_core/lib/src/retrievers/fake.dart
@@ -8,7 +8,8 @@ import 'types.dart';
 /// {@endtemplate}
 class FakeRetriever extends Retriever<RetrieverOptions> {
   /// {@macro fake_retriever}
-  const FakeRetriever(this.docs);
+  const FakeRetriever(this.docs)
+      : super(defaultOptions: const RetrieverOptions());
 
   /// The documents to return.
   final List<Document> docs;

--- a/packages/langchain_core/lib/src/retrievers/vector_store.dart
+++ b/packages/langchain_core/lib/src/retrievers/vector_store.dart
@@ -9,16 +9,13 @@ import 'types.dart';
 class VectorStoreRetriever<V extends VectorStore>
     extends Retriever<VectorStoreRetrieverOptions> {
   /// {@macro vector_store_retriever}
-  VectorStoreRetriever({
+  const VectorStoreRetriever({
     required this.vectorStore,
-    this.defaultOptions = const VectorStoreRetrieverOptions(),
+    super.defaultOptions = const VectorStoreRetrieverOptions(),
   });
 
   /// The vector store to retrieve documents from.
   final V vectorStore;
-
-  /// Default options for this retriever.
-  VectorStoreRetrieverOptions defaultOptions;
 
   @override
   Future<List<Document>> getRelevantDocuments(

--- a/packages/langchain_core/lib/src/runnables/binding.dart
+++ b/packages/langchain_core/lib/src/runnables/binding.dart
@@ -1,5 +1,5 @@
-import '../langchain/types.dart';
 import 'runnable.dart';
+import 'types.dart';
 
 /// {@template runnable_binding}
 /// A [RunnableBinding] allows you to run a [Runnable] object with
@@ -37,19 +37,19 @@ import 'runnable.dart';
 /// ```
 /// {@endtemplate}
 class RunnableBinding<RunInput extends Object?,
-        CallOptions extends BaseLangChainOptions, RunOutput extends Object?>
+        CallOptions extends RunnableOptions, RunOutput extends Object?>
     extends Runnable<RunInput, CallOptions, RunOutput> {
   /// {@macro runnable_binding}
   const RunnableBinding({
     required this.bound,
-    this.options,
-  });
+    required this.options,
+  }) : super(defaultOptions: options);
 
   /// The [Runnable] to bind.
   final Runnable<RunInput, CallOptions, RunOutput> bound;
 
   /// The [CallOptions] to bind the [Runnable] with.
-  final CallOptions? options;
+  final CallOptions options;
 
   /// Invokes the [RunnableBinding] on the given [input].
   ///

--- a/packages/langchain_core/lib/src/runnables/function.dart
+++ b/packages/langchain_core/lib/src/runnables/function.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import '../langchain/types.dart';
 import 'runnable.dart';
+import 'types.dart';
 
 /// {@template runnable_function}
 /// A [RunnableFunction] allows you to run a Dart function as part of a chain.
@@ -40,7 +40,7 @@ import 'runnable.dart';
 ///     }) |
 ///     promptTemplate |
 ///     model |
-///     const StringOutputParser();
+///     StringOutputParser();
 ///
 /// final res = await chain.invoke({'foo': 'foo', 'bar': 'bar'});
 /// print(res);
@@ -48,14 +48,15 @@ import 'runnable.dart';
 /// ```
 /// {@endtemplate}
 class RunnableFunction<RunInput extends Object, RunOutput extends Object>
-    extends Runnable<RunInput, BaseLangChainOptions, RunOutput> {
+    extends Runnable<RunInput, RunnableOptions, RunOutput> {
   /// {@macro runnable_function}
-  const RunnableFunction(this.function);
+  const RunnableFunction(this.function)
+      : super(defaultOptions: const RunnableOptions());
 
   /// The function to run.
   final FutureOr<RunOutput> Function(
     RunInput input,
-    BaseLangChainOptions? options,
+    RunnableOptions? options,
   ) function;
 
   /// Invokes the [RunnableFunction] on the given [input].
@@ -65,7 +66,7 @@ class RunnableFunction<RunInput extends Object, RunOutput extends Object>
   @override
   Future<RunOutput> invoke(
     final RunInput input, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) async {
     return function(input, options);
   }

--- a/packages/langchain_core/lib/src/runnables/input_getter.dart
+++ b/packages/langchain_core/lib/src/runnables/input_getter.dart
@@ -1,5 +1,5 @@
-import '../langchain/types.dart';
 import 'runnable.dart';
+import 'types.dart';
 
 /// {@template runnable_item_from_map}
 /// A [RunnableItemFromMap] allows you to get a value from the input.
@@ -29,7 +29,7 @@ import 'runnable.dart';
 ///     }) |
 ///     promptTemplate |
 ///     model |
-///     const StringOutputParser();
+///     StringOutputParser();
 ///
 /// final res = await chain.invoke({
 ///   'question': 'What payment methods do you accept?',
@@ -40,9 +40,10 @@ import 'runnable.dart';
 /// ```
 /// {@endtemplate}
 class RunnableItemFromMap<RunOutput extends Object>
-    extends Runnable<Map<String, dynamic>, BaseLangChainOptions, RunOutput> {
+    extends Runnable<Map<String, dynamic>, RunnableOptions, RunOutput> {
   /// {@macro runnable_item_from_map}
-  const RunnableItemFromMap(this.key);
+  const RunnableItemFromMap(this.key)
+      : super(defaultOptions: const RunnableOptions());
 
   /// The key of the item to get from the input map.
   final String key;
@@ -54,7 +55,7 @@ class RunnableItemFromMap<RunOutput extends Object>
   @override
   Future<RunOutput> invoke(
     final Map<String, dynamic> input, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) async {
     return input[key];
   }
@@ -91,7 +92,7 @@ class RunnableItemFromMap<RunOutput extends Object>
 /// final chain = Runnable.getMapFromInput('foo') |
 ///     promptTemplate |
 ///     model |
-///     const StringOutputParser();
+///     StringOutputParser();
 ///
 /// final res = await chain.invoke('bears');
 /// print(res);
@@ -99,9 +100,10 @@ class RunnableItemFromMap<RunOutput extends Object>
 /// ```
 /// {@endtemplate}
 class RunnableMapFromInput<RunInput extends Object>
-    extends Runnable<RunInput, BaseLangChainOptions, Map<String, dynamic>> {
+    extends Runnable<RunInput, RunnableOptions, Map<String, dynamic>> {
   /// {@macro runnable_map_from_input}
-  const RunnableMapFromInput(this.key);
+  const RunnableMapFromInput(this.key)
+      : super(defaultOptions: const RunnableOptions());
 
   /// The key where to place the input in the output map.
   final String key;
@@ -113,7 +115,7 @@ class RunnableMapFromInput<RunInput extends Object>
   @override
   Future<Map<String, dynamic>> invoke(
     final RunInput input, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) async {
     return {key: input};
   }

--- a/packages/langchain_core/lib/src/runnables/input_map.dart
+++ b/packages/langchain_core/lib/src/runnables/input_map.dart
@@ -1,5 +1,5 @@
-import '../langchain/types.dart';
 import 'runnable.dart';
+import 'types.dart';
 
 /// {@template runnable_map_input}
 /// A [RunnableMapInput] allows you to map the input to a different value.
@@ -26,9 +26,10 @@ import 'runnable.dart';
 /// ```
 /// {@endtemplate}
 class RunnableMapInput<RunInput extends Object, RunOutput extends Object>
-    extends Runnable<RunInput, BaseLangChainOptions, RunOutput> {
+    extends Runnable<RunInput, RunnableOptions, RunOutput> {
   /// {@macro runnable_map_from_input_items}
-  const RunnableMapInput(this.inputMapper);
+  const RunnableMapInput(this.inputMapper)
+      : super(defaultOptions: const RunnableOptions());
 
   /// A function that maps [RunInput] to [RunOutput].
   final RunOutput Function(RunInput input) inputMapper;
@@ -40,7 +41,7 @@ class RunnableMapInput<RunInput extends Object, RunOutput extends Object>
   @override
   Future<RunOutput> invoke(
     final RunInput input, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) async {
     return inputMapper(input);
   }

--- a/packages/langchain_core/lib/src/runnables/map.dart
+++ b/packages/langchain_core/lib/src/runnables/map.dart
@@ -1,7 +1,7 @@
 import 'package:async/async.dart' show StreamGroup;
 
-import '../langchain/types.dart';
 import 'runnable.dart';
+import 'types.dart';
 
 /// {@template runnable_map}
 /// A [RunnableMap] allows you to run multiple [Runnable] objects in parallel
@@ -28,7 +28,7 @@ import 'runnable.dart';
 /// final promptTemplate3 = ChatPromptTemplate.fromTemplate(
 ///   'Is {city} a good city for a {age} years old person?',
 /// );
-/// const stringOutputParser = StringOutputParser();
+/// const stringOutputParser = StringOutputParser<ChatResult>();
 ///
 /// final chain = Runnable.fromMap({
 ///   'city': promptTemplate1 | model | stringOutputParser,
@@ -42,12 +42,13 @@ import 'runnable.dart';
 /// ```
 /// {@endtemplate}
 class RunnableMap<RunInput extends Object>
-    extends Runnable<RunInput, BaseLangChainOptions, Map<String, dynamic>> {
+    extends Runnable<RunInput, RunnableOptions, Map<String, dynamic>> {
   /// {@macro runnable_map}
-  const RunnableMap(this.steps);
+  const RunnableMap(this.steps)
+      : super(defaultOptions: const RunnableOptions());
 
   /// The map of [Runnable] objects to run in parallel.
-  final Map<String, Runnable<RunInput, BaseLangChainOptions, Object>> steps;
+  final Map<String, Runnable<RunInput, RunnableOptions, Object>> steps;
 
   /// Invokes the [RunnableMap] on the given [input].
   ///
@@ -56,7 +57,7 @@ class RunnableMap<RunInput extends Object>
   @override
   Future<Map<String, dynamic>> invoke(
     final RunInput input, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) async {
     final output = <String, dynamic>{};
 
@@ -70,7 +71,7 @@ class RunnableMap<RunInput extends Object>
   @override
   Stream<Map<String, dynamic>> stream(
     final RunInput input, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) {
     return streamFromInputStream(
       Stream.value(input).asBroadcastStream(),
@@ -81,7 +82,7 @@ class RunnableMap<RunInput extends Object>
   @override
   Stream<Map<String, dynamic>> streamFromInputStream(
     final Stream<RunInput> inputStream, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) {
     return StreamGroup.merge(
       steps.entries.map((final entry) {

--- a/packages/langchain_core/lib/src/runnables/passthrough.dart
+++ b/packages/langchain_core/lib/src/runnables/passthrough.dart
@@ -1,5 +1,5 @@
-import '../langchain/types.dart';
 import 'runnable.dart';
+import 'types.dart';
 
 /// {@template runnable_passthrough}
 /// A [RunnablePassthrough] takes the input it receives and passes it through
@@ -23,7 +23,7 @@ import 'runnable.dart';
 /// final map = Runnable.fromMap({
 ///   'foo': Runnable.passthrough(),
 /// });
-/// final chain = map | promptTemplate | model | const StringOutputParser();
+/// final chain = map | promptTemplate | model | StringOutputParser();
 ///
 /// final res = await chain.invoke('bears');
 /// print(res);
@@ -31,9 +31,9 @@ import 'runnable.dart';
 /// ```
 /// {@endtemplate}
 class RunnablePassthrough<RunInput extends Object>
-    extends Runnable<RunInput, BaseLangChainOptions, RunInput> {
+    extends Runnable<RunInput, RunnableOptions, RunInput> {
   /// {@macro runnable_passthrough}
-  const RunnablePassthrough();
+  const RunnablePassthrough() : super(defaultOptions: const RunnableOptions());
 
   /// Invokes the [RunnablePassthrough] on the given [input].
   ///
@@ -42,7 +42,7 @@ class RunnablePassthrough<RunInput extends Object>
   @override
   Future<RunInput> invoke(
     final RunInput input, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) {
     return Future.value(input);
   }

--- a/packages/langchain_core/lib/src/runnables/runnable_ext.dart
+++ b/packages/langchain_core/lib/src/runnables/runnable_ext.dart
@@ -1,11 +1,11 @@
-import '../langchain/types.dart';
 import 'runnable.dart';
 import 'sequence.dart';
+import 'types.dart';
 
 /// Extension methods for [Runnable]s.
 extension RunnableX<
     RunInput extends Object,
-    CallOptions extends BaseLangChainOptions,
+    CallOptions extends RunnableOptions,
     RunOutput extends Object,
     NewRunOutput extends Object> on Runnable<RunInput, CallOptions, RunOutput> {
   /// Pipes the output of this [Runnable] into another [Runnable].
@@ -19,7 +19,7 @@ extension RunnableX<
   ///
   /// - [next] - the [Runnable] to pipe the output into.
   RunnableSequence<RunInput, NewRunOutput> operator |(
-    final Runnable<RunOutput, BaseLangChainOptions, NewRunOutput> next,
+    final Runnable<RunOutput, RunnableOptions, NewRunOutput> next,
   ) {
     return pipe(next);
   }

--- a/packages/langchain_core/lib/src/runnables/runnables.dart
+++ b/packages/langchain_core/lib/src/runnables/runnables.dart
@@ -7,3 +7,4 @@ export 'passthrough.dart';
 export 'runnable.dart';
 export 'runnable_ext.dart';
 export 'sequence.dart';
+export 'types.dart';

--- a/packages/langchain_core/lib/src/runnables/sequence.dart
+++ b/packages/langchain_core/lib/src/runnables/sequence.dart
@@ -1,5 +1,5 @@
-import '../langchain/types.dart';
 import 'runnable.dart';
+import 'types.dart';
 
 /// {@template runnable_sequence}
 /// A [RunnableSequence] allows you to run multiple [Runnable] objects
@@ -47,10 +47,10 @@ import 'runnable.dart';
 /// );
 ///
 /// // The following three chains are equivalent:
-/// final chain1 = promptTemplate | model | const StringOutputParser();
-/// final chain2 = promptTemplate.pipe(model).pipe(const StringOutputParser());
+/// final chain1 = promptTemplate | model | StringOutputParser();
+/// final chain2 = promptTemplate.pipe(model).pipe(StringOutputParser());
 /// final chain3 = Runnable.fromList(
-///   [promptTemplate, model, const StringOutputParser()],
+///   [promptTemplate, model, StringOutputParser()],
 /// );
 ///
 /// final res = await chain1.invoke({'topic': 'bears'});
@@ -59,22 +59,22 @@ import 'runnable.dart';
 /// ```
 /// {@endtemplate}
 class RunnableSequence<RunInput extends Object?, RunOutput extends Object?>
-    extends Runnable<RunInput, BaseLangChainOptions, RunOutput> {
+    extends Runnable<RunInput, RunnableOptions, RunOutput> {
   /// {@macro runnable_sequence}
   const RunnableSequence({
     required this.first,
     this.middle = const [],
     required this.last,
-  });
+  }) : super(defaultOptions: const RunnableOptions());
 
   /// The first [Runnable] in the [RunnableSequence].
-  final Runnable<RunInput, BaseLangChainOptions, Object?> first;
+  final Runnable<RunInput, RunnableOptions, Object?> first;
 
   /// The middle [Runnable]s in the [RunnableSequence].
   final List<Runnable> middle;
 
   /// The last [Runnable] in the [RunnableSequence].
-  final Runnable<Object?, BaseLangChainOptions, RunOutput> last;
+  final Runnable<Object?, RunnableOptions, RunOutput> last;
 
   /// Returns a list of all the [Runnable]s in the [RunnableSequence].
   List<Runnable> get steps => [first, ...middle, last];
@@ -97,7 +97,7 @@ class RunnableSequence<RunInput extends Object?, RunOutput extends Object?>
   @override
   Future<RunOutput> invoke(
     final RunInput input, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) async {
     Object? nextStepInput = input;
 
@@ -111,7 +111,7 @@ class RunnableSequence<RunInput extends Object?, RunOutput extends Object?>
   @override
   Stream<RunOutput> stream(
     final RunInput input, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) {
     return streamFromInputStream(
       Stream.value(input).asBroadcastStream(),
@@ -122,7 +122,7 @@ class RunnableSequence<RunInput extends Object?, RunOutput extends Object?>
   @override
   Stream<RunOutput> streamFromInputStream(
     final Stream<RunInput> inputStream, {
-    final BaseLangChainOptions? options,
+    final RunnableOptions? options,
   }) {
     var nextStepStream = first.streamFromInputStream(inputStream);
 
@@ -138,7 +138,7 @@ class RunnableSequence<RunInput extends Object?, RunOutput extends Object?>
   /// - [next] - the [Runnable] to pipe the output into.
   @override
   RunnableSequence<RunInput, NewRunOutput> pipe<NewRunOutput extends Object?,
-      NewCallOptions extends BaseLangChainOptions>(
+      NewCallOptions extends RunnableOptions>(
     final Runnable<RunOutput, NewCallOptions, NewRunOutput> next,
   ) {
     if (next is RunnableSequence<RunOutput, NewRunOutput>) {

--- a/packages/langchain_core/lib/src/runnables/types.dart
+++ b/packages/langchain_core/lib/src/runnables/types.dart
@@ -1,0 +1,10 @@
+import 'package:meta/meta.dart';
+
+/// {@template runnable_options}
+/// Options to pass into a runnable.
+/// {@endtemplate}
+@immutable
+class RunnableOptions {
+  /// {@macro runnable_options}
+  const RunnableOptions();
+}

--- a/packages/langchain_core/lib/src/tools/base.dart
+++ b/packages/langchain_core/lib/src/tools/base.dart
@@ -20,8 +20,10 @@ abstract base class BaseTool<Options extends ToolOptions>
     required this.inputJsonSchema,
     this.returnDirect = false,
     this.handleToolError,
+    final Options? defaultOptions,
   })  : assert(name.isNotEmpty, 'Tool name cannot be empty.'),
-        assert(description.isNotEmpty, 'Tool description cannot be empty.');
+        assert(description.isNotEmpty, 'Tool description cannot be empty.'),
+        super(defaultOptions: defaultOptions ?? const ToolOptions() as Options);
 
   /// The unique name of the tool that clearly communicates its purpose.
   final String name;
@@ -64,6 +66,7 @@ abstract base class BaseTool<Options extends ToolOptions>
       Options? options,
     }) func,
     required final Map<String, dynamic> inputJsonSchema,
+    final Options? defaultOptions,
     final bool returnDirect = false,
     final String Function(ToolException)? handleToolError,
   }) {
@@ -74,6 +77,7 @@ abstract base class BaseTool<Options extends ToolOptions>
       inputJsonSchema: inputJsonSchema,
       returnDirect: returnDirect,
       handleToolError: handleToolError,
+      defaultOptions: defaultOptions ?? const ToolOptions() as Options,
     );
   }
 
@@ -159,6 +163,7 @@ final class _BaseToolFunc<Options extends ToolOptions>
     required super.inputJsonSchema,
     super.returnDirect = false,
     super.handleToolError,
+    super.defaultOptions,
   });
 
   /// The function to run when the tool is called.
@@ -189,6 +194,7 @@ abstract base class Tool<Options extends ToolOptions>
     final String inputDescription = 'The input to the tool',
     super.returnDirect = false,
     super.handleToolError,
+    super.defaultOptions,
   }) : super(
           inputJsonSchema: {
             'type': 'object',
@@ -267,6 +273,7 @@ final class _ToolFunc<Options extends ToolOptions> extends Tool<Options> {
     required this.func,
     super.returnDirect = false,
     super.handleToolError,
+    super.defaultOptions,
   });
 
   final FutureOr<String> Function(

--- a/packages/langchain_core/lib/src/tools/types.dart
+++ b/packages/langchain_core/lib/src/tools/types.dart
@@ -1,10 +1,10 @@
 import '../exceptions/base.dart';
-import '../language_models/types.dart';
+import '../langchain/types.dart';
 
 /// {@template tool_options}
 /// Generation options to pass into the Tool.
 /// {@endtemplate}
-class ToolOptions extends LanguageModelOptions {
+class ToolOptions extends BaseLangChainOptions {
   /// {@macro tool_options}
   const ToolOptions();
 }

--- a/packages/langchain_core/lib/src/utils/chunk.dart
+++ b/packages/langchain_core/lib/src/utils/chunk.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart';
 
-/// Chunk an array into smaller arrays of a specified size.
-List<List<T>> chunkArray<T>(
+/// Chunk a list into smaller list of a specified size.
+List<List<T>> chunkList<T>(
   final List<T> arr, {
   required final int chunkSize,
 }) {

--- a/packages/langchain_core/test/output_parsers/functions_test.dart
+++ b/packages/langchain_core/test/output_parsers/functions_test.dart
@@ -42,7 +42,7 @@ void main() {
 
   group('OutputFunctionsParser tests', () {
     test('OutputFunctionsParser from ChatResult', () async {
-      final res = await OutputFunctionsParser().parseResult(result);
+      final res = await OutputFunctionsParser().invoke(result);
       expect(res, '{"foo":"bar","bar":"foo"}');
     });
 
@@ -52,8 +52,7 @@ void main() {
     });
 
     test('OutputFunctionsParser from ChatResult argsOnly=false', () async {
-      final res =
-          await OutputFunctionsParser(argsOnly: false).parseResult(result);
+      final res = await OutputFunctionsParser(argsOnly: false).invoke(result);
       expect(
         res,
         json.encode({
@@ -85,7 +84,7 @@ void main() {
 
   group('JsonOutputFunctionsParser tests', () {
     test('JsonOutputFunctionsParser from ChatResult', () async {
-      final res = await JsonOutputFunctionsParser().parseResult(result);
+      final res = await JsonOutputFunctionsParser().invoke(result);
       expect(res, {'foo': 'bar', 'bar': 'foo'});
     });
 
@@ -98,8 +97,8 @@ void main() {
 
   group('JsonKeyOutputFunctionsParser tests', () {
     test('JsonKeyOutputFunctionsParser from ChatResult', () async {
-      final res = await JsonKeyOutputFunctionsParser(keyName: 'foo')
-          .parseResult(result);
+      final res =
+          await JsonKeyOutputFunctionsParser(keyName: 'foo').invoke(result);
       expect(res, 'bar');
     });
 

--- a/packages/langchain_core/test/output_parsers/string_test.dart
+++ b/packages/langchain_core/test/output_parsers/string_test.dart
@@ -15,7 +15,7 @@ void main() {
         metadata: {},
         usage: LanguageModelUsage(),
       );
-      final res = await const StringOutputParser().parseResult(result);
+      final res = await const StringOutputParser().invoke(result);
       expect(res, 'Hello world!');
     });
 
@@ -27,7 +27,7 @@ void main() {
         metadata: {},
         usage: LanguageModelUsage(),
       );
-      final res = await const StringOutputParser().parseResult(result);
+      final res = await const StringOutputParser().invoke(result);
       expect(res, 'Hello world!');
     });
   });

--- a/packages/langchain_core/test/runnables/binding_test.dart
+++ b/packages/langchain_core/test/runnables/binding_test.dart
@@ -11,7 +11,7 @@ void main() {
     test('RunnableBinding from Runnable.bind', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}');
       const model = _FakeOptionsChatModel();
-      const outputParser = StringOutputParser<AIChatMessage>();
+      const outputParser = StringOutputParser<ChatResult>();
       final chain = prompt |
           model.bind(const _FakeOptionsChatModelOptions('world')) |
           outputParser;
@@ -23,7 +23,7 @@ void main() {
     test('Streaming RunnableBinding', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}');
       const model = _FakeOptionsChatModel();
-      const outputParser = StringOutputParser<AIChatMessage>();
+      const outputParser = StringOutputParser<ChatResult>();
 
       final chain = prompt
           .pipe(model.bind(const _FakeOptionsChatModelOptions('world')))
@@ -42,7 +42,8 @@ void main() {
 
 class _FakeOptionsChatModel
     extends SimpleChatModel<_FakeOptionsChatModelOptions> {
-  const _FakeOptionsChatModel();
+  const _FakeOptionsChatModel()
+      : super(defaultOptions: const _FakeOptionsChatModelOptions(''));
 
   @override
   String get modelType => 'fake-options-chat-model';

--- a/packages/langchain_core/test/runnables/function_test.dart
+++ b/packages/langchain_core/test/runnables/function_test.dart
@@ -10,7 +10,7 @@ void main() {
     test('RunnableFunction from Runnable.fromFunction', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<AIChatMessage>();
+      const outputParser = StringOutputParser<ChatResult>();
       final chain = prompt |
           model |
           outputParser |

--- a/packages/langchain_core/test/runnables/map_test.dart
+++ b/packages/langchain_core/test/runnables/map_test.dart
@@ -13,7 +13,7 @@ void main() {
       final prompt1 = PromptTemplate.fromTemplate('Hello {input}!');
       final prompt2 = PromptTemplate.fromTemplate('Bye {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<AIChatMessage>();
+      const outputParser = StringOutputParser<ChatResult>();
       final chain = Runnable.fromMap({
         'left': prompt1 | model | outputParser,
         'right': prompt2 | model | outputParser,
@@ -30,7 +30,7 @@ void main() {
       final prompt1 = PromptTemplate.fromTemplate('Hello {input}!');
       final prompt2 = PromptTemplate.fromTemplate('Bye {input}!');
       const model = FakeEchoLLM();
-      const outputParser = StringOutputParser<String>();
+      const outputParser = StringOutputParser<LLMResult>();
       final chain = Runnable.fromMap({
         'left': prompt1 | model | outputParser,
         'right': prompt2 | model | outputParser,

--- a/packages/langchain_core/test/runnables/passthrough_test.dart
+++ b/packages/langchain_core/test/runnables/passthrough_test.dart
@@ -10,7 +10,7 @@ void main() {
     test('RunnablePassthrough from Runnable.passthrough', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<AIChatMessage>();
+      const outputParser = StringOutputParser<ChatResult>();
       final chain = Runnable.fromMap({
         'in': Runnable.passthrough(),
         'out': Runnable.getMapFromInput() | prompt | model | outputParser,

--- a/packages/langchain_core/test/runnables/sequence_test.dart
+++ b/packages/langchain_core/test/runnables/sequence_test.dart
@@ -11,7 +11,7 @@ void main() {
     test('RunnableSequence from Runnable.pipe', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<AIChatMessage>();
+      const outputParser = StringOutputParser<ChatResult>();
       final chain = prompt.pipe(model).pipe(outputParser);
 
       final res = await chain.invoke({'input': 'world'});
@@ -21,7 +21,7 @@ void main() {
     test('RunnableSequence from | operator', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<AIChatMessage>();
+      const outputParser = StringOutputParser<ChatResult>();
       final chain = prompt | model | outputParser;
 
       final res = await chain.invoke({'input': 'world'});
@@ -31,7 +31,7 @@ void main() {
     test('RunnableSequence from Runnable.fromList', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoChatModel();
-      const outputParser = StringOutputParser<AIChatMessage>();
+      const outputParser = StringOutputParser<ChatResult>();
       final chain = Runnable.fromList([prompt, model, outputParser]);
 
       final res = await chain.invoke({'input': 'world'});
@@ -41,7 +41,7 @@ void main() {
     test('Streaming RunnableSequence', () async {
       final prompt = PromptTemplate.fromTemplate('Hello {input}!');
       const model = FakeEchoLLM();
-      const outputParser = StringOutputParser<String>();
+      const outputParser = StringOutputParser<LLMResult>();
       final chain = prompt.pipe(model).pipe(outputParser);
       final stream = chain.stream({'input': 'world'});
 

--- a/packages/langchain_core/test/utils/chunk_test.dart
+++ b/packages/langchain_core/test/utils/chunk_test.dart
@@ -4,13 +4,13 @@ import 'package:test/test.dart';
 void main() {
   group('Chunk tests', () {
     test('Test with empty list', () {
-      expect(chunkArray(<int>[], chunkSize: 3), <int>[]);
+      expect(chunkList(<int>[], chunkSize: 3), <int>[]);
     });
 
     test('Test with list of integers and chunk size 2', () {
       final arr = [1, 2, 3, 4, 5, 6, 7];
       expect(
-        chunkArray(arr, chunkSize: 2),
+        chunkList(arr, chunkSize: 2),
         [
           [1, 2],
           [3, 4],
@@ -23,7 +23,7 @@ void main() {
     test('Test with list of strings and chunk size 3', () {
       final arr = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
       expect(
-        chunkArray(arr, chunkSize: 3),
+        chunkList(arr, chunkSize: 3),
         [
           ['a', 'b', 'c'],
           ['d', 'e', 'f'],
@@ -35,7 +35,7 @@ void main() {
     test('Test with chunk size larger than list size', () {
       final arr = [1, 2, 3];
       expect(
-        chunkArray(arr, chunkSize: 4),
+        chunkList(arr, chunkSize: 4),
         [
           [1, 2, 3],
         ],

--- a/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
@@ -160,7 +160,7 @@ class ChatGoogleGenerativeAI
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const ChatGoogleGenerativeAIOptions(
+    super.defaultOptions = const ChatGoogleGenerativeAIOptions(
       model: 'gemini-pro',
     ),
   }) : _client = GoogleAIClient(
@@ -173,9 +173,6 @@ class ChatGoogleGenerativeAI
 
   /// A client for interacting with Google AI API.
   final GoogleAIClient _client;
-
-  /// The default options to use when calling the chat completions API.
-  ChatGoogleGenerativeAIOptions defaultOptions;
 
   /// A UUID generator.
   late final Uuid _uuid = const Uuid();

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/chat_vertex_ai.dart
@@ -116,7 +116,7 @@ class ChatVertexAI extends BaseChatModel<ChatVertexAIOptions> {
     required final String project,
     final String location = 'us-central1',
     final String? rootUrl,
-    this.defaultOptions = const ChatVertexAIOptions(
+    super.defaultOptions = const ChatVertexAIOptions(
       publisher: 'google',
       model: 'chat-bison',
     ),
@@ -129,9 +129,6 @@ class ChatVertexAI extends BaseChatModel<ChatVertexAIOptions> {
 
   /// A client for interacting with Vertex AI API.
   final VertexAIGenAIClient client;
-
-  /// The default options to use when calling the model.
-  ChatVertexAIOptions defaultOptions;
 
   /// Scope required for Vertex AI API calls.
   static const cloudPlatformScope = VertexAIGenAIClient.cloudPlatformScope;

--- a/packages/langchain_google/lib/src/embeddings/google_ai/google_ai_embeddings.dart
+++ b/packages/langchain_google/lib/src/embeddings/google_ai/google_ai_embeddings.dart
@@ -120,7 +120,7 @@ class GoogleGenerativeAIEmbeddings implements Embeddings {
   Future<List<List<double>>> embedDocuments(
     final List<Document> documents,
   ) async {
-    final batches = chunkArray(documents, chunkSize: batchSize);
+    final batches = chunkList(documents, chunkSize: batchSize);
 
     final List<List<List<double>>> embeddings = await Future.wait(
       batches.map((final batch) async {

--- a/packages/langchain_google/lib/src/embeddings/vertex_ai/vertex_ai_embeddings.dart
+++ b/packages/langchain_google/lib/src/embeddings/vertex_ai/vertex_ai_embeddings.dart
@@ -168,7 +168,7 @@ class VertexAIEmbeddings implements Embeddings {
   Future<List<List<double>>> embedDocuments(
     final List<Document> documents,
   ) async {
-    final batches = chunkArray(documents, chunkSize: batchSize);
+    final batches = chunkList(documents, chunkSize: batchSize);
 
     final embeddings = await Future.wait(
       batches.map((final batch) async {

--- a/packages/langchain_google/lib/src/llms/vertex_ai/vertex_ai.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai/vertex_ai.dart
@@ -122,7 +122,7 @@ class VertexAI extends BaseLLM<VertexAIOptions> {
     required final String project,
     final String location = 'us-central1',
     final String? rootUrl,
-    this.defaultOptions = const VertexAIOptions(
+    super.defaultOptions = const VertexAIOptions(
       publisher: 'google',
       model: 'text-bison',
     ),
@@ -135,9 +135,6 @@ class VertexAI extends BaseLLM<VertexAIOptions> {
 
   /// A client for interacting with Vertex AI API.
   final VertexAIGenAIClient client;
-
-  /// The default options to use when calling the model.
-  VertexAIOptions defaultOptions;
 
   /// Scope required for Vertex AI API calls.
   static const cloudPlatformScope = VertexAIGenAIClient.cloudPlatformScope;

--- a/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
@@ -155,7 +155,7 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const ChatMistralAIOptions(
+    super.defaultOptions = const ChatMistralAIOptions(
       model: 'mistral-small',
     ),
     this.encoding = 'cl100k_base',
@@ -169,9 +169,6 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
 
   /// A client for interacting with Mistral AI API.
   final MistralAIClient _client;
-
-  /// The default options to use when calling the chat completions API.
-  ChatMistralAIOptions defaultOptions;
 
   /// The encoding to use by tiktoken when [tokenize] is called.
   ///

--- a/packages/langchain_mistralai/lib/src/embeddings/mistralai_embeddings.dart
+++ b/packages/langchain_mistralai/lib/src/embeddings/mistralai_embeddings.dart
@@ -112,7 +112,7 @@ class MistralAIEmbeddings implements Embeddings {
   Future<List<List<double>>> embedDocuments(
     final List<Document> documents,
   ) async {
-    final batches = chunkArray(documents, chunkSize: batchSize);
+    final batches = chunkList(documents, chunkSize: batchSize);
 
     final embeddings = await Future.wait(
       batches.map((final batch) async {

--- a/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
+++ b/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
@@ -25,7 +25,7 @@ void main() {
     });
 
     test('Test ChatMistralAI parameters', () async {
-      chatModel.defaultOptions = const ChatMistralAIOptions(
+      const options = ChatMistralAIOptions(
         model: 'foo',
         temperature: 0.1,
         topP: 0.5,
@@ -34,12 +34,12 @@ void main() {
         randomSeed: 1234,
       );
 
-      expect(chatModel.defaultOptions.model, 'foo');
-      expect(chatModel.defaultOptions.temperature, 0.1);
-      expect(chatModel.defaultOptions.topP, 0.5);
-      expect(chatModel.defaultOptions.maxTokens, 10);
-      expect(chatModel.defaultOptions.safePrompt, true);
-      expect(chatModel.defaultOptions.randomSeed, 1234);
+      expect(options.model, 'foo');
+      expect(options.temperature, 0.1);
+      expect(options.topP, 0.5);
+      expect(options.maxTokens, 10);
+      expect(options.safePrompt, true);
+      expect(options.randomSeed, 1234);
     });
 
     test('Test call to ChatMistralAI', () async {
@@ -112,7 +112,7 @@ void main() {
         'Output ONLY the numbers in one line without any spaces or commas. '
         'NUMBERS:',
       );
-      const stringOutputParser = StringOutputParser<AIChatMessage>();
+      const stringOutputParser = StringOutputParser<ChatResult>();
 
       final chain = promptTemplate.pipe(chatModel).pipe(stringOutputParser);
 

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
@@ -150,7 +150,7 @@ class ChatOllama extends BaseChatModel<ChatOllamaOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const ChatOllamaOptions(
+    super.defaultOptions = const ChatOllamaOptions(
       model: 'llama2',
     ),
     this.encoding = 'cl100k_base',
@@ -163,9 +163,6 @@ class ChatOllama extends BaseChatModel<ChatOllamaOptions> {
 
   /// A client for interacting with Ollama API.
   final OllamaClient _client;
-
-  /// The default options to use when calling the completions API.
-  ChatOllamaOptions defaultOptions;
 
   /// The encoding to use by tiktoken when [tokenize] is called.
   ///

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -151,7 +151,7 @@ class Ollama extends BaseLLM<OllamaOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const OllamaOptions(
+    super.defaultOptions = const OllamaOptions(
       model: 'llama2',
     ),
     this.encoding = 'cl100k_base',
@@ -164,9 +164,6 @@ class Ollama extends BaseLLM<OllamaOptions> {
 
   /// A client for interacting with Ollama API.
   final OllamaClient _client;
-
-  /// The default options to use when calling the completions API.
-  OllamaOptions defaultOptions;
 
   /// The encoding to use by tiktoken when [tokenize] is called.
   ///

--- a/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
+++ b/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
@@ -27,7 +27,7 @@ void main() {
     });
 
     test('Test ChatOllama parameters', () async {
-      chatModel.defaultOptions = const ChatOllamaOptions(
+      const options = ChatOllamaOptions(
         model: 'foo',
         format: OllamaResponseFormat.json,
         numKeep: 0,
@@ -65,44 +65,41 @@ void main() {
         numThread: 21,
       );
 
-      expect(chatModel.defaultOptions.model, 'foo');
-      expect(chatModel.defaultOptions.format, OllamaResponseFormat.json);
-      expect(chatModel.defaultOptions.numKeep, 0);
-      expect(chatModel.defaultOptions.seed, 1);
-      expect(chatModel.defaultOptions.numPredict, 2);
-      expect(chatModel.defaultOptions.topK, 3);
-      expect(chatModel.defaultOptions.topP, 4.0);
-      expect(chatModel.defaultOptions.tfsZ, 5.0);
-      expect(chatModel.defaultOptions.typicalP, 6.0);
-      expect(chatModel.defaultOptions.repeatLastN, 7);
-      expect(chatModel.defaultOptions.temperature, 8.0);
-      expect(chatModel.defaultOptions.repeatPenalty, 9.0);
-      expect(chatModel.defaultOptions.presencePenalty, 10.0);
-      expect(chatModel.defaultOptions.frequencyPenalty, 11.0);
-      expect(chatModel.defaultOptions.mirostat, 12);
-      expect(chatModel.defaultOptions.mirostatTau, 13.0);
-      expect(chatModel.defaultOptions.mirostatEta, 14.0);
-      expect(chatModel.defaultOptions.penalizeNewline, false);
-      expect(
-        chatModel.defaultOptions.stop,
-        ['stop <start_message>', 'stop <stop_message>'],
-      );
-      expect(chatModel.defaultOptions.numa, true);
-      expect(chatModel.defaultOptions.numCtx, 15);
-      expect(chatModel.defaultOptions.numBatch, 16);
-      expect(chatModel.defaultOptions.numGqa, 17);
-      expect(chatModel.defaultOptions.numGpu, 0);
-      expect(chatModel.defaultOptions.mainGpu, 18);
-      expect(chatModel.defaultOptions.lowVram, true);
-      expect(chatModel.defaultOptions.f16KV, true);
-      expect(chatModel.defaultOptions.logitsAll, true);
-      expect(chatModel.defaultOptions.vocabOnly, true);
-      expect(chatModel.defaultOptions.useMmap, true);
-      expect(chatModel.defaultOptions.useMlock, true);
-      expect(chatModel.defaultOptions.embeddingOnly, true);
-      expect(chatModel.defaultOptions.ropeFrequencyBase, 19.0);
-      expect(chatModel.defaultOptions.ropeFrequencyScale, 20.0);
-      expect(chatModel.defaultOptions.numThread, 21);
+      expect(options.model, 'foo');
+      expect(options.format, OllamaResponseFormat.json);
+      expect(options.numKeep, 0);
+      expect(options.seed, 1);
+      expect(options.numPredict, 2);
+      expect(options.topK, 3);
+      expect(options.topP, 4.0);
+      expect(options.tfsZ, 5.0);
+      expect(options.typicalP, 6.0);
+      expect(options.repeatLastN, 7);
+      expect(options.temperature, 8.0);
+      expect(options.repeatPenalty, 9.0);
+      expect(options.presencePenalty, 10.0);
+      expect(options.frequencyPenalty, 11.0);
+      expect(options.mirostat, 12);
+      expect(options.mirostatTau, 13.0);
+      expect(options.mirostatEta, 14.0);
+      expect(options.penalizeNewline, false);
+      expect(options.stop, ['stop <start_message>', 'stop <stop_message>']);
+      expect(options.numa, true);
+      expect(options.numCtx, 15);
+      expect(options.numBatch, 16);
+      expect(options.numGqa, 17);
+      expect(options.numGpu, 0);
+      expect(options.mainGpu, 18);
+      expect(options.lowVram, true);
+      expect(options.f16KV, true);
+      expect(options.logitsAll, true);
+      expect(options.vocabOnly, true);
+      expect(options.useMmap, true);
+      expect(options.useMlock, true);
+      expect(options.embeddingOnly, true);
+      expect(options.ropeFrequencyBase, 19.0);
+      expect(options.ropeFrequencyScale, 20.0);
+      expect(options.numThread, 21);
     });
 
     test('Test model output contains metadata', () async {
@@ -177,7 +174,7 @@ void main() {
         'Output ONLY the numbers in one line without any spaces or commas. '
         'NUMBERS:',
       );
-      const stringOutputParser = StringOutputParser<AIChatMessage>();
+      const stringOutputParser = StringOutputParser<ChatResult>();
 
       final chain = promptTemplate.pipe(chatModel).pipe(stringOutputParser);
 

--- a/packages/langchain_ollama/test/llms/ollama_test.dart
+++ b/packages/langchain_ollama/test/llms/ollama_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values
 import 'dart:io';
 
+import 'package:langchain_core/llms.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_ollama/langchain_ollama.dart';
@@ -24,7 +25,7 @@ void main() {
     });
 
     test('Test Ollama parameters', () async {
-      llm.defaultOptions = const OllamaOptions(
+      const options = OllamaOptions(
         model: 'foo',
         system: 'system prompt',
         template: 'TEMPLATE """',
@@ -71,46 +72,43 @@ void main() {
         llm.defaultOptions.system,
         'system prompt',
       );
-      expect(llm.defaultOptions.template, 'TEMPLATE """');
-      expect(llm.defaultOptions.context, [1, 2, 3]);
-      expect(llm.defaultOptions.format, OllamaResponseFormat.json);
-      expect(llm.defaultOptions.raw, true);
-      expect(llm.defaultOptions.numKeep, 0);
-      expect(llm.defaultOptions.seed, 1);
-      expect(llm.defaultOptions.numPredict, 2);
-      expect(llm.defaultOptions.topK, 3);
-      expect(llm.defaultOptions.topP, 4.0);
-      expect(llm.defaultOptions.tfsZ, 5.0);
-      expect(llm.defaultOptions.typicalP, 6.0);
-      expect(llm.defaultOptions.repeatLastN, 7);
-      expect(llm.defaultOptions.temperature, 8.0);
-      expect(llm.defaultOptions.repeatPenalty, 9.0);
-      expect(llm.defaultOptions.presencePenalty, 10.0);
-      expect(llm.defaultOptions.frequencyPenalty, 11.0);
-      expect(llm.defaultOptions.mirostat, 12);
-      expect(llm.defaultOptions.mirostatTau, 13.0);
-      expect(llm.defaultOptions.mirostatEta, 14.0);
-      expect(llm.defaultOptions.penalizeNewline, false);
-      expect(
-        llm.defaultOptions.stop,
-        ['stop <start_message>', 'stop <stop_message>'],
-      );
-      expect(llm.defaultOptions.numa, true);
-      expect(llm.defaultOptions.numCtx, 15);
-      expect(llm.defaultOptions.numBatch, 16);
-      expect(llm.defaultOptions.numGqa, 17);
-      expect(llm.defaultOptions.numGpu, 0);
-      expect(llm.defaultOptions.mainGpu, 18);
-      expect(llm.defaultOptions.lowVram, true);
-      expect(llm.defaultOptions.f16KV, true);
-      expect(llm.defaultOptions.logitsAll, true);
-      expect(llm.defaultOptions.vocabOnly, true);
-      expect(llm.defaultOptions.useMmap, true);
-      expect(llm.defaultOptions.useMlock, true);
-      expect(llm.defaultOptions.embeddingOnly, true);
-      expect(llm.defaultOptions.ropeFrequencyBase, 19.0);
-      expect(llm.defaultOptions.ropeFrequencyScale, 20.0);
-      expect(llm.defaultOptions.numThread, 21);
+      expect(options.template, 'TEMPLATE """');
+      expect(options.context, [1, 2, 3]);
+      expect(options.format, OllamaResponseFormat.json);
+      expect(options.raw, true);
+      expect(options.numKeep, 0);
+      expect(options.seed, 1);
+      expect(options.numPredict, 2);
+      expect(options.topK, 3);
+      expect(options.topP, 4.0);
+      expect(options.tfsZ, 5.0);
+      expect(options.typicalP, 6.0);
+      expect(options.repeatLastN, 7);
+      expect(options.temperature, 8.0);
+      expect(options.repeatPenalty, 9.0);
+      expect(options.presencePenalty, 10.0);
+      expect(options.frequencyPenalty, 11.0);
+      expect(options.mirostat, 12);
+      expect(options.mirostatTau, 13.0);
+      expect(options.mirostatEta, 14.0);
+      expect(options.penalizeNewline, false);
+      expect(options.stop, ['stop <start_message>', 'stop <stop_message>']);
+      expect(options.numa, true);
+      expect(options.numCtx, 15);
+      expect(options.numBatch, 16);
+      expect(options.numGqa, 17);
+      expect(options.numGpu, 0);
+      expect(options.mainGpu, 18);
+      expect(options.lowVram, true);
+      expect(options.f16KV, true);
+      expect(options.logitsAll, true);
+      expect(options.vocabOnly, true);
+      expect(options.useMmap, true);
+      expect(options.useMlock, true);
+      expect(options.embeddingOnly, true);
+      expect(options.ropeFrequencyBase, 19.0);
+      expect(options.ropeFrequencyScale, 20.0);
+      expect(options.numThread, 21);
     });
 
     test('Test call to Ollama', () async {
@@ -190,7 +188,7 @@ void main() {
         'Output ONLY the numbers in one line without any spaces or commas. '
         'NUMBERS:',
       );
-      const stringOutputParser = StringOutputParser<String>();
+      const stringOutputParser = StringOutputParser<LLMResult>();
 
       final chain = promptTemplate.pipe(llm).pipe(stringOutputParser);
 

--- a/packages/langchain_openai/lib/src/chains/qa_with_sources.dart
+++ b/packages/langchain_openai/lib/src/chains/qa_with_sources.dart
@@ -1,5 +1,4 @@
 import 'package:langchain_core/chat_models.dart';
-import 'package:langchain_core/langchain.dart';
 import 'package:langchain_core/output_parsers.dart';
 
 import 'qa_with_structure.dart';
@@ -91,8 +90,8 @@ class QAWithSources {
 /// {@template qa_with_sources_output_parser}
 /// A parser that converts the output of the OpenAI API into a [QAWithSources].
 /// {@endtemplate}
-class QAWithSourcesOutputParser<CallOptions extends BaseLangChainOptions>
-    extends BaseOutputFunctionsParser<CallOptions, QAWithSources> {
+class QAWithSourcesOutputParser
+    extends BaseOutputFunctionsParser<OutputParserOptions, QAWithSources> {
   /// {@macro qa_with_sources_output_parser}
   QAWithSourcesOutputParser();
 

--- a/packages/langchain_openai/lib/src/chains/qa_with_structure.dart
+++ b/packages/langchain_openai/lib/src/chains/qa_with_structure.dart
@@ -1,6 +1,5 @@
 import 'package:langchain_core/chains.dart';
 import 'package:langchain_core/chat_models.dart';
-import 'package:langchain_core/langchain.dart';
 import 'package:langchain_core/memory.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:langchain_core/prompts.dart';
@@ -16,15 +15,14 @@ import '../chat_models/chat_models.dart';
 /// a specific structure (e.g. the answer and the sources used to answer the
 /// question).
 /// {@endtemplate}
-class OpenAIQAWithStructureChain<CallOptions extends BaseLangChainOptions,
-        S extends Object>
-    extends LLMChain<ChatOpenAI, ChatOpenAIOptions,
-        BaseOutputFunctionsParser<CallOptions, S>, BaseChatMemory> {
+class OpenAIQAWithStructureChain<S extends Object>
+    extends LLMChain<ChatOpenAI, ChatOpenAIOptions, BaseChatMemory> {
   /// {@macro openai_qa_with_structure_chain}
   OpenAIQAWithStructureChain({
     required super.llm,
     required final ChatFunction function,
-    required BaseOutputFunctionsParser<CallOptions, S> super.outputParser,
+    required BaseOutputFunctionsParser<OutputParserOptions, S>
+        super.outputParser,
     final BasePromptTemplate? prompt,
   }) : super(
           prompt: prompt ?? _getPrompt(),

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
@@ -191,7 +191,7 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const ChatOpenAIOptions(
+    super.defaultOptions = const ChatOpenAIOptions(
       model: 'gpt-3.5-turbo',
     ),
     this.encoding,
@@ -206,9 +206,6 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
 
   /// A client for interacting with OpenAI API.
   final OpenAIClient _client;
-
-  /// The default options to use when calling the completions API.
-  ChatOpenAIOptions defaultOptions;
 
   /// The encoding to use by tiktoken when [tokenize] is called.
   ///

--- a/packages/langchain_openai/lib/src/embeddings/openai.dart
+++ b/packages/langchain_openai/lib/src/embeddings/openai.dart
@@ -185,7 +185,7 @@ class OpenAIEmbeddings implements Embeddings {
     final List<Document> documents,
   ) async {
     // TODO use tiktoken to chunk documents that exceed the context length of the model
-    final batches = chunkArray(documents, chunkSize: batchSize);
+    final batches = chunkList(documents, chunkSize: batchSize);
 
     final embeddings = await Future.wait(
       batches.map((final batch) async {

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -184,7 +184,7 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const OpenAIOptions(
+    super.defaultOptions = const OpenAIOptions(
       model: 'gpt-3.5-turbo-instruct',
       maxTokens: 256,
     ),
@@ -200,9 +200,6 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
 
   /// A client for interacting with OpenAI API.
   final OpenAIClient _client;
-
-  /// The default options to use when calling the completions API.
-  OpenAIOptions defaultOptions;
 
   /// The encoding to use by tiktoken when [tokenize] is called.
   ///

--- a/packages/langchain_openai/lib/src/tools/dall_e.dart
+++ b/packages/langchain_openai/lib/src/tools/dall_e.dart
@@ -54,7 +54,7 @@ final class OpenAIDallETool extends Tool<OpenAIDallEToolOptions> {
     final Map<String, String>? headers,
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
-    this.defaultOptions = const OpenAIDallEToolOptions(),
+    super.defaultOptions = const OpenAIDallEToolOptions(),
   })  : _client = OpenAIClient(
           apiKey: apiKey ?? '',
           organization: organization,
@@ -72,9 +72,6 @@ final class OpenAIDallETool extends Tool<OpenAIDallEToolOptions> {
 
   /// A client for interacting with OpenAI API.
   final OpenAIClient _client;
-
-  /// The default options to use when calling the DALL-E tool.
-  OpenAIDallEToolOptions defaultOptions;
 
   /// Set or replace the API key.
   set apiKey(final String value) => _client.apiKey = value;

--- a/packages/langchain_openai/test/chains/qa_with_sources_test.dart
+++ b/packages/langchain_openai/test/chains/qa_with_sources_test.dart
@@ -131,7 +131,7 @@ Question: {question}
           temperature: 0,
         ),
       );
-      const outputParser = StringOutputParser<AIChatMessage>();
+      const outputParser = StringOutputParser<ChatResult>();
 
       final chain = Runnable.fromMap<String>({
         'context': retriever.pipe(docCombiner),

--- a/packages/langchain_openai/test/chat_models/chat_openai_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_test.dart
@@ -250,7 +250,7 @@ void main() {
         ),
       ]);
       final chat = ChatOpenAI(apiKey: openaiApiKey);
-      const stringOutputParser = StringOutputParser<AIChatMessage>();
+      const stringOutputParser = StringOutputParser<ChatResult>();
 
       final chain = promptTemplate.pipe(chat).pipe(stringOutputParser);
       final stream = chain.stream({'max_num': '9'});

--- a/packages/langchain_openai/test/llms/openai_test.dart
+++ b/packages/langchain_openai/test/llms/openai_test.dart
@@ -3,6 +3,7 @@ library; // Uses dart:io
 
 import 'dart:io';
 
+import 'package:langchain_core/llms.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_openai/langchain_openai.dart';
@@ -10,8 +11,23 @@ import 'package:test/test.dart';
 
 void main() {
   group('OpenAI tests', () {
-    final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
     const defaultModel = 'gpt-3.5-turbo-instruct';
+    final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
+
+    late OpenAI llm;
+
+    setUp(() async {
+      llm = OpenAI(
+        apiKey: openaiApiKey,
+        defaultOptions: const OpenAIOptions(
+          model: defaultModel,
+        ),
+      );
+    });
+
+    tearDown(() {
+      llm.close();
+    });
 
     test('Test OpenAI parameters', () async {
       final llm = OpenAI(
@@ -29,6 +45,7 @@ void main() {
           user: 'foo',
         ),
       );
+      expect(llm.apiKey, openaiApiKey);
       expect(llm.defaultOptions.model, defaultModel);
       expect(llm.defaultOptions.maxTokens, 10);
       expect(llm.defaultOptions.temperature, 0.1);
@@ -42,25 +59,11 @@ void main() {
     });
 
     test('Test call to OpenAI', () async {
-      final llm = OpenAI(
-        apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(
-          model: defaultModel,
-          maxTokens: 10,
-        ),
-      );
       final output = await llm('Say foo:');
       expect(output, isNotEmpty);
     });
 
     test('Test close OpenAI', () async {
-      final llm = OpenAI(
-        apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(
-          model: defaultModel,
-          maxTokens: 10,
-        ),
-      );
       final output = await llm('Say foo:');
       expect(output, isNotEmpty);
       llm.close();
@@ -68,13 +71,6 @@ void main() {
     });
 
     test('Test invoke to OpenAI', () async {
-      final llm = OpenAI(
-        apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(
-          model: defaultModel,
-          maxTokens: 10,
-        ),
-      );
       final res = await llm.invoke(
         PromptValue.string('Hello, how are you?'),
       );
@@ -82,13 +78,6 @@ void main() {
     });
 
     test('Test model output contains metadata', () async {
-      final llm = OpenAI(
-        apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(
-          model: defaultModel,
-          maxTokens: 10,
-        ),
-      );
       final res = await llm.invoke(
         PromptValue.string('Hello, how are you?'),
       );
@@ -99,39 +88,32 @@ void main() {
     });
 
     test('Test stop logic on valid configuration', () async {
-      const query = 'write an ordered list of five items';
-      final llm = OpenAI(
-        apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(
-          model: defaultModel,
+      final res = await llm.invoke(
+        PromptValue.string('write an ordered list of five items'),
+        options: const OpenAIOptions(
+          stop: ['3'],
           temperature: 0,
         ),
       );
-      final res = await llm(query, options: const OpenAIOptions(stop: ['3']));
-      expect(res.contains('2.'), isTrue);
-      expect(res.contains('3.'), isFalse);
+      expect(res.output.contains('2.'), isTrue);
+      expect(res.output.contains('3.'), isFalse);
     });
 
     test('Test tokenize', () async {
-      final llm = OpenAI(apiKey: openaiApiKey);
-      const text = 'Hello, how are you?';
-
-      final tokens = await llm.tokenize(PromptValue.string(text));
+      final text = PromptValue.string('Hello, how are you?');
+      final tokens = await llm.tokenize(text);
       expect(tokens, [9906, 11, 1268, 527, 499, 30]);
     });
 
     test('Test different encoding than the model', () async {
-      final llm = OpenAI(apiKey: openaiApiKey, encoding: 'cl100k_base');
+      llm.encoding = 'cl100k_base';
       const text = 'Hello, how are you?';
-
       final tokens = await llm.tokenize(PromptValue.string(text));
       expect(tokens, [9906, 11, 1268, 527, 499, 30]);
     });
 
     test('Test countTokens', () async {
-      final llm = OpenAI(apiKey: openaiApiKey);
       const text = 'Hello, how are you?';
-
       final numTokens = await llm.countTokens(PromptValue.string(text));
       expect(numTokens, 6);
     });
@@ -140,8 +122,7 @@ void main() {
       final promptTemplate = PromptTemplate.fromTemplate(
         'List the numbers from 1 to {max_num} in order without any spaces or commas',
       );
-      final llm = OpenAI(apiKey: openaiApiKey);
-      const stringOutputParser = StringOutputParser<String>();
+      const stringOutputParser = StringOutputParser<LLMResult>();
 
       final chain = promptTemplate.pipe(llm).pipe(stringOutputParser);
 
@@ -159,17 +140,14 @@ void main() {
 
     test('Test response seed', () async {
       final prompt = PromptValue.string('How are you?');
-      final llm = OpenAI(
-        apiKey: openaiApiKey,
-        defaultOptions: const OpenAIOptions(
-          model: defaultModel,
-          temperature: 0,
-          seed: 9999,
-        ),
+      const options = OpenAIOptions(
+        model: defaultModel,
+        temperature: 0,
+        seed: 9999,
       );
 
-      final res1 = await llm.invoke(prompt);
-      final res2 = await llm.invoke(prompt);
+      final res1 = await llm.invoke(prompt, options: options);
+      final res2 = await llm.invoke(prompt, options: options);
 
       expect(
         res1.metadata['system_fingerprint'],


### PR DESCRIPTION
Relates to #266

The `BaseOutputParser` class has been reworked. Before it was strongly coupled to LLMs/ChatModels and they could not be used with other types of `Runnables`. You couldn't pass options to the parser either.

Now the `BaseOutputParser` takes 3 generic parameters:
- `ParserInput` (`extends Object?`): the type of the input to the parser.
- `CallOptions` (`extends OutputParserOptions`): the type of the options to pass to the parser.
- `ParserOutput` (`extends Object?`): the type of the output of the parser.

## Migration guide

### `StringOutputParser`

You now have to specify in input type in the generic parameter of `StringOutputParser`.

If you were using a `StringOutputParser` with an llm (e.g. `OpenAI`):

**Before:**
```dart
const outputParser = StringOutputParser<String>();
```

**After:**
```dart
const outputParser = StringOutputParser<LLMResult>();
```

If you were using a `StringOutputParser` with a Chat Model (e.g. `ChatOpenAI`):

**Before:**
```dart
const outputParser = StringOutputParser<AIChatMessage>();
```

**After:**
```dart
const outputParser = StringOutputParser<ChatResult>();
```

If you were using a `StringOutputParser` defined inside the chain, the generic type will still be inferred automatically:

```dart
final chain = promptTemplate.pipe(model).pipe(StringOutputParser());
```