### PR TITLE
feat: Handle finish reason in ChatOllama

### DIFF
--- a/packages/langchain_ollama/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/mappers.dart
@@ -103,7 +103,7 @@ extension ChatResultMapper on GenerateChatCompletionResponse {
       output: AIChatMessage(
         content: message?.content ?? '',
       ),
-      finishReason: FinishReason.unspecified,
+      finishReason: _mapFinishReason(doneReason),
       metadata: {
         'model': model,
         'created_at': createdAt,
@@ -124,9 +124,19 @@ extension ChatResultMapper on GenerateChatCompletionResponse {
     return LanguageModelUsage(
       promptTokens: promptEvalCount,
       responseTokens: evalCount,
-      totalTokens: (promptEvalCount != null && evalCount != null)
-          ? promptEvalCount! + evalCount!
+      totalTokens: (promptEvalCount != null || evalCount != null)
+          ? (promptEvalCount ?? 0) + (evalCount ?? 0)
           : null,
     );
   }
+
+  FinishReason _mapFinishReason(
+    final DoneReason? reason,
+  ) =>
+      switch (reason) {
+        DoneReason.stop => FinishReason.stop,
+        DoneReason.length => FinishReason.length,
+        DoneReason.load => FinishReason.unspecified,
+        null => FinishReason.unspecified,
+      };
 }

--- a/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
+++ b/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/output_parsers.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_ollama/langchain_ollama.dart';
@@ -18,6 +19,7 @@ void main() {
       chatModel = ChatOllama(
         defaultOptions: const ChatOllamaOptions(
           model: defaultModel,
+          keepAlive: 1,
         ),
       );
     });
@@ -108,6 +110,7 @@ void main() {
         res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('123456789'),
       );
+      expect(res.finishReason, FinishReason.stop);
       expect(res.metadata, isNotNull);
       expect(res.metadata['model'], defaultModel);
       expect(res.metadata['created_at'], isNotNull);
