### PR TITLE
feat: Add reduceOutputStream option to StringOutputParser

### DIFF
--- a/packages/langchain_core/lib/src/chat_models/fake.dart
+++ b/packages/langchain_core/lib/src/chat_models/fake.dart
@@ -30,6 +30,24 @@ class FakeChatModel extends SimpleChatModel {
   }
 
   @override
+  Stream<ChatResult> stream(
+    final PromptValue input, {
+    final ChatModelOptions? options,
+  }) {
+    final res = responses[_i++ % responses.length].split('');
+    return Stream.fromIterable(res).map(
+      (final char) => ChatResult(
+        id: 'fake-chat-model',
+        output: AIChatMessage(content: char),
+        finishReason: FinishReason.stop,
+        metadata: const {},
+        usage: const LanguageModelUsage(),
+        streaming: true,
+      ),
+    );
+  }
+
+  @override
   Future<List<int>> tokenize(
     final PromptValue promptValue, {
     final ChatModelOptions? options,

--- a/packages/langchain_core/test/output_parsers/string_test.dart
+++ b/packages/langchain_core/test/output_parsers/string_test.dart
@@ -3,6 +3,7 @@ import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/llms.dart';
 import 'package:langchain_core/output_parsers.dart';
+import 'package:langchain_core/prompts.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -29,6 +30,21 @@ void main() {
       );
       final res = await const StringOutputParser().invoke(result);
       expect(res, 'Hello world!');
+    });
+
+    test('Test reduceOutputStream', () async {
+      final chat = FakeChatModel(responses: ['ABC']);
+
+      final chain1 =
+          chat.pipe(const StringOutputParser(reduceOutputStream: false));
+      final chain2 =
+          chat.pipe(const StringOutputParser(reduceOutputStream: true));
+
+      final res1 = await chain1.stream(PromptValue.string('test')).toList();
+      final res2 = await chain2.stream(PromptValue.string('test')).toList();
+
+      expect(res1, ['A', 'B', 'C']);
+      expect(res2, ['ABC']);
     });
   });
 }


### PR DESCRIPTION
When invoking this parser with `Runnable.stream`, every item from the input stream will be parsed and emitted by default. If `reduceOutputStream` is set to `true`, the parser will reduce the output stream into a single String and emit it as a single item. This is useful when the next `Runnable` in a chain expects a single String as input.

Visual example:
```
- reduceOutputStream = false
'A', 'B', 'C' -> 'A', 'B', 'C'
- reduceOutputStream = true
'A', 'B', 'C' -> 'ABC'
```