### PR TITLE
feat: Implement .batch support

### DIFF
--- a/docs/expression_language/interface.md
+++ b/docs/expression_language/interface.md
@@ -17,7 +17,7 @@ The type of the input and output varies by component:
 | `LLM`                       | `PromptValue`          | `LLMResult`            |
 | `ChatModel`                 | `PromptValue`          | `ChatResult`           |
 | `Chain`                     | `Map<String, dynamic>` | `Map<String, dynamic>` |
-| `OutputParser`              | `LanguageModelResult`  | Parser output type     |
+| `OutputParser`              | Runnable input type    | Parser output type     |
 | `Tool`                      | `Map<String, dynamic>` | `String`               |
 | `RunnableSequence`          | Fist input type        | Last output type       |
 | `RunnableMap`               | Runnable input type    | `Map<String, dynamic>` |
@@ -104,7 +104,40 @@ await for (final res in stream) {
 
 ### Batch
 
-Batch is not supported yet.
+Batches the invocation of the `Runnable` on the given `inputs`.
+
+```dart
+final res = await chain.batch([
+  {'topic': 'bears'},
+  {'topic': 'cats'},
+]);
+print(res);
+//['Why did the bear break up with his girlfriend? Because she was too "grizzly" for him!',
+// 'Why was the cat sitting on the computer? Because it wanted to keep an eye on the mouse!']
+```
+
+If the underlying provider supports batching, this method will try to batch the calls to the provider. Otherwise, it will just call `invoke` on each input concurrently. You can configure the concurrency limit by setting the `concurrencyLimit` field in the `options` parameter.
+
+You can provide call options to the `batch` method using the `options` parameter. It can be:
+- `null`: the default options are used.
+- List with 1 element: the same options are used for all inputs.
+- List with the same length as the inputs: each input gets its own options.
+
+```dart
+final res = await chain.batch(
+  [
+    {'topic': 'bears'},
+    {'topic': 'cats'},
+  ],
+  options: [
+    const ChatOpenAIOptions(model: 'gpt-3.5-turbo', temperature: 0.5),
+    const ChatOpenAIOptions(model: 'gpt-4', temperature: 0.7),
+  ],
+);
+print(res);
+//['Why did the bear break up with his girlfriend? Because he couldn't bear the relationship anymore!,',
+// 'Why don't cats play poker in the jungle? Because there's too many cheetahs!']
+```
 
 ## Runnable types
 

--- a/examples/docs_examples/bin/expression_language/interface.dart
+++ b/examples/docs_examples/bin/expression_language/interface.dart
@@ -10,6 +10,8 @@ void main(final List<String> arguments) async {
   // Runnable interface
   await _runnableInterfaceInvoke();
   await _runnableInterfaceStream();
+  await _runnableInterfaceBatch();
+  await _runnableInterfaceBatchOptions();
 
   // Runnable types
   await _runnableTypesRunnableSequence();
@@ -70,6 +72,50 @@ Future<void> _runnableInterfaceStream() async {
   // 13:  catch
   // 14:  it
   // 15: !
+}
+
+Future<void> _runnableInterfaceBatch() async {
+  final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
+  final model = ChatOpenAI(apiKey: openaiApiKey);
+
+  final promptTemplate = ChatPromptTemplate.fromTemplate(
+    'Tell me a joke about {topic}',
+  );
+
+  final chain = promptTemplate.pipe(model).pipe(const StringOutputParser());
+
+  final res = await chain.batch([
+    {'topic': 'bears'},
+    {'topic': 'cats'},
+  ]);
+  print(res);
+  //['Why did the bear break up with his girlfriend? Because she was too "grizzly" for him!',
+  // 'Why was the cat sitting on the computer? Because it wanted to keep an eye on the mouse!']
+}
+
+Future<void> _runnableInterfaceBatchOptions() async {
+  final openaiApiKey = Platform.environment['OPENAI_API_KEY'];
+  final model = ChatOpenAI(apiKey: openaiApiKey);
+
+  final promptTemplate = ChatPromptTemplate.fromTemplate(
+    'Tell me a joke about {topic}',
+  );
+
+  final chain = promptTemplate.pipe(model).pipe(const StringOutputParser());
+
+  final res = await chain.batch(
+    [
+      {'topic': 'bears'},
+      {'topic': 'cats'},
+    ],
+    options: [
+      const ChatOpenAIOptions(model: 'gpt-3.5-turbo', temperature: 0.5),
+      const ChatOpenAIOptions(model: 'gpt-4', temperature: 0.7),
+    ],
+  );
+  print(res);
+  //['Why did the bear break up with his girlfriend? Because he couldn't bear the relationship anymore!,',
+  // 'Why don't cats play poker in the jungle? Because there's too many cheetahs!']
 }
 
 Future<void> _runnableTypesRunnableSequence() async {

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -18,7 +18,7 @@ The components can be grouped into a few core modules:
 
 ![LangChain.dart](https://raw.githubusercontent.com/davidmigloz/langchain_dart/main/docs/img/langchain.dart.png)
 
-- 📃 **Model I/O:** LangChain offers a unified API for interacting with various LLM providers (e.g. OpenAI, Google, Mistral, Ollama, etc.), allowing developers to switch between them with ease. Additionally, it provides tools for managing model inputs (prompt templates and example selectors) and parses the resulting model outputs (output parsers).
+- 📃 **Model I/O:** LangChain offers a unified API for interacting with various LLM providers (e.g. OpenAI, Google, Mistral, Ollama, etc.), allowing developers to switch between them with ease. Additionally, it provides tools for managing model inputs (prompt templates and example selectors) and parsing the resulting model outputs (output parsers).
 - 📚 **Retrieval:** assists in loading user data (via document loaders), transforming it (with text splitters), extracting its meaning (using embedding models), storing (in vector stores) and retrieving it (through retrievers) so that it can be used to ground the model's responses (i.e. Retrieval-Augmented Generation or RAG). 
 - 🤖 **Agents:** "bots" that leverage LLMs to make informed decisions about which available tools (such as web search, calculators, database lookup, etc.) to use to accomplish the designated task.
 

--- a/packages/langchain_core/lib/src/chains/types.dart
+++ b/packages/langchain_core/lib/src/chains/types.dart
@@ -11,5 +11,7 @@ typedef ChainValues = Map<String, dynamic>;
 @immutable
 class ChainOptions extends BaseLangChainOptions {
   /// {@macro chain_options}
-  const ChainOptions();
+  const ChainOptions({
+    super.concurrencyLimit,
+  });
 }

--- a/packages/langchain_core/lib/src/chat_models/types.dart
+++ b/packages/langchain_core/lib/src/chat_models/types.dart
@@ -8,7 +8,9 @@ import '../language_models/language_models.dart';
 /// {@endtemplate}
 class ChatModelOptions extends LanguageModelOptions {
   /// {@macro chat_model_options}
-  const ChatModelOptions();
+  const ChatModelOptions({
+    super.concurrencyLimit,
+  });
 }
 
 /// {@template chat_result}
@@ -43,6 +45,19 @@ class ChatResult extends LanguageModelResult<AIChatMessage> {
       usage: usage.concat(other.usage),
       streaming: other.streaming,
     );
+  }
+
+  @override
+  String toString() {
+    return '''
+ChatResult{
+  id: $id, 
+  output: $output,
+  finishReason: $finishReason,
+  metadata: $metadata,
+  usage: $usage,
+  streaming: $streaming
+}''';
   }
 }
 

--- a/packages/langchain_core/lib/src/langchain/types.dart
+++ b/packages/langchain_core/lib/src/langchain/types.dart
@@ -8,5 +8,7 @@ import '../runnables/types.dart';
 @immutable
 class BaseLangChainOptions extends RunnableOptions {
   /// {@macro base_lang_chain_options}
-  const BaseLangChainOptions();
+  const BaseLangChainOptions({
+    super.concurrencyLimit,
+  });
 }

--- a/packages/langchain_core/lib/src/language_models/types.dart
+++ b/packages/langchain_core/lib/src/language_models/types.dart
@@ -9,7 +9,9 @@ import '../langchain/types.dart';
 @immutable
 abstract class LanguageModelOptions extends BaseLangChainOptions {
   /// {@macro language_model_options}
-  const LanguageModelOptions();
+  const LanguageModelOptions({
+    super.concurrencyLimit,
+  });
 }
 
 /// {@template language_model}
@@ -75,19 +77,6 @@ abstract class LanguageModelResult<O extends Object> {
 
   /// Merges this result with another by concatenating the outputs.
   LanguageModelResult<O> concat(final LanguageModelResult<O> other);
-
-  @override
-  String toString() {
-    return '''
-LanguageModelResult{
-  id: $id, 
-  output: $output,
-  finishReason: $finishReason,
-  metadata: $metadata,
-  usage: $usage,
-  streaming: $streaming
-}''';
-  }
 }
 
 /// {@template language_model_usage}

--- a/packages/langchain_core/lib/src/llms/types.dart
+++ b/packages/langchain_core/lib/src/llms/types.dart
@@ -1,11 +1,16 @@
+import 'package:meta/meta.dart';
+
 import '../language_models/types.dart';
 
 /// {@template llm_options}
 /// Generation options to pass into the LLM.
 /// {@endtemplate}
+@immutable
 class LLMOptions extends LanguageModelOptions {
   /// {@macro llm_options}
-  const LLMOptions();
+  const LLMOptions({
+    super.concurrencyLimit,
+  });
 }
 
 /// {@template llm_result}
@@ -40,5 +45,18 @@ class LLMResult extends LanguageModelResult<String> {
       usage: usage.concat(other.usage),
       streaming: other.streaming,
     );
+  }
+
+  @override
+  String toString() {
+    return '''
+LLMResult{
+  id: $id, 
+  output: $output,
+  finishReason: $finishReason,
+  metadata: $metadata,
+  usage: $usage,
+  streaming: $streaming
+}''';
   }
 }

