### PR TITLE
feat: Add Runnable.close() to close any resources associated with it

### DIFF
--- a/packages/langchain_core/lib/src/runnables/binding.dart
+++ b/packages/langchain_core/lib/src/runnables/binding.dart
@@ -70,4 +70,9 @@ class RunnableBinding<RunInput extends Object?,
       options: options ?? this.options,
     );
   }
+
+  @override
+  void close() {
+    bound.close();
+  }
 }

--- a/packages/langchain_core/lib/src/runnables/map.dart
+++ b/packages/langchain_core/lib/src/runnables/map.dart
@@ -108,4 +108,11 @@ class RunnableMap<RunInput extends Object>
       }),
     ).asBroadcastStream();
   }
+
+  @override
+  void close() {
+    for (final step in steps.values) {
+      step.close();
+    }
+  }
 }

--- a/packages/langchain_core/lib/src/runnables/runnable.dart
+++ b/packages/langchain_core/lib/src/runnables/runnable.dart
@@ -289,4 +289,14 @@ abstract class Runnable<RunInput extends Object?,
   ) {
     return options is CallOptions ? options : null;
   }
+
+  /// Cleans up any resources associated with it the [Runnable].
+  ///
+  /// For example, if the [Runnable] uses a http client internally, it closes
+  /// it. If there is no resource to clean up, this method does nothing.
+  ///
+  /// Don't try to call the [Runnable] after calling this method.
+  void close() {
+    // Override this method if the Runnable needs to clean up resources
+  }
 }

--- a/packages/langchain_core/lib/src/runnables/sequence.dart
+++ b/packages/langchain_core/lib/src/runnables/sequence.dart
@@ -205,4 +205,11 @@ Please ensure that the output of the previous runnable in the sequence matches t
     ''';
     throw ArgumentError(errorMessage);
   }
+
+  @override
+  void close() {
+    for (final step in steps) {
+      step.close();
+    }
+  }
 }

--- a/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
@@ -349,7 +349,7 @@ class ChatGoogleGenerativeAI
     return tokens.totalTokens;
   }
 
-  /// Closes the client and cleans up any resources associated with it.
+  @override
   void close() {
     _httpClient.close();
   }

--- a/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
@@ -248,7 +248,7 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
     return encoding.encode(promptValue.toString());
   }
 
-  /// Closes the client and cleans up any resources associated with it.
+  @override
   void close() {
     _client.endSession();
   }

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama.dart
@@ -278,7 +278,7 @@ class ChatOllama extends BaseChatModel<ChatOllamaOptions> {
     return encoding.encode(promptValue.toString());
   }
 
-  /// Closes the client and cleans up any resources associated with it.
+  @override
   void close() {
     _client.endSession();
   }

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -276,7 +276,7 @@ class Ollama extends BaseLLM<OllamaOptions> {
     return encoding.encode(promptValue.toString());
   }
 
-  /// Closes the client and cleans up any resources associated with it.
+  @override
   void close() {
     _client.endSession();
   }

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
@@ -399,7 +399,7 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
         : getEncoding('cl100k_base');
   }
 
-  /// Closes the client and cleans up any resources associated with it.
+  @override
   void close() {
     _client.endSession();
   }

--- a/packages/langchain_openai/lib/src/llms/openai.dart
+++ b/packages/langchain_openai/lib/src/llms/openai.dart
@@ -345,7 +345,7 @@ class OpenAI extends BaseLLM<OpenAIOptions> {
     return encoding.encode(promptValue.toString());
   }
 
-  /// Closes the client and cleans up any resources associated with it.
+  @override
   void close() {
     _client.endSession();
   }

--- a/packages/langchain_openai/lib/src/tools/dall_e.dart
+++ b/packages/langchain_openai/lib/src/tools/dall_e.dart
@@ -111,7 +111,7 @@ final class OpenAIDallETool extends StringTool<OpenAIDallEToolOptions> {
     }
   }
 
-  /// Closes the client and cleans up any resources associated with it.
+  @override
   void close() {
     _client.endSession();
   }

--- a/packages/langchain_openai/test/chat_models/open_router_test.dart
+++ b/packages/langchain_openai/test/chat_models/open_router_test.dart
@@ -107,8 +107,8 @@ void main() {
       }
     });
 
-    test('Test tool calling',
-        timeout: const Timeout(Duration(minutes: 1)), () async {
+    test('Test tool calling', timeout: const Timeout(Duration(minutes: 1)),
+        () async {
       const tool = ToolSpec(
         name: 'get_current_weather',
         description: 'Get the current weather in a given location',


### PR DESCRIPTION
Previously only LLMs and ChatModels had a `close` method to close the associated client, but it was not a standard interface. Now the `close` method is part of the Runnable interface, so you can close any Runnable.

For example:
```dart
final chain = promptTemplate
    .pipe(model)
    .pipe(outputParser);
// ...
chain.close();
```
This will call the close method of all the runnables in the chain. In this case, it won't do anything for `promptTemplate` and `outputParser` as they have no associated resources to close, but it will close the HTTP client of the model.