@@ -120,44 +123,48 @@ void main() {
     });
 
     test('Test stop logic on valid configuration', () async {
-      const query = 'write an ordered list of five items';
-      final res = await chatModel(
-        [ChatMessage.humanText(query)],
+      final res = await chatModel.invoke(
+        PromptValue.string('write an ordered list of five items'),
         options: const ChatOllamaOptions(
           temperature: 0,
           stop: ['3'],
         ),
       );
-      expect(res.content.contains('2.'), isTrue);
-      expect(res.content.contains('3.'), isFalse);
+      expect(res.output.content.contains('2.'), isTrue);
+      expect(res.output.content.contains('3.'), isFalse);
+      expect(res.finishReason, FinishReason.stop);
+    });
+
+    test('Test max tokens', () async {
+      final res = await chatModel.invoke(
+        PromptValue.string('write an ordered list of five items'),
+        options: const ChatOllamaOptions(
+          numPredict: 2,
+        ),
+      );
+      expect(res.finishReason, FinishReason.length);
     });
 
     test('Test tokenize', () async {
-      const text = 'antidisestablishmentarianism';
-
       final tokens = await chatModel.tokenize(
-        PromptValue.chat([ChatMessage.humanText(text)]),
+        PromptValue.string('antidisestablishmentarianism'),
       );
-      expect(tokens, [35075, 25, 3276, 85342, 34500, 479, 8997, 2191]);
+      expect(tokens, [519, 85342, 34500, 479, 8997, 2191]);
     });
 
     test('Test different encoding than the model', () async {
       chatModel.encoding = 'cl100k_base';
-      const text = 'antidisestablishmentarianism';
-
       final tokens = await chatModel.tokenize(
-        PromptValue.chat([ChatMessage.humanText(text)]),
+        PromptValue.string('antidisestablishmentarianism'),
       );
-      expect(tokens, [35075, 25, 3276, 85342, 34500, 479, 8997, 2191]);
+      expect(tokens, [519, 85342, 34500, 479, 8997, 2191]);
     });
 
     test('Test countTokens', () async {
-      const text = 'Hello, how are you?';
-
       final numTokens = await chatModel.countTokens(
-        PromptValue.chat([ChatMessage.humanText(text)]),
+        PromptValue.string('Hello, how are you?'),
       );
-      expect(numTokens, 8);
+      expect(numTokens, 6);
     });
 
     test('Test streaming', () async {
@@ -202,11 +209,7 @@ void main() {
 
     test('Test Multi-turn conversations', () async {
       final prompt = PromptValue.chat([
-        ChatMessage.humanText(
-          'List the numbers from 1 to 9 in order. '
-          'Output ONLY the numbers in one line without any spaces or commas. '
-          'NUMBERS:',
-        ),
+        ChatMessage.humanText('List the numbers from 1 to 9 in order. '),
         ChatMessage.ai('123456789'),
         ChatMessage.humanText(
           'Remove the number "4" from the list',

--- a/packages/langchain_ollama/test/embeddings/ollama_test.dart
+++ b/packages/langchain_ollama/test/embeddings/ollama_test.dart
@@ -8,7 +8,7 @@ void main() {
   group('OllamaEmbeddings tests', skip: Platform.environment.containsKey('CI'),
       () {
     late OllamaEmbeddings embeddings;
-    const defaultModel = 'llama2:latest';
+    const defaultModel = 'llama3:latest';
 
     setUp(() async {
       embeddings = OllamaEmbeddings(

--- a/packages/langchain_ollama/test/llms/ollama_test.dart
+++ b/packages/langchain_ollama/test/llms/ollama_test.dart
@@ -10,12 +10,13 @@ import 'package:test/test.dart';
 void main() {
   group('Ollama tests', skip: Platform.environment.containsKey('CI'), () {
     late Ollama llm;
-    const defaultModel = 'llama2:latest';
+    const defaultModel = 'llama3:latest';
 
     setUp(() async {
       llm = Ollama(
         defaultOptions: const OllamaOptions(
           model: defaultModel,
+          keepAlive: 1,
         ),
       );
     });
@@ -63,11 +64,8 @@ void main() {
         numThread: 21,
       );
 
-      expect(llm.defaultOptions.model, 'foo');
-      expect(
-        llm.defaultOptions.system,
-        'system prompt',
-      );
+      expect(options.model, 'foo');
+      expect(options.system, 'system prompt');
       expect(options.template, 'TEMPLATE """');
       expect(options.context, [1, 2, 3]);
       expect(options.format, OllamaResponseFormat.json);
@@ -134,7 +132,6 @@ void main() {
       expect(res.metadata['context'], isNotEmpty);
       expect(res.metadata['total_duration'], greaterThan(0));
       expect(res.metadata['load_duration'], greaterThan(0));
-      // expect(res.metadata['prompt_eval_count'], greaterThan(0)); // TODO check why it's null
       expect(res.metadata['eval_count'], greaterThan(0));
       expect(res.metadata['eval_duration'], greaterThan(0));
     });
@@ -199,9 +196,16 @@ void main() {
     test('Test raw mode', () async {
       final res = await llm.invoke(
         PromptValue.string(
-          '[INST] List the numbers from 1 to 9 in order. '
-          'Output ONLY the numbers in one line without any spaces or commas. '
-          'NUMBERS: [/INST]',
+          '''
+<|start_header_id|>system<|end_header_id|>
+
+You are an AI assistant that follows instructions precisely.
+<|eot_id|><|start_header_id|>user<|end_header_id|>
+
+List the numbers from 1 to 9 in order. Output ONLY the numbers on one line without any spaces or commas between them.
+<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+'''
+              .trim(),
         ),
         options: const OllamaOptions(raw: true),
       );

--- a/packages/ollama_dart/test/ollama_dart_models_test.dart
+++ b/packages/ollama_dart/test/ollama_dart_models_test.dart
@@ -83,7 +83,8 @@ void main() {
         ),
       );
       final res = await client.listModels();
-      expect(res.models?.any((final m) => m.model == '$newName:latest'), isTrue);
+      expect(
+          res.models?.any((final m) => m.model == '$newName:latest'), isTrue);
     });
 
     test('Test delete model', () async {


### PR DESCRIPTION
```dart
final chatModel = ChatOllama(...);
final res = await chatModel.invoke(....);
print(res.finishReason);
```

- `FinishReason.stop`: The generation hit a stop token or sequence.
- `FinishReason.length`: The maximum number of tokens was reached (when setting `ChatOllamaOptions(numPredict: {maxToken}`)