--- a/packages/langchain_core/lib/src/output_parsers/types.dart
+++ b/packages/langchain_core/lib/src/output_parsers/types.dart
@@ -8,5 +8,7 @@ import '../langchain/types.dart';
 @immutable
 class OutputParserOptions extends BaseLangChainOptions {
   /// {@macro output_parser_options}
-  const OutputParserOptions();
+  const OutputParserOptions({
+    super.concurrencyLimit,
+  });
 }

--- a/packages/langchain_core/lib/src/runnables/map.dart
+++ b/packages/langchain_core/lib/src/runnables/map.dart
@@ -62,7 +62,10 @@ class RunnableMap<RunInput extends Object>
     final output = <String, dynamic>{};
 
     await Future.forEach(steps.entries, (final entry) async {
-      output[entry.key] = await entry.value.invoke(input, options: options);
+      output[entry.key] = await entry.value.invoke(
+        input,
+        options: entry.value.getCompatibleOptions(options),
+      );
     });
 
     return output;
@@ -87,7 +90,10 @@ class RunnableMap<RunInput extends Object>
     return StreamGroup.merge(
       steps.entries.map((final entry) {
         return entry.value
-            .streamFromInputStream(inputStream, options: options)
+            .streamFromInputStream(
+              inputStream,
+              options: entry.value.getCompatibleOptions(options),
+            )
             .map((final output) => {entry.key: output});
       }),
     ).asBroadcastStream();

