### PR TITLE
feat: Add support for Firebase Auth in ChatFirebaseVertexAI

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -33,6 +33,7 @@ command:
       equatable: ^2.0.5
       fetch_client: ^1.0.2
       firebase_app_check: ^0.3.0
+      firebase_auth: ^5.1.0
       firebase_core: ^3.1.0
       firebase_vertexai: ^0.2.2
       flat_buffers: ^23.5.26

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_vertexai/firebase_vertexai.dart';
 import 'package:langchain_core/chat_models.dart';
@@ -157,6 +158,7 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
     ),
     this.app,
     this.appCheck,
+    this.auth,
     this.options,
     this.location,
   }) : _currentModel = defaultOptions.model ?? '' {
@@ -170,6 +172,9 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
 
   /// The optional [FirebaseAppCheck] to use to protect the project from abuse.
   final FirebaseAppCheck? appCheck;
+
+  /// The optional [FirebaseAuth] to use for authentication.
+  final FirebaseAuth? auth;
 
   /// Configuration parameters for sending requests to Firebase.
   final RequestOptions? options;

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
@@ -217,45 +217,38 @@ extension ChatToolListMapper on List<ToolSpec> {
     switch (type) {
       case 'string':
         if (enumValues != null) {
-          return f.Schema(
-            f.SchemaType.string,
+          return f.Schema.enumString(
             enumValues: enumValues,
             description: description,
             nullable: nullable,
-            format: 'enum',
           );
         } else {
-          return f.Schema(
-            f.SchemaType.string,
+          return f.Schema.string(
             description: description,
             nullable: nullable,
           );
         }
       case 'number':
-        return f.Schema(
-          f.SchemaType.number,
+        return f.Schema.number(
           description: description,
           nullable: nullable,
           format: format,
         );
       case 'integer':
-        return f.Schema(
-          f.SchemaType.integer,
+        return f.Schema.integer(
           description: description,
           nullable: nullable,
           format: format,
         );
       case 'boolean':
-        return f.Schema(
-          f.SchemaType.boolean,
+        return f.Schema.boolean(
           description: description,
           nullable: nullable,
         );
       case 'array':
         if (items != null) {
           final itemsSchema = _mapJsonSchemaToSchema(items);
-          return f.Schema(
-            f.SchemaType.array,
+          return f.Schema.array(
             description: description,
             nullable: nullable,
             items: itemsSchema,
@@ -267,8 +260,7 @@ extension ChatToolListMapper on List<ToolSpec> {
           final propertiesSchema = properties.map(
             (key, value) => MapEntry(key, _mapJsonSchemaToSchema(value)),
           );
-          return f.Schema(
-            f.SchemaType.object,
+          return f.Schema.object(
             properties: propertiesSchema,
             requiredProperties: requiredProperties,
             description: description,

--- a/packages/langchain_firebase/pubspec.lock
+++ b/packages/langchain_firebase/pubspec.lock
@@ -98,7 +98,7 @@ packages:
     source: hosted
     version: "0.1.2+9"
   firebase_auth:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_auth
       sha256: "3af60a78e92567af3d9a5e25d3955f0f6a3f7a33b900724c1c4c336ff5e44200"

--- a/packages/langchain_firebase/pubspec.yaml
+++ b/packages/langchain_firebase/pubspec.yaml
@@ -20,6 +20,7 @@ environment:
 dependencies:
   collection: '>=1.17.0 <1.19.0'
   firebase_app_check: ^0.3.0
+  firebase_auth: ^5.1.0
   firebase_core: ^3.1.0
   firebase_vertexai: ^0.2.2
   langchain_core: ^0.3.2


### PR DESCRIPTION
You can now specify the Firebase Auth instance to use for your VertexAI requests.

Ref: https://github.com/firebase/flutterfire/pull/12797