### PR TITLE
feat: Reduce input stream for PromptTemplate, LLM, ChatModel, Retriever and Tool

### DIFF
--- a/docs/modules/memory/memory.md
+++ b/docs/modules/memory/memory.md
@@ -42,7 +42,7 @@ You may want to use this class directly if you are managing memory outside of a 
 ```dart
 final history = ChatMessageHistory();
 
-history.addUserChatMessage('hi!');
+history.addHumanChatMessage('hi!');
 history.addAIChatMessage('whats up?');
 
 print(await history.getChatMessages());
@@ -60,7 +60,7 @@ We can first extract it as a string.
 ```dart
 final memory = ConversationBufferMemory();
 
-memory.chatHistory.addUserChatMessage('hi!');
+memory.chatHistory.addHumanChatMessage('hi!');
 memory.chatHistory.addAIChatMessage('whats up
 
 print(await memory.loadMemoryVariables());
@@ -72,7 +72,7 @@ We can also get the history as a list of messages:
 ```dart
 final memory = ConversationBufferMemory(returnMessages: true);
 
-memory.chatHistory.addUserChatMessage('hi!');
+memory.chatHistory.addHumanChatMessage('hi!');
 memory.chatHistory.addAIChatMessage('whats up?');
 
 print(await memory.loadMemoryVariables());

--- a/docs/modules/model_io/models/llms/how_to/fake_llm.md
+++ b/docs/modules/model_io/models/llms/how_to/fake_llm.md
@@ -4,14 +4,14 @@ We expose some fake LLM classes that can be used for testing. This allows you
 to mock out calls to the LLM and simulate what would happen if the LLM 
 responded in a certain way.
 
-## FakeListLLM
+## FakeLLM
 
 You can configure a list of responses that the LLM will return in order.
 
 Example:
 ```dart
 test('Test LLMChain call', () async {
-  final model = FakeListLLM(responses: ['Hello world!']);
+  final model = FakeLLM(responses: ['Hello world!']);
   final prompt = PromptTemplate.fromTemplate('Print {foo}');
   final chain = LLMChain(prompt: prompt, llm: model);
   final res = await chain.call({'foo': 'Hello world!'});

--- a/examples/browser_summarizer/pubspec.lock
+++ b/examples/browser_summarizer/pubspec.lock
@@ -382,6 +382,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/examples/docs_examples/pubspec.lock
+++ b/examples/docs_examples/pubspec.lock
@@ -356,6 +356,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   source_span:
     dependency: transitive
     description:

--- a/examples/hello_world_backend/pubspec.lock
+++ b/examples/hello_world_backend/pubspec.lock
@@ -165,6 +165,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   shelf:
     dependency: "direct main"
     description:

--- a/examples/hello_world_cli/pubspec.lock
+++ b/examples/hello_world_cli/pubspec.lock
@@ -157,6 +157,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   source_span:
     dependency: transitive
     description:

--- a/examples/hello_world_flutter/pubspec.lock
+++ b/examples/hello_world_flutter/pubspec.lock
@@ -210,6 +210,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.1"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/packages/langchain/example/langchain_example.dart
+++ b/packages/langchain/example/langchain_example.dart
@@ -5,7 +5,7 @@ void main() async {
   final promptTemplate = PromptTemplate.fromTemplate(
     'tell me a joke about {subject}',
   );
-  final llm = FakeListLLM(
+  final llm = FakeLLM(
     responses: ['Why did the AI go on a diet? Because it had too many bytes!'],
   );
   final chain = promptTemplate.pipe(llm).pipe(const StringOutputParser());

--- a/packages/langchain/test/chains/base_test.dart
+++ b/packages/langchain/test/chains/base_test.dart
@@ -94,7 +94,7 @@ void main() {
 
   group('Runnable tests', () {
     test('Chain as Runnable', () async {
-      final model = FakeListLLM(responses: ['Hello world!']);
+      final model = FakeLLM(responses: ['Hello world!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo}');
       final run = LLMChain(prompt: prompt, llm: model);
       final res = await run.invoke({'foo': 'Hello world!'});
@@ -102,7 +102,7 @@ void main() {
     });
 
     test('Streaming Chain', () async {
-      final model = FakeListLLM(responses: ['Hello world!']);
+      final model = FakeLLM(responses: ['Hello world!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo}');
       final run = LLMChain(prompt: prompt, llm: model);
       final stream = run.stream({'foo': 'Hello world!'});

--- a/packages/langchain/test/chains/combine_documents/map_reduce_test.dart
+++ b/packages/langchain/test/chains/combine_documents/map_reduce_test.dart
@@ -37,7 +37,7 @@ void main() {
     }
 
     test('Test MapReduceDocumentsChain with LLM', () async {
-      final model = FakeListLLM(
+      final model = FakeLLM(
         responses: [
           // Summarize this content: Hello 1!
           '1',

--- a/packages/langchain/test/chains/combine_documents/reduce_test.dart
+++ b/packages/langchain/test/chains/combine_documents/reduce_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   group('ReduceDocumentsChain tests', () {
     test('Test reduce', () async {
-      final llm = FakeListLLM(
+      final llm = FakeLLM(
         responses: [
           // Summarize this content: Hello 1!\n\nHello 2!\n\nHello 3!\n\nHello 4!
           'Hello 1234!',
@@ -32,7 +32,7 @@ void main() {
     });
 
     test('Test reduce and collapse', () async {
-      final llm = FakeListLLM(
+      final llm = FakeLLM(
         responses: [
           // Collapse this content: Hello 1!\n\nHello 2!\n\nHello 3!
           'Hello 123!',

--- a/packages/langchain_core/lib/src/chat_models/base.dart
+++ b/packages/langchain_core/lib/src/chat_models/base.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../language_models/language_models.dart';
 import '../prompts/types.dart';
+import '../utils/reduce.dart';
 import 'types.dart';
 
 /// {@template base_chat_model}
@@ -15,22 +16,15 @@ abstract class BaseChatModel<Options extends ChatModelOptions>
     required super.defaultOptions,
   });
 
-  /// Runs the chat model on the given prompt value.
-  ///
-  /// - [input] The prompt value to pass into the model.
-  /// - [options] Generation options to pass into the Chat Model.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await chat.invoke(
-  ///   PromptValue.chat([ChatMessage.humanText('say hi!')]),
-  /// );
-  /// ```
   @override
-  Future<ChatResult> invoke(
-    final PromptValue input, {
+  Stream<ChatResult> streamFromInputStream(
+    final Stream<PromptValue> inputStream, {
     final Options? options,
-  });
+  }) async* {
+    final input = await inputStream.toList();
+    final reduced = reduce<PromptValue>(input);
+    yield* stream(reduced, options: options);
+  }
 
   /// Runs the chat model on the given messages and returns a chat message.
   ///

--- a/packages/langchain_core/lib/src/chat_models/types.dart
+++ b/packages/langchain_core/lib/src/chat_models/types.dart
@@ -31,7 +31,7 @@ class ChatResult extends LanguageModelResult<AIChatMessage> {
   String get outputAsString => output.content;
 
   @override
-  LanguageModelResult<AIChatMessage> concat(
+  ChatResult concat(
     final LanguageModelResult<AIChatMessage> other,
   ) {
     return ChatResult(

--- a/packages/langchain_core/lib/src/language_models/base.dart
+++ b/packages/langchain_core/lib/src/language_models/base.dart
@@ -25,16 +25,6 @@ abstract class BaseLanguageModel<
   /// Return type of language model.
   String get modelType;
 
-  /// Runs the Language Model on the given prompt value.
-  ///
-  /// - [input] The prompt value to pass into the model.
-  /// - [options] Generation options to pass into the model.
-  @override
-  Future<Output> invoke(
-    final PromptValue input, {
-    final Options? options,
-  });
-
   /// Tokenizes the given prompt using the encoding used by the language
   /// model.
   ///

--- a/packages/langchain_core/lib/src/llms/base.dart
+++ b/packages/langchain_core/lib/src/llms/base.dart
@@ -16,23 +16,6 @@ abstract class BaseLLM<Options extends LLMOptions>
     required super.defaultOptions,
   });
 
-  /// Runs the LLM on the given prompt value.
-  ///
-  /// - [input] The prompt value to pass into the model.
-  /// - [options] Generation options to pass into the LLM.
-  ///
-  /// Example:
-  /// ```dart
-  /// final result = await openai.invoke(
-  ///   PromptValue.string('Tell me a joke.'),
-  /// );
-  /// ```
-  @override
-  Future<LLMResult> invoke(
-    final PromptValue input, {
-    final Options? options,
-  });
-
   /// Runs the LLM on the given String prompt and returns a String with the
   /// generated text.
   ///

--- a/packages/langchain_core/lib/src/llms/fake.dart
+++ b/packages/langchain_core/lib/src/llms/fake.dart
@@ -7,9 +7,9 @@ import 'types.dart';
 /// Fake LLM for testing.
 /// You can pass in a list of responses to return in order when called.
 /// {@endtemplate}
-class FakeListLLM extends SimpleLLM {
+class FakeLLM extends SimpleLLM {
   /// {@macro fake_list_llm}
-  FakeListLLM({
+  FakeLLM({
     required this.responses,
   }) : super(defaultOptions: const LLMOptions());
 
@@ -27,6 +27,24 @@ class FakeListLLM extends SimpleLLM {
     final LLMOptions? options,
   }) {
     return Future<String>.value(responses[_i++ % responses.length]);
+  }
+
+  @override
+  Stream<LLMResult> stream(
+    final PromptValue input, {
+    final LLMOptions? options,
+  }) {
+    final res = responses[_i++ % responses.length].split('');
+    return Stream.fromIterable(res).map(
+      (final item) => LLMResult(
+        id: 'fake-echo',
+        output: item,
+        finishReason: FinishReason.unspecified,
+        metadata: const {},
+        usage: const LanguageModelUsage(),
+        streaming: true,
+      ),
+    );
   }
 
   @override

--- a/packages/langchain_core/lib/src/llms/types.dart
+++ b/packages/langchain_core/lib/src/llms/types.dart
@@ -31,7 +31,7 @@ class LLMResult extends LanguageModelResult<String> {
   String get outputAsString => output;
 
   @override
-  LanguageModelResult<String> concat(
+  LLMResult concat(
     final LanguageModelResult<String> other,
   ) {
     return LLMResult(

--- a/packages/langchain_core/lib/src/retrievers/base.dart
+++ b/packages/langchain_core/lib/src/retrievers/base.dart
@@ -1,5 +1,6 @@
 import '../documents/document.dart';
 import '../runnables/runnable.dart';
+import '../utils/reduce.dart';
 import 'types.dart';
 
 /// {@template base_retriever}
@@ -22,6 +23,21 @@ abstract class Retriever<Options extends RetrieverOptions>
     final Options? options,
   }) {
     return getRelevantDocuments(input, options: options);
+  }
+
+  /// Streams the most relevant documents for the query resulting from
+  /// reducing the input stream.
+  ///
+  /// - [inputStream] - the input stream to reduce and use as the query.
+  /// - [options] - Retrieval options.
+  @override
+  Stream<List<Document>> streamFromInputStream(
+    final Stream<String> inputStream, {
+    final Options? options,
+  }) async* {
+    final input = await inputStream.toList();
+    final reduced = reduce<String>(input);
+    yield* stream(reduced, options: options);
   }
 
   /// Get the most relevant documents for a given query.

--- a/packages/langchain_core/lib/src/tools/base.dart
+++ b/packages/langchain_core/lib/src/tools/base.dart
@@ -5,6 +5,7 @@ import 'package:meta/meta.dart';
 
 import '../chat_models/types.dart';
 import '../langchain/base.dart';
+import '../utils/reduce.dart';
 import 'types.dart';
 
 /// {@template base_tool}
@@ -91,6 +92,21 @@ abstract base class BaseTool<Options extends ToolOptions>
     final Options? options,
   }) async {
     return run(input);
+  }
+
+  /// Streams the tool's output for the input resulting from
+  /// reducing the input stream.
+  ///
+  /// - [inputStream] - the input stream to reduce and use as the input.
+  /// - [options] is the options to pass to the tool.
+  @override
+  Stream<String> streamFromInputStream(
+    final Stream<Map<String, dynamic>> inputStream, {
+    final Options? options,
+  }) async* {
+    final input = await inputStream.toList();
+    final reduced = reduce<Map<String, dynamic>>(input);
+    yield* stream(reduced, options: options);
   }
 
   /// Runs the tool.

--- a/packages/langchain_core/lib/src/utils/reduce.dart
+++ b/packages/langchain_core/lib/src/utils/reduce.dart
@@ -1,6 +1,7 @@
 import '../chat_models/types.dart';
 import '../documents/document.dart';
 import '../language_models/types.dart';
+import '../prompts/types.dart';
 
 /// Reduces a list of objects to a single object by concatenating them.
 ///
@@ -24,6 +25,8 @@ Type reduce<Type>(final Iterable<Type> input) {
     String() => input.cast<String>().join(),
     ChatMessage() =>
       input.cast<ChatMessage>().reduce((final a, final b) => a.concat(b)),
+    PromptValue() =>
+      input.cast<PromptValue>().reduce((final a, final b) => a.concat(b)),
     LanguageModelResult() => input
         .cast<LanguageModelResult>()
         .reduce((final a, final b) => a.concat(b)),
@@ -34,7 +37,7 @@ Type reduce<Type>(final Iterable<Type> input) {
     Iterable<dynamic>() => _reduceIterable(input.cast<Iterable<dynamic>>()),
     Map<String, String>() => _reduceMap(input.cast<Map<String, String>>()),
     Map<String, Object>() => _reduceMap(input.cast<Map<String, Object>>()),
-    Map<String, dynamic>() => _reduceMap(input.cast<Map<String, String>>()),
+    Map<String, dynamic>() => _reduceMap(input.cast<Map<String, dynamic>>()),
     Map<dynamic, dynamic>() => _reduceMap(input.cast<Map<dynamic, dynamic>>()),
     _ => input.last,
   } as Type;

--- a/packages/langchain_core/pubspec.yaml
+++ b/packages/langchain_core/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   cross_file: ^0.3.4+1
   crypto: ^3.0.3
   meta: ^1.11.0
+  rxdart: ^0.27.7
 
 dev_dependencies:
   test: ^1.25.2

--- a/packages/langchain_core/test/chains/llm_chain_test.dart
+++ b/packages/langchain_core/test/chains/llm_chain_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 void main() {
   group('LLMChain tests', () {
     test('Test LLMChain call', () async {
-      final model = FakeListLLM(responses: ['Hello world!']);
+      final model = FakeLLM(responses: ['Hello world!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo}');
       final chain = LLMChain(prompt: prompt, llm: model);
       final res = await chain.call({'foo': 'Hello world!'});
@@ -16,7 +16,7 @@ void main() {
     });
 
     test('Test LLMChain call single value', () async {
-      final model = FakeListLLM(responses: ['Hello world!']);
+      final model = FakeLLM(responses: ['Hello world!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo}');
       final chain = LLMChain(prompt: prompt, llm: model);
       final res = await chain.call('Hello world!');
@@ -25,7 +25,7 @@ void main() {
     });
 
     test('Test LLMChain call returnOnlyOutputs true', () async {
-      final model = FakeListLLM(responses: ['Hello world! again!']);
+      final model = FakeLLM(responses: ['Hello world! again!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo} {bar}');
       final chain = LLMChain(prompt: prompt, llm: model);
       final res = await chain.call(
@@ -37,7 +37,7 @@ void main() {
     });
 
     test('Test LLMChain outputKey', () async {
-      final model = FakeListLLM(responses: ['Hello world! again!']);
+      final model = FakeLLM(responses: ['Hello world! again!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo} {bar}');
       final chain = LLMChain(prompt: prompt, llm: model, outputKey: 'xxx');
       final res = await chain.call(
@@ -49,7 +49,7 @@ void main() {
     });
 
     test('Test LLMChain run single input value', () async {
-      final model = FakeListLLM(responses: ['Hello world!']);
+      final model = FakeLLM(responses: ['Hello world!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo}');
       final chain = LLMChain(prompt: prompt, llm: model);
       final res = await chain.run('Hello world!');
@@ -57,7 +57,7 @@ void main() {
     });
 
     test('Test LLMChain run multiple input values', () async {
-      final model = FakeListLLM(responses: ['Hello world! again!']);
+      final model = FakeLLM(responses: ['Hello world! again!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo} {bar}');
       final chain = LLMChain(prompt: prompt, llm: model);
       final res = await chain.run({'foo': 'Hello world!, ', 'bar': 'again!'});
@@ -65,7 +65,7 @@ void main() {
     });
 
     test('Test LLMChain throws error with less input values', () async {
-      final model = FakeListLLM(responses: ['Hello world! again!']);
+      final model = FakeLLM(responses: ['Hello world! again!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo} {bar} {baz}');
       final chain = LLMChain(prompt: prompt, llm: model);
       expect(
@@ -75,7 +75,7 @@ void main() {
     });
 
     test('Test LLMChain throws error with wrong input values', () async {
-      final model = FakeListLLM(responses: ['Hello world! again!']);
+      final model = FakeLLM(responses: ['Hello world! again!']);
       final prompt = PromptTemplate.fromTemplate('Print {foo} {bar}');
       final chain = LLMChain(prompt: prompt, llm: model);
       expect(

--- a/packages/langchain_core/test/runnables/batch_test.dart
+++ b/packages/langchain_core/test/runnables/batch_test.dart
@@ -73,7 +73,7 @@ void main() {
     });
 
     test('LLM batch', () async {
-      final run = FakeListLLM(
+      final run = FakeLLM(
         responses: ['test1', 'test2', 'test3'],
       );
       final res = await run.batch([

--- a/packages/langchain_core/test/runnables/router_test.dart
+++ b/packages/langchain_core/test/runnables/router_test.dart
@@ -23,7 +23,7 @@ void main() {
       expect(result2, equals(-2));
     });
 
-    test('RunnableBranch batch', () async {
+    test('RunnableRouter batch', () async {
       final add = Runnable.fromFunction((int x, _) => x + 1);
       final multiply = Runnable.fromFunction((int x, _) => x * 10);
       final subtract = Runnable.fromFunction((int x, _) => x - 1);
@@ -40,7 +40,7 @@ void main() {
       expect(batchResult, equals([2, 100, -1]));
     });
 
-    test('RunnableBranch stream', () async {
+    test('RunnableRouter stream', () async {
       final promptTemplate = ChatPromptTemplate.fromTemplate('{question}');
       const model = FakeEchoChatModel();
 

--- a/packages/langchain_core/test/runnables/stream_test.dart
+++ b/packages/langchain_core/test/runnables/stream_test.dart
@@ -119,4 +119,181 @@ void main() {
       expect(res, 'hello');
     });
   });
+
+  test('Test call to PromptTemplate from streaming input', () async {
+    final inputStream = Stream.fromIterable([
+      {'input': 'H'},
+      {'input': 'e'},
+      {'input': 'l'},
+      {'input': 'l'},
+      {'input': 'o'},
+      {'input': ' '},
+      {'input': 'W'},
+      {'input': 'o'},
+      {'input': 'r'},
+      {'input': 'l'},
+      {'input': 'd'},
+    ]);
+
+    final promptTemplate = PromptTemplate.fromTemplate(
+      'Spell the following text {input}',
+    );
+
+    final stream = promptTemplate.streamFromInputStream(inputStream);
+    int count = 0;
+    PromptValue output = PromptValue.string('');
+    await stream.forEach((final i) {
+      count++;
+      output = output.concat(i);
+    });
+    expect(count, 1);
+    expect(output, PromptValue.string('Spell the following text Hello World'));
+  });
+
+  test('Test call to ChatPromptTemplate from streaming input', () async {
+    final inputStream = Stream.fromIterable([
+      {'input': 'H'},
+      {'input': 'e'},
+      {'input': 'l'},
+      {'input': 'l'},
+      {'input': 'o'},
+      {'input': ' '},
+      {'input': 'W'},
+      {'input': 'o'},
+      {'input': 'r'},
+      {'input': 'l'},
+      {'input': 'd'},
+    ]);
+
+    final promptTemplate = ChatPromptTemplate.fromTemplate(
+      'Spell the following text {input}',
+    );
+
+    final stream = promptTemplate.streamFromInputStream(inputStream);
+    int count = 0;
+    PromptValue output = PromptValue.chat([ChatMessage.humanText('')]);
+    await stream.forEach((final i) {
+      count++;
+      output = output.concat(i);
+    });
+    expect(count, 1);
+    expect(
+      output,
+      PromptValue.chat(
+        [ChatMessage.humanText('Spell the following text Hello World')],
+      ),
+    );
+  });
+
+  test('Test call to LLM from streaming input', () async {
+    final inputStream = Stream.fromIterable([
+      PromptValue.string('H'),
+      PromptValue.string('e'),
+      PromptValue.string('l'),
+      PromptValue.string('l'),
+      PromptValue.string('o'),
+      PromptValue.string(' '),
+      PromptValue.string('W'),
+      PromptValue.string('o'),
+      PromptValue.string('r'),
+      PromptValue.string('l'),
+      PromptValue.string('d'),
+    ]);
+
+    const llm = FakeEchoLLM();
+    final stream = llm.streamFromInputStream(inputStream);
+    int count = 0;
+    LLMResult? output;
+    await stream.forEach((final LLMResult i) {
+      count++;
+      output = output?.concat(i) ?? i;
+    });
+    expect(count, 11);
+    expect(output?.output, 'Hello World');
+  });
+
+  test('Test call to ChatModel from streaming input', () async {
+    final inputStream = Stream.fromIterable([
+      PromptValue.chat([ChatMessage.humanText('H')]),
+      PromptValue.chat([ChatMessage.humanText('e')]),
+      PromptValue.chat([ChatMessage.humanText('l')]),
+      PromptValue.chat([ChatMessage.humanText('l')]),
+      PromptValue.chat([ChatMessage.humanText('o')]),
+      PromptValue.chat([ChatMessage.humanText(' ')]),
+      PromptValue.chat([ChatMessage.humanText('W')]),
+      PromptValue.chat([ChatMessage.humanText('o')]),
+      PromptValue.chat([ChatMessage.humanText('r')]),
+      PromptValue.chat([ChatMessage.humanText('l')]),
+      PromptValue.chat([ChatMessage.humanText('d')]),
+    ]);
+
+    const chatModel = FakeEchoChatModel();
+    final stream = chatModel.streamFromInputStream(inputStream);
+    int count = 0;
+    ChatResult? output;
+    await stream.forEach((final ChatResult i) {
+      count++;
+      output = output?.concat(i) ?? i;
+    });
+    expect(count, 11);
+    expect(output?.output.content, 'Hello World');
+  });
+
+  test('Test call to Tool from streaming input', () async {
+    final inputStream = Stream.fromIterable([
+      {'input': 'H'},
+      {'input': 'e'},
+      {'input': 'l'},
+      {'input': 'l'},
+      {'input': 'o'},
+      {'input': ' '},
+      {'input': 'W'},
+      {'input': 'o'},
+      {'input': 'r'},
+      {'input': 'l'},
+      {'input': 'd'},
+    ]);
+
+    final tool = FakeTool();
+    final stream = tool.streamFromInputStream(inputStream);
+    int count = 0;
+    String? output;
+    await stream.forEach((final String i) {
+      count++;
+      output = i;
+    });
+    expect(count, 1);
+    expect(output, 'Hello World');
+  });
+
+  test('Test call to Retriever from streaming input', () async {
+    final inputStream = Stream.fromIterable([
+      'H',
+      'e',
+      'l',
+      'l',
+      'o',
+      ' ',
+      'W',
+      'o',
+      'r',
+      'l',
+      'd',
+    ]);
+
+    const doc = Document(
+      id: '1',
+      pageContent: 'Hello World',
+    );
+    const retriever = FakeRetriever([doc]);
+    final stream = retriever.streamFromInputStream(inputStream);
+    int count = 0;
+    List<Document>? output;
+    await stream.forEach((final List<Document> i) {
+      count++;
+      output = i;
+    });
+    expect(count, 1);
+    expect(output, [doc]);
+  });
 }


### PR DESCRIPTION
Previously, the following components processed each chunk of an input stream individually, making it difficult to implement streaming chains. Now these components reduce the input stream to a single value before processing it.
- `PromptTemplate`
- `ChatPromptTemplate`
- `LLM`
- `ChatModel`
- `Retriever`
- `Tool`