### PR TITLE
feat!: Update ChatFirebaseVertexAI default model to  gemini-1.5-flash

### DIFF
--- a/docs/modules/model_io/models/chat_models/integrations/firebase_vertex_ai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/firebase_vertex_ai.md
@@ -66,22 +66,22 @@ print(res);
 ## Available models
 
 The following models are available:
-- `gemini-1.0-pro`
-  * text -> text model
-  * Max input token: 30720
-  * Max output tokens: 2048
+- `gemini-1.5-flash`:
+  * text / image / audio -> text model
+  * Max input token: 1048576
+  * Max output tokens: 8192
+- `gemini-1.5-pro`:
+  * text / image / audio -> text model
+  * Max input token: 1048576
+  * Max output tokens: 8192
 - `gemini-1.0-pro-vision`:
   * text / image -> text model
   * Max input token: 12288
   * Max output tokens: 4096
-- `gemini-1.5-pro-preview-0514`:
-  * text / image / audio -> text model
-  * Max input token: 1048576
-  * Max output tokens: 8192
-- `gemini-1.5-flash-preview-0514`:
-  * text / image / audio -> text model
-  * Max input token: 1048576
-  * Max output tokens: 8192
+- `gemini-1.0-pro`
+  * text -> text model
+  * Max input token: 30720
+  * Max output tokens: 2048
       
 Mind that this list may not be up-to-date. Refer to the [documentation](https://firebase.google.com/docs/vertex-ai/gemini-models) for the updated list.
 
@@ -90,7 +90,7 @@ Mind that this list may not be up-to-date. Refer to the [documentation](https://
 ```dart
 final chatModel = ChatFirebaseVertexAI(
   defaultOptions: ChatFirebaseVertexAIOptions(
-    model: 'gemini-1.5-pro-preview-0514',
+    model: 'gemini-1.5-pro',
   ),
 );
 final res = await chatModel.invoke(
@@ -122,7 +122,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplates(const [
 
 final chatModel = ChatFirebaseVertexAI(
   defaultOptions: ChatFirebaseVertexAIOptions(
-    model: 'gemini-1.5-pro-preview-0514',
+    model: 'gemini-1.5-pro',
   ),
 );
 
@@ -160,7 +160,7 @@ const tool = ToolSpec(
 );
 final chatModel = ChatFirebaseVertexAI(
   defaultOptions: ChatFirebaseVertexAIOptions(
-    model: 'gemini-1.5-pro-preview-0514',
+    model: 'gemini-1.5-pro',
     temperature: 0,
     tools: [tool],
   ),

--- a/packages/langchain_firebase/example/lib/main.dart
+++ b/packages/langchain_firebase/example/lib/main.dart
@@ -155,7 +155,7 @@ class _ChatWidgetState extends State<ChatWidget> {
 
     _model = ChatFirebaseVertexAI(
       defaultOptions: ChatFirebaseVertexAIOptions(
-        model: 'gemini-1.5-pro-preview-0514',
+        model: 'gemini-1.5-pro',
         tools: [exchangeRateTool],
       ),
       // location: 'us-central1',

--- a/packages/langchain_firebase/example/web/flutter_bootstrap.js
+++ b/packages/langchain_firebase/example/web/flutter_bootstrap.js
@@ -1,0 +1,12 @@
+{{flutter_js}}
+{{flutter_build_config}}
+
+_flutter.loader.load({
+  serviceWorkerSettings: {
+    serviceWorkerVersion: {{flutter_service_worker_version}},
+  },
+  onEntrypointLoaded: async function(engineInitializer) {
+    const appRunner = await engineInitializer.initializeEngine({useColorEmoji: true});
+    await appRunner.runApp();
+  },
+});

--- a/packages/langchain_firebase/example/web/index.html
+++ b/packages/langchain_firebase/example/web/index.html
@@ -1,61 +1,25 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <!--
-    If you are serving your web app in a path other than the root, change the
-    href value below to reflect the base path you are serving from.
-
-    The path provided below has to start and end with a slash "/" in order for
-    it to work correctly.
-
-    For more details:
-    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
-
-    This is a placeholder for base href that will be replaced by the value of
-    the `--base-href` argument provided to `flutter build`.
-  -->
   <base href="$FLUTTER_BASE_HREF">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta content="A sample Flutter app integrating VertexAI for Firebase in LangChain.dart." name="description">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="example">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+  <meta content="yes" name="apple-mobile-web-app-capable">
+  <meta content="black" name="apple-mobile-web-app-status-bar-style">
+  <meta content="hello_world_flutter" name="apple-mobile-web-app-title">
+  <link href="icons/Icon-192.png" rel="apple-touch-icon">
 
   <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+  <link href="favicon.png" rel="icon" type="image/png"/>
 
-  <title>example</title>
-  <link rel="manifest" href="manifest.json">
-
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    const serviceWorkerVersion = null;
-  </script>
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer></script>
+  <title>VertexAI for Firebase in LangChain.dart</title>
+  <link href="manifest.json" rel="manifest">
 </head>
 <body>
-  <script>
-    window.addEventListener('load', function(ev) {
-      // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        },
-        onEntrypointLoaded: function(engineInitializer) {
-          engineInitializer.initializeEngine({
-            useColorEmoji: true,
-          }).then(function(appRunner) {
-            appRunner.runApp();
-          });
-        }
-      });
-    });
-  </script>
+<script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
@@ -36,22 +36,22 @@ import 'types.dart';
 /// ### Available models
 ///
 /// The following models are available:
-/// - `gemini-1.0-pro`
-///   * text -> text model
-///   * Max input token: 30720
-///   * Max output tokens: 2048
+/// - `gemini-1.5-flash`:
+///   * text / image / audio -> text model
+///   * Max input token: 1048576
+///   * Max output tokens: 8192
+/// - `gemini-1.5-pro`:
+///   * text / image / audio -> text model
+///   * Max input token: 1048576
+///   * Max output tokens: 8192
 /// - `gemini-1.0-pro-vision`:
 ///   * text / image -> text model
 ///   * Max input token: 12288
 ///   * Max output tokens: 4096
-/// - `gemini-1.5-pro-preview-0514`:
-///   * text / image / audio -> text model
-///   * Max input token: 1048576
-///   * Max output tokens: 8192
-/// - `gemini-1.5-flash-preview-0514`:
-///   * text / image / audio -> text model
-///   * Max input token: 1048576
-///   * Max output tokens: 8192
+/// - `gemini-1.0-pro`
+///   * text -> text model
+///   * Max input token: 30720
+///   * Max output tokens: 2048
 ///
 /// Mind that this list may not be up-to-date.
 /// Refer to the [documentation](https://firebase.google.com/docs/vertex-ai/gemini-models)
@@ -132,7 +132,7 @@ import 'types.dart';
 /// );
 /// final chatModel = ChatFirebaseVertexAI(
 ///   defaultOptions: ChatFirebaseVertexAIOptions(
-///     model: 'gemini-1.5-pro-preview-0514',
+///     model: 'gemini-1.5-pro',
 ///     temperature: 0,
 ///     tools: [tool],
 ///   ),

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/types.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/types.dart
@@ -6,7 +6,7 @@ import 'package:langchain_core/chat_models.dart';
 class ChatFirebaseVertexAIOptions extends ChatModelOptions {
   /// {@macro chat_firebase_vertex_ai_options}
   const ChatFirebaseVertexAIOptions({
-    this.model = 'gemini-1.0-pro',
+    this.model = 'gemini-1.5-flash',
     this.topP,
     this.topK,
     this.candidateCount,


### PR DESCRIPTION
The default models has been updated from `gemini-1.0-pro` to `gemini-1.5-flash`