### PR TITLE
feat!: Update ChatGoogleGenerativeAI default model to  gemini-1.5-flash

### DIFF
--- a/docs/modules/model_io/models/chat_models/integrations/googleai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/googleai.md
@@ -7,22 +7,22 @@ Wrapper around [Google AI for Developers](https://ai.google.dev/) API (aka Gemin
 To use `ChatGoogleGenerativeAI` you need to have an API key. You can get one [here](https://aistudio.google.com/app/apikey).
 
 The following models are available:
-- `gemini-1.0-pro` (or `gemini-pro`):
-  * text -> text model
-  * Max input token: 30720
-  * Max output tokens: 2048
+- `gemini-1.5-flash`:
+  * text / image / audio -> text model
+  * Max input token: 1048576
+  * Max output tokens: 8192
+- `gemini-1.5-pro`: text / image -> text model
+  * text / image / audio -> text model
+  * Max input token: 1048576
+  * Max output tokens: 8192
 - `gemini-pro-vision`:
   * text / image -> text model
   * Max input token: 12288
   * Max output tokens: 4096
-- `gemini-1.5-pro-latest`: text / image -> text model
-  * text / image / audio -> text model
-  * Max input token: 1048576
-  * Max output tokens: 8192
-- `gemini-1.5-flash-latest`:
-  * text / image / audio -> text model
-  * Max input token: 1048576
-  * Max output tokens: 8192
+- `gemini-1.0-pro` (or `gemini-pro`):
+  * text -> text model
+  * Max input token: 30720
+  * Max output tokens: 2048
 
 Mind that this list may not be up-to-date. Refer to the [documentation](https://ai.google.dev/models) for the updated list.
 
@@ -34,7 +34,7 @@ final apiKey = Platform.environment['GOOGLEAI_API_KEY'];
 final chatModel = ChatGoogleGenerativeAI(
   apiKey: apiKey,
   defaultOptions: ChatGoogleGenerativeAIOptions(
-    model: 'gemini-1.5-pro-latest',
+    model: 'gemini-1.5-pro',
     temperature: 0,
   ),
 );
@@ -63,7 +63,7 @@ final apiKey = Platform.environment['GOOGLEAI_API_KEY'];
 final chatModel = ChatGoogleGenerativeAI(
   apiKey: apiKey,
   defaultOptions: ChatGoogleGenerativeAIOptions(
-    model: 'gemini-1.5-pro-latest',
+    model: 'gemini-1.5-pro',
     temperature: 0,
   ),
 );
@@ -99,7 +99,7 @@ final promptTemplate = ChatPromptTemplate.fromTemplates(const [
 final chatModel = ChatGoogleGenerativeAI(
   apiKey: apiKey,
   defaultOptions: const ChatGoogleGenerativeAIOptions(
-    model: 'gemini-1.5-pro-latest',
+    model: 'gemini-1.5-pro',
     temperature: 0,
   ),
 );
@@ -138,7 +138,7 @@ const tool = ToolSpec(
 );
 final chatModel = ChatGoogleGenerativeAI(
   defaultOptions: ChatGoogleGenerativeAIOptions(
-    model: 'gemini-1.5-pro-latest',
+    model: 'gemini-1.5-pro',
     temperature: 0,
     tools: [tool],
   ),

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
@@ -154,7 +154,7 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
   /// - [ChatFirebaseVertexAI.location]
   ChatFirebaseVertexAI({
     super.defaultOptions = const ChatFirebaseVertexAIOptions(
-      model: 'gemini-1.0-pro',
+      model: 'gemini-1.5-flash',
     ),
     this.app,
     this.appCheck,

--- a/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
@@ -31,22 +31,22 @@ import 'types.dart';
 /// ### Available models
 ///
 /// The following models are available:
-/// - `gemini-1.0-pro` (or `gemini-pro`):
-///   * text -> text model
-///   * Max input token: 30720
-///   * Max output tokens: 2048
+/// - `gemini-1.5-flash`:
+///   * text / image / audio -> text model
+///   * Max input token: 1048576
+///   * Max output tokens: 8192
+/// - `gemini-1.5-pro`: text / image -> text model
+///   * text / image / audio -> text model
+///   * Max input token: 1048576
+///   * Max output tokens: 8192
 /// - `gemini-pro-vision`:
 ///   * text / image -> text model
 ///   * Max input token: 12288
 ///   * Max output tokens: 4096
-/// - `gemini-1.5-pro-latest`: text / image -> text model
-///   * text / image / audio -> text model
-///   * Max input token: 1048576
-///   * Max output tokens: 8192
-/// - `gemini-1.5-flash-latest`:
-///   * text / image / audio -> text model
-///   * Max input token: 1048576
-///   * Max output tokens: 8192
+/// - `gemini-1.0-pro` (or `gemini-pro`):
+///   * text -> text model
+///   * Max input token: 30720
+///   * Max output tokens: 2048
 ///
 /// Mind that this list may not be up-to-date.
 /// Refer to the [documentation](https://ai.google.dev/models) for the updated list.
@@ -211,7 +211,7 @@ class ChatGoogleGenerativeAI
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
     super.defaultOptions = const ChatGoogleGenerativeAIOptions(
-      model: 'gemini-pro',
+      model: 'gemini-1.5-flash',
     ),
   })  : _currentModel = defaultOptions.model ?? '',
         _httpClient = createDefaultHttpClient(

--- a/packages/langchain_google/lib/src/chat_models/google_ai/types.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/types.dart
@@ -6,7 +6,7 @@ import 'package:langchain_core/chat_models.dart';
 class ChatGoogleGenerativeAIOptions extends ChatModelOptions {
   /// {@macro chat_google_generative_ai_options}
   const ChatGoogleGenerativeAIOptions({
-    this.model = 'gemini-pro',
+    this.model = 'gemini-1.5-flash',
     this.topP,
     this.topK,
     this.candidateCount,


### PR DESCRIPTION
The default models has been updated from `gemini-1.0-pro` to `gemini-1.5-flash`