--- a/packages/langchain_core/lib/src/runnables/sequence.dart
+++ b/packages/langchain_core/lib/src/runnables/sequence.dart
@@ -102,10 +102,16 @@ class RunnableSequence<RunInput extends Object?, RunOutput extends Object?>
     Object? nextStepInput = input;
 
     for (final step in [first, ...middle]) {
-      nextStepInput = await step.invoke(nextStepInput, options: options);
+      nextStepInput = await step.invoke(
+        nextStepInput,
+        options: step.getCompatibleOptions(options),
+      );
     }
 
-    return last.invoke(nextStepInput, options: options);
+    return last.invoke(
+      nextStepInput,
+      options: last.getCompatibleOptions(options),
+    );
   }
 
   @override
@@ -126,21 +132,30 @@ class RunnableSequence<RunInput extends Object?, RunOutput extends Object?>
   }) {
     Stream<Object?> nextStepStream;
     try {
-      nextStepStream = first.streamFromInputStream(inputStream);
+      nextStepStream = first.streamFromInputStream(
+        inputStream,
+        options: first.getCompatibleOptions(options),
+      );
     } on TypeError catch (e) {
       _throwInvalidInputTypeStream(e, first);
     }
 
     for (final step in middle) {
       try {
-        nextStepStream = step.streamFromInputStream(nextStepStream);
+        nextStepStream = step.streamFromInputStream(
+          nextStepStream,
+          options: step.getCompatibleOptions(options),
+        );
       } on TypeError catch (e) {
         _throwInvalidInputTypeStream(e, step);
       }
     }
 
     try {
-      return last.streamFromInputStream(nextStepStream);
+      return last.streamFromInputStream(
+        nextStepStream,
+        options: last.getCompatibleOptions(options),
+      );
     } on TypeError catch (e) {
       _throwInvalidInputTypeStream(e, last);
     }

--- a/packages/langchain_core/lib/src/runnables/types.dart
+++ b/packages/langchain_core/lib/src/runnables/types.dart
@@ -6,5 +6,11 @@ import 'package:meta/meta.dart';
 @immutable
 class RunnableOptions {
   /// {@macro runnable_options}
-  const RunnableOptions();
+  const RunnableOptions({
+    this.concurrencyLimit = 1000,
+  });
+
+  /// The maximum number of concurrent calls that the runnable can make.
+  /// Defaults to 1000 (different Runnable types may have different defaults).
+  final int concurrencyLimit;
 }

--- a/packages/langchain_core/test/runnables/batch_test.dart
+++ b/packages/langchain_core/test/runnables/batch_test.dart
@@ -1,0 +1,137 @@
+// ignore_for_file: unused_element
+import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/documents.dart';
+import 'package:langchain_core/language_models.dart';
+import 'package:langchain_core/llms.dart';
+import 'package:langchain_core/output_parsers.dart';
+import 'package:langchain_core/prompts.dart';
+import 'package:langchain_core/retrievers.dart';
+import 'package:langchain_core/tools.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Runnable batch tests', () {
+    test('PromptTemplate batch', () async {
+      final run = PromptTemplate.fromTemplate('This is a {input}');
+      final res = await run.batch([
+        {'input': 'test1'},
+        {'input': 'test2'},
+        {'input': 'test3'},
+      ]);
+      expect(
+        res.map((final e) => e.toString()).toList(),
+        equals(['This is a test1', 'This is a test2', 'This is a test3']),
+      );
+    });
+
+    test('ChatPromptTemplate batch', () async {
+      final run = ChatPromptTemplate.fromPromptMessages([
+        SystemChatMessagePromptTemplate.fromTemplate(
+          'You are a helpful chatbot',
+        ),
+        HumanChatMessagePromptTemplate.fromTemplate('{input}'),
+      ]);
+      final res = await run.batch([
+        {'input': 'test1'},
+        {'input': 'test2'},
+        {'input': 'test3'},
+      ]);
+      expect(
+        res.map((final e) => e.toChatMessages()).toList(),
+        equals([
+          [
+            ChatMessage.system('You are a helpful chatbot'),
+            ChatMessage.humanText('test1'),
+          ],
+          [
+            ChatMessage.system('You are a helpful chatbot'),
+            ChatMessage.humanText('test2'),
+          ],
+          [
+            ChatMessage.system('You are a helpful chatbot'),
+            ChatMessage.humanText('test3'),
+          ],
+        ]),
+      );
+    });
+
+    test('Retriever batch', () async {
+      const doc = Document(
+        id: '1',
+        pageContent: 'This is a test',
+      );
+      const run = FakeRetriever([doc]);
+      final res = await run.batch(['test1', 'test2', 'test3']);
+      expect(
+        res.map((final e) => e).toList(),
+        equals([
+          [doc],
+          [doc],
+          [doc],
+        ]),
+      );
+    });
+
+    test('LLM batch', () async {
+      final run = FakeListLLM(
+        responses: ['test1', 'test2', 'test3'],
+      );
+      final res = await run.batch([
+        PromptValue.string('test1'),
+        PromptValue.string('test2'),
+        PromptValue.string('test3'),
+      ]);
+      expect(
+        res.map((final e) => e.output).toList(),
+        equals(['test1', 'test2', 'test3']),
+      );
+    });
+
+    test('ChatModel batch', () async {
+      final run = FakeChatModel(
+        responses: ['test1', 'test2', 'test3'],
+      );
+      final res = await run.batch([
+        PromptValue.string('test1'),
+        PromptValue.string('test2'),
+        PromptValue.string('test3'),
+      ]);
+      expect(
+        res.map((final e) => e.output.content).toList(),
+        equals(['test1', 'test2', 'test3']),
+      );
+    });
+
+    test('OutputParser batch', () async {
+      final results = List.generate(
+        3,
+        (final i) => LLMResult(
+          id: 'id$i',
+          output: 'Hello world! $i',
+          finishReason: FinishReason.stop,
+          metadata: const {},
+          usage: const LanguageModelUsage(),
+        ),
+      );
+      const run = StringOutputParser();
+      final res = await run.batch(results);
+      expect(
+        res,
+        equals(['Hello world! 0', 'Hello world! 1', 'Hello world! 2']),
+      );
+    });
+
+    test('Tool batch', () async {
+      final run = FakeTool();
+      final res = await run.batch([
+        {'input': 'hello1'},
+        {'input': 'hello2'},
+        {'input': 'hello3'},
+      ]);
+      expect(
+        res.map((final e) => e).toList(),
+        equals(['hello1', 'hello2', 'hello3']),
+      );
+    });
+  });
+}

--- a/packages/langchain_core/test/runnables/invoke_test.dart
+++ b/packages/langchain_core/test/runnables/invoke_test.dart
@@ -10,7 +10,7 @@ import 'package:langchain_core/tools.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Runnable tests', () {
+  group('Runnable invoke tests', () {
     test('PromptTemplate as Runnable', () async {
       final run = PromptTemplate.fromTemplate('This is a {input}');
       final res = await run.invoke({'input': 'test'});

--- a/packages/langchain_google/lib/src/chat_models/google_ai/types.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/types.dart
@@ -14,6 +14,7 @@ class ChatGoogleGenerativeAIOptions extends ChatModelOptions {
     this.temperature,
     this.stopSequences,
     this.safetySettings,
+    super.concurrencyLimit,
   });
 
   /// The LLM to use.

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/types.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/types.dart
@@ -15,6 +15,7 @@ class ChatVertexAIOptions extends ChatModelOptions {
     this.stopSequences,
     this.candidateCount,
     this.examples,
+    super.concurrencyLimit,
   });
 
   /// The publisher of the model.

--- a/packages/langchain_google/lib/src/llms/vertex_ai/types.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai/types.dart
@@ -14,6 +14,7 @@ class VertexAIOptions extends LLMOptions {
     this.topK,
     this.stopSequences,
     this.candidateCount,
+    super.concurrencyLimit,
   });
 
   /// The publisher of the model.

--- a/packages/langchain_mistralai/lib/src/chat_models/types.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/types.dart
@@ -12,6 +12,7 @@ class ChatMistralAIOptions extends ChatModelOptions {
     this.maxTokens,
     this.safePrompt,
     this.randomSeed,
+    super.concurrencyLimit,
   });
 
   /// ID of the model to use. You can use the [List Available Models](https://docs.mistral.ai/api#operation/listModels)

--- a/packages/langchain_ollama/lib/src/chat_models/types.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/types.dart
@@ -44,6 +44,7 @@ class ChatOllamaOptions extends ChatModelOptions {
     this.ropeFrequencyBase,
     this.ropeFrequencyScale,
     this.numThread,
+    super.concurrencyLimit,
   });
 
   /// The model used to generate completions

