### PR TITLE
refactor: Don't send OpenAI-Beta header in ChatOpenAI

### DIFF
--- a/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
@@ -200,6 +200,7 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
   }) : _client = OpenAIClient(
           apiKey: apiKey ?? '',
           organization: organization,
+          beta: null,
           baseUrl: baseUrl,
           headers: headers,
           queryParams: queryParams,


### PR DESCRIPTION
`OpenAI-Beta` header is only required if you use OpenAI beta features (like the Assistant API). `ChatOpenAI` doesn't use any beta API. However `OpenAIClient` adds this header by default, which seems to cause issues with some OpenAI compatible APIs (like [OpenRouter](https://github.com/davidmigloz/langchain_dart/issues/510)).