### PR TITLE
feat: Add support for service tier in ChatOpenAI

### DIFF
--- a/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
@@ -276,13 +276,15 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final bool stream = false,
   }) {
     final messagesDtos = messages.toChatCompletionMessages();
-    final toolsDtos = options?.tools?.toChatCompletionTool() ??
-        defaultOptions.tools?.toChatCompletionTool();
-    final toolChoice = options?.toolChoice?.toChatCompletionToolChoice() ??
-        defaultOptions.toolChoice?.toChatCompletionToolChoice();
-    final responseFormat =
-        options?.responseFormat ?? defaultOptions.responseFormat;
-    final responseFormatDto = responseFormat?.toChatCompletionResponseFormat();
+    final toolsDtos =
+        (options?.tools ?? defaultOptions.tools)?.toChatCompletionTool();
+    final toolChoice = (options?.toolChoice ?? defaultOptions.toolChoice)
+        ?.toChatCompletionToolChoice();
+    final responseFormatDto =
+        (options?.responseFormat ?? defaultOptions.responseFormat)
+            ?.toChatCompletionResponseFormat();
+    final serviceTierDto = (options?.serviceTier ?? defaultOptions.serviceTier)
+        .toCreateChatCompletionRequestServiceTier();
 
     return CreateChatCompletionRequest(
       model: ChatCompletionModel.modelId(
@@ -307,6 +309,7 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
       topP: options?.topP ?? defaultOptions.topP,
       parallelToolCalls:
           options?.parallelToolCalls ?? defaultOptions.parallelToolCalls,
+      serviceTier: serviceTierDto,
       user: options?.user ?? defaultOptions.user,
       streamOptions:
           stream ? const ChatCompletionStreamOptions(includeUsage: true) : null,

--- a/packages/langchain_openai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/mappers.dart
@@ -260,6 +260,17 @@ extension ChatOpenAIResponseFormatMapper on ChatOpenAIResponseFormat {
   }
 }
 
+extension ChatOpenAIServiceTierX on ChatOpenAIServiceTier? {
+  CreateChatCompletionRequestServiceTier?
+      toCreateChatCompletionRequestServiceTier() => switch (this) {
+            ChatOpenAIServiceTier.auto =>
+              CreateChatCompletionRequestServiceTier.auto,
+            ChatOpenAIServiceTier.vDefault =>
+              CreateChatCompletionRequestServiceTier.vDefault,
+            null => null,
+          };
+}
+
 FinishReason _mapFinishReason(
   final ChatCompletionFinishReason? reason,
 ) =>

--- a/packages/langchain_openai/lib/src/chat_models/types.dart
+++ b/packages/langchain_openai/lib/src/chat_models/types.dart
@@ -19,6 +19,7 @@ class ChatOpenAIOptions extends ChatModelOptions {
     this.temperature,
     this.topP,
     this.parallelToolCalls,
+    this.serviceTier,
     this.user,
     super.tools,
     super.toolChoice,
@@ -131,6 +132,10 @@ class ChatOpenAIOptions extends ChatModelOptions {
   /// Ref: https://platform.openai.com/docs/guides/function-calling/parallel-function-calling
   final bool? parallelToolCalls;
 
+  /// Specifies the latency tier to use for processing the request.
+  /// This is relevant for customers subscribed to the scale tier service.
+  final ChatOpenAIServiceTier? serviceTier;
+
   /// A unique identifier representing your end-user, which can help OpenAI to
   /// monitor and detect abuse.
   ///
@@ -151,6 +156,8 @@ class ChatOpenAIOptions extends ChatModelOptions {
     final List<String>? stop,
     final double? temperature,
     final double? topP,
+    final bool? parallelToolCalls,
+    final ChatOpenAIServiceTier? serviceTier,
     final String? user,
     final List<ToolSpec>? tools,
     final ChatToolChoice? toolChoice,
@@ -167,6 +174,8 @@ class ChatOpenAIOptions extends ChatModelOptions {
       stop: stop ?? this.stop,
       temperature: temperature ?? this.temperature,
       topP: topP ?? this.topP,
+      parallelToolCalls: parallelToolCalls ?? this.parallelToolCalls,
+      serviceTier: serviceTier ?? this.serviceTier,
       user: user ?? this.user,
       tools: tools ?? this.tools,
       toolChoice: toolChoice ?? this.toolChoice,
@@ -195,4 +204,15 @@ enum ChatOpenAIResponseFormatType {
   /// [ChatOpenAIResponseFormatType.jsonObject] enables JSON mode, which
   /// guarantees the message the model generates is valid JSON.
   jsonObject,
+}
+
+/// Specifies the latency tier to use for processing the request.
+/// This is relevant for customers subscribed to the scale tier service.
+enum ChatOpenAIServiceTier {
+  /// The system will utilize scale tier credits until they are exhausted.
+  auto,
+
+  /// The request will be processed using the default service tier with a lower
+  /// uptime SLA and no latency guarantee.
+  vDefault,
 }


### PR DESCRIPTION
Specifies the latency tier to use for processing the request. This parameter is relevant for customers subscribed to the scale tier service:
- If set to 'auto', the system will utilize scale tier credits until they are exhausted.
- If set to 'default', the request will be processed using the default service tier with a lower uptime SLA and no latency guarantee.

When this parameter is set, the response body will include the `service_tier` utilized.