--- a/packages/langchain_ollama/lib/src/llms/types.dart
+++ b/packages/langchain_ollama/lib/src/llms/types.dart
@@ -46,6 +46,7 @@ class OllamaOptions extends LLMOptions {
     this.ropeFrequencyBase,
     this.ropeFrequencyScale,
     this.numThread,
+    super.concurrencyLimit,
   });
 
   /// The model used to generate completions

--- a/packages/langchain_openai/lib/src/chat_models/types.dart
+++ b/packages/langchain_openai/lib/src/chat_models/types.dart
@@ -20,6 +20,7 @@ class ChatOpenAIOptions extends ChatModelOptions {
     this.functions,
     this.functionCall,
     this.user,
+    super.concurrencyLimit,
   });
 
   /// ID of the model to use (e.g. 'gpt-3.5-turbo').

--- a/packages/langchain_openai/lib/src/llms/mappers.dart
+++ b/packages/langchain_openai/lib/src/llms/mappers.dart
@@ -1,25 +1,29 @@
 // ignore_for_file: public_member_api_docs
+import 'package:collection/collection.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/llms.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 extension CreateCompletionResponseMapper on CreateCompletionResponse {
-  LLMResult toLLMResult(final String id, {final bool streaming = false}) {
-    final choice = choices.first;
-
-    return LLMResult(
-      id: id,
-      output: choice.text,
-      finishReason: _mapFinishReason(choice.finishReason),
-      metadata: {
-        'created': created,
-        'model': model,
-        'system_fingerprint': systemFingerprint,
-        'logprobs': choice.logprobs?.toJson(),
-      },
-      usage: _mapUsage(usage),
-      streaming: streaming,
-    );
+  List<LLMResult> toLLMResults({final bool streaming = false}) {
+    final totalUsage = _mapUsage(usage);
+    return choices
+        .mapIndexed(
+          (final index, final choice) => LLMResult(
+            id: '$id:$index',
+            output: choice.text,
+            finishReason: _mapFinishReason(choice.finishReason),
+            metadata: {
+              'created': created,
+              'model': model,
+              'system_fingerprint': systemFingerprint,
+              'logprobs': choice.logprobs?.toJson(),
+            },
+            usage: totalUsage,
+            streaming: streaming,
+          ),
+        )
+        .toList(growable: false);
   }
 
   FinishReason _mapFinishReason(

--- a/packages/langchain_openai/lib/src/llms/types.dart
+++ b/packages/langchain_openai/lib/src/llms/types.dart
@@ -1,8 +1,11 @@
+import 'package:collection/collection.dart';
 import 'package:langchain_core/llms.dart';
+import 'package:meta/meta.dart';
 
 /// {@template openai_options}
 /// Options to pass into the OpenAI LLM.
 /// {@endtemplate}
+@immutable
 class OpenAIOptions extends LLMOptions {
   /// {@macro openai_options}
   const OpenAIOptions({
@@ -20,6 +23,7 @@ class OpenAIOptions extends LLMOptions {
     this.temperature,
     this.topP,
     this.user,
+    super.concurrencyLimit = 20,
   });
 
   /// ID of the model to use (e.g. 'gpt-3.5-turbo-instruct').
@@ -156,4 +160,40 @@ class OpenAIOptions extends LLMOptions {
       user: user ?? this.user,
     );
   }
+
+  @override
+  bool operator ==(covariant final OpenAIOptions other) =>
+      identical(this, other) ||
+      runtimeType == other.runtimeType &&
+          model == other.model &&
+          bestOf == other.bestOf &&
+          frequencyPenalty == other.frequencyPenalty &&
+          const MapEquality<String, int>().equals(logitBias, other.logitBias) &&
+          logprobs == other.logprobs &&
+          maxTokens == other.maxTokens &&
+          n == other.n &&
+          presencePenalty == other.presencePenalty &&
+          seed == other.seed &&
+          stop == other.stop &&
+          suffix == other.suffix &&
+          temperature == other.temperature &&
+          topP == other.topP &&
+          user == other.user;
+
+  @override
+  int get hashCode =>
+      model.hashCode ^
+      bestOf.hashCode ^
+      frequencyPenalty.hashCode ^
+      const MapEquality<String, int>().hash(logitBias) ^
+      logprobs.hashCode ^
+      maxTokens.hashCode ^
+      n.hashCode ^
+      presencePenalty.hashCode ^
+      seed.hashCode ^
+      stop.hashCode ^
+      suffix.hashCode ^
+      temperature.hashCode ^
+      topP.hashCode ^
+      user.hashCode;
 }

--- a/packages/langchain_openai/test/llms/openai_test.dart
+++ b/packages/langchain_openai/test/llms/openai_test.dart
@@ -155,5 +155,46 @@ void main() {
       );
       expect(res1.output, res2.output);
     });
