### PR TITLE
feat: Add chatgpt-4o-latest to model catalog

### DIFF
--- a/packages/langchain_openai/lib/src/chat_models/types.dart
+++ b/packages/langchain_openai/lib/src/chat_models/types.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 /// Options to pass into the OpenAI Chat Model.
 ///
 /// Available [ChatOpenAIOptions.model]s:
+/// - `chatgpt-4o-latest`
 /// - `gpt-4`
 /// - `gpt-4-32k`
 /// - `gpt-4-32k-0314`

--- a/packages/openai_dart/lib/src/generated/schema/create_chat_completion_request.dart
+++ b/packages/openai_dart/lib/src/generated/schema/create_chat_completion_request.dart
@@ -277,6 +277,8 @@ class CreateChatCompletionRequest with _$CreateChatCompletionRequest {
 
 /// Available completion models. Mind that the list may not be exhaustive nor up-to-date.
 enum ChatCompletionModels {
+  @JsonValue('chatgpt-4o-latest')
+  chatgpt4oLatest,
   @JsonValue('gpt-4')
   gpt4,
   @JsonValue('gpt-4-32k')

--- a/packages/openai_dart/lib/src/generated/schema/schema.g.dart
+++ b/packages/openai_dart/lib/src/generated/schema/schema.g.dart
@@ -414,6 +414,7 @@ Map<String, dynamic> _$$ChatCompletionModelEnumerationImplToJson(
     };
 
 const _$ChatCompletionModelsEnumMap = {
+  ChatCompletionModels.chatgpt4oLatest: 'chatgpt-4o-latest',
   ChatCompletionModels.gpt4: 'gpt-4',
   ChatCompletionModels.gpt432k: 'gpt-4-32k',
   ChatCompletionModels.gpt432k0314: 'gpt-4-32k-0314',

--- a/packages/openai_dart/oas/openapi_curated.yaml
+++ b/packages/openai_dart/oas/openapi_curated.yaml
@@ -1806,6 +1806,7 @@ components:
                 Available completion models. Mind that the list may not be exhaustive nor up-to-date.
               enum:
                 [
+                  "chatgpt-4o-latest",
                   "gpt-4",
                   "gpt-4-32k",
                   "gpt-4-32k-0314",

--- a/packages/openai_dart/oas/openapi_official.yaml
+++ b/packages/openai_dart/oas/openapi_official.yaml
@@ -8173,6 +8173,7 @@ components:
                   "gpt-4o",
                   "gpt-4o-2024-05-13",
                   "gpt-4o-2024-08-06",
+                  "chatgpt-4o-latest",
                   "gpt-4o-mini",
                   "gpt-4o-mini-2024-07-18",
                   "gpt-4-turbo",


### PR DESCRIPTION
> `chatgpt-4o-latest` model version continuously points to the version of GPT-4o used in [ChatGPT](https://chatgpt.com/), and is updated frequently. 
>
> We are releasing this model for developers and researchers to explore OpenAI's latest research. For production use, OpenAI recommends using dated GPT models, which are optimized for API usage.

