### PR TITLE
feat: Include logprobs in result metadata from ChatOpenAI

### DIFF
--- a/packages/langchain_openai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/mappers.dart
@@ -209,6 +209,7 @@ extension CreateChatCompletionResponseMapper on CreateChatCompletionResponse {
         'model': model,
         'created': created,
         'system_fingerprint': systemFingerprint,
+        'logprobs': choice.logprobs?.toMap(),
       },
       usage: _mapUsage(usage),
     );


### PR DESCRIPTION
Include log probability information for the generation (`result.metadata.logprobs`).

- token: The token.
- logprob:  The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely.
- bytes: A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token.
    required List<int>? bytes,
- topLogprobs:  List of the most likely tokens and their log probability, at this token position. In rare cases, there may be fewer than the number of requested `top_logprobs` returned.