+
+    test('Test batch with same options for all inputs', () async {
+      const count = 10;
+      final prompts = List.generate(
+        count,
+        (final i) => PromptValue.string('Output the following number: $i'),
+      );
+
+      final res = await llm.batch(
+        prompts,
+        options: [const OpenAIOptions(concurrencyLimit: count ~/ 2)],
+      );
+
+      expect(res.length, count);
+      for (int i = 0; i < count; i++) {
+        expect(res[i].id.endsWith(':${i % (count ~/ 2)}'), isTrue);
+        expect(res[i].output.contains('$i'), isTrue);
+      }
+    });
+
+    test('Test batch with different options per input', () async {
+      const count = 10;
+      final prompts = List.generate(
+        count,
+        (final i) => PromptValue.string('Output the following number: $i'),
+      );
+      final options = List.generate(
+        count,
+        (final i) => OpenAIOptions(
+          temperature: 0 + (i / 10),
+        ),
+      );
+
+      final res = await llm.batch(prompts, options: options);
+
+      expect(res.length, count);
+      for (int i = 0; i < count; i++) {
+        expect(res[i].id.endsWith(':0'), isTrue);
+        expect(res[i].output.contains('$i'), isTrue);
+      }
+    });
   });
 }


### PR DESCRIPTION
Related to #266

Batches the invocation of the `Runnable` on the given `inputs`.

```dart
final model = ChatOpenAI(apiKey: openaiApiKey);
final promptTemplate = ChatPromptTemplate.fromTemplate(
  'Tell me a joke about {topic}',
);
final chain = promptTemplate | model | StringOutputParser();

final res = await chain.batch([
  {'topic': 'bears'},
  {'topic': 'cats'},
]);
print(res);
//['Why did the bear break up with his girlfriend? Because she was too "grizzly" for him!',
// 'Why was the cat sitting on the computer? Because it wanted to keep an eye on the mouse!']
```

If the underlying provider supports batching, this method will try to batch the calls to the provider. Otherwise, it will just call `invoke` on each input concurrently. You can configure the concurrency limit by setting the `concurrencyLimit` field in the `options` parameter.

You can provide call options to the `batch` method using the `options` parameter. It can be:
- `null`: the default options are used.
- List with 1 element: the same options are used for all inputs.
- List with the same length as the inputs: each input gets its own options.

```dart
final res = await chain.batch(
  [
    {'topic': 'bears'},
    {'topic': 'cats'},
  ],
  options: [
    const ChatOpenAIOptions(model: 'gpt-3.5-turbo', temperature: 0.5),
    const ChatOpenAIOptions(model: 'gpt-4', temperature: 0.7),
  ],
);
print(res);
//['Why did the bear break up with his girlfriend? Because he couldn't bear the relationship anymore!,',
// 'Why don't cats play poker in the jungle? Because there's too many cheetahs!']
```