### PR TITLE
feat: Support OpenAI's strict mode for tool calling in ChatOpenAI

### DIFF
--- a/packages/langchain_core/lib/src/tools/base.dart
+++ b/packages/langchain_core/lib/src/tools/base.dart
@@ -18,6 +18,7 @@ class ToolSpec {
     required this.name,
     required this.description,
     required this.inputJsonSchema,
+    this.strict = false,
   });
 
   /// The unique name of the tool that clearly communicates its purpose.
@@ -50,18 +51,31 @@ class ToolSpec {
   /// ```
   final Map<String, dynamic> inputJsonSchema;
 
+  /// Whether to enable strict schema adherence when generating the tool call.
+  /// If set to true, the model will follow the exact schema defined in the
+  /// [inputJsonSchema] field.
+  ///
+  /// This is only supported by some providers (e.g. OpenAI). Mind that when
+  /// enabled, only a subset of JSON Schema may be supported. Check out the
+  /// provider's tool calling documentation for more information.
+  final bool strict;
+
   @override
   bool operator ==(covariant final ToolSpec other) {
     final mapEquals = const DeepCollectionEquality().equals;
     return identical(this, other) ||
         name == other.name &&
             description == other.description &&
-            mapEquals(inputJsonSchema, other.inputJsonSchema);
+            mapEquals(inputJsonSchema, other.inputJsonSchema) &&
+            strict == other.strict;
   }
 
   @override
   int get hashCode =>
-      name.hashCode ^ description.hashCode ^ inputJsonSchema.hashCode;
+      name.hashCode ^
+      description.hashCode ^
+      inputJsonSchema.hashCode ^
+      strict.hashCode;
 
   @override
   String toString() {
@@ -70,6 +84,7 @@ ToolSpec{
   name: $name,
   description: $description,
   inputJsonSchema: $inputJsonSchema,
+  strict: $strict,
 }
 ''';
   }
@@ -80,6 +95,7 @@ ToolSpec{
       'name': name,
       'description': description,
       'inputJsonSchema': inputJsonSchema,
+      'strict': strict,
     };
   }
 }
@@ -102,6 +118,7 @@ abstract base class Tool<Input extends Object, Options extends ToolOptions,
     required this.name,
     required this.description,
     required this.inputJsonSchema,
+    this.strict = false,
     this.returnDirect = false,
     this.handleToolError,
     final Options? defaultOptions,
@@ -118,6 +135,9 @@ abstract base class Tool<Input extends Object, Options extends ToolOptions,
   @override
   final Map<String, dynamic> inputJsonSchema;
 
+  @override
+  final bool strict;
+
   /// Whether to return the tool's output directly.
   /// Setting this to true means that after the tool is called,
   /// the AgentExecutor will stop looping.
@@ -132,7 +152,9 @@ abstract base class Tool<Input extends Object, Options extends ToolOptions,
   ///   purpose.
   /// - [description] is used to tell the model how/when/why to use the tool.
   ///   You can provide few-shot examples as a part of the description.
-  /// - [inputJsonSchema] is the schema to parse and validate tool's input
+  /// - [inputJsonSchema] is the schema to parse and validate tool's input.
+  /// - [strict] whether to enable strict schema adherence when generating the
+  ///   tool call (only supported by some providers).
   /// - [func] is the function that will be called when the tool is run.
   ///   arguments.
   /// - [getInputFromJson] is a function that parses the input JSON to the
@@ -148,6 +170,7 @@ abstract base class Tool<Input extends Object, Options extends ToolOptions,
     required final String name,
     required final String description,
     required final Map<String, dynamic> inputJsonSchema,
+    final bool strict = false,
     required final FutureOr<Output> Function(Input input) func,
     Input Function(Map<String, dynamic> json)? getInputFromJson,
     final bool returnDirect = false,
@@ -157,6 +180,7 @@ abstract base class Tool<Input extends Object, Options extends ToolOptions,
       name: name,
       description: description,
       inputJsonSchema: inputJsonSchema,
+      strict: strict,
       function: func,
       getInputFromJson: getInputFromJson ?? (json) => json['input'] as Input,
       returnDirect: returnDirect,
@@ -217,12 +241,16 @@ abstract base class Tool<Input extends Object, Options extends ToolOptions,
     return identical(this, other) ||
         name == other.name &&
             description == other.description &&
-            mapEquals(inputJsonSchema, other.inputJsonSchema);
+            mapEquals(inputJsonSchema, other.inputJsonSchema) &&
+            strict == other.strict;
   }
 
   @override
   int get hashCode =>
-      name.hashCode ^ description.hashCode ^ inputJsonSchema.hashCode;
+      name.hashCode ^
+      description.hashCode ^
+      inputJsonSchema.hashCode ^
+      strict.hashCode;
 
   @override
   Map<String, dynamic> toJson() {
@@ -230,6 +258,7 @@ abstract base class Tool<Input extends Object, Options extends ToolOptions,
       'name': name,
       'description': description,
       'inputJsonSchema': inputJsonSchema,
+      'strict': strict,
     };
   }
 }
@@ -245,6 +274,7 @@ final class _ToolFunc<Input extends Object, Output extends Object>
     required super.name,
     required super.description,
     required super.inputJsonSchema,
+    required super.strict,
     required FutureOr<Output> Function(Input input) function,
     required Input Function(Map<String, dynamic> json) getInputFromJson,
     super.returnDirect = false,

--- a/packages/langchain_core/lib/src/tools/string.dart
+++ b/packages/langchain_core/lib/src/tools/string.dart
@@ -14,6 +14,7 @@ abstract base class StringTool<Options extends ToolOptions>
     required super.name,
     required super.description,
     final String inputDescription = 'The input to the tool',
+    super.strict = false,
     super.returnDirect = false,
     super.handleToolError,
     super.defaultOptions,
@@ -36,6 +37,8 @@ abstract base class StringTool<Options extends ToolOptions>
   ///   purpose.
   /// - [description] is used to tell the model how/when/why to use the tool.
   ///   You can provide few-shot examples as a part of the description.
+  /// - [strict] whether to enable strict schema adherence when generating the
+  ///   tool call (only supported by some providers).
   /// - [func] is the function that will be called when the tool is run.
   /// - [returnDirect] whether to return the tool's output directly.
   ///   Setting this to true means that after the tool is called,
@@ -46,6 +49,7 @@ abstract base class StringTool<Options extends ToolOptions>
     required final String name,
     required final String description,
     final String inputDescription = 'The input to the tool',
+    final bool strict = false,
     required final FutureOr<String> Function(String input) func,
     final bool returnDirect = false,
     final String Function(ToolException)? handleToolError,
@@ -54,6 +58,7 @@ abstract base class StringTool<Options extends ToolOptions>
       name: name,
       description: description,
       inputDescription: inputDescription,
+      strict: strict,
       func: func,
       returnDirect: returnDirect,
       handleToolError: handleToolError,
@@ -84,6 +89,7 @@ final class _StringToolFunc<Options extends ToolOptions>
     required super.name,
     required super.description,
     super.inputDescription,
+    required super.strict,
     required FutureOr<String> Function(String) func,
     super.returnDirect = false,
     super.handleToolError,


### PR DESCRIPTION
When defining your tool, set the `strict` parameter to true to enable strict schema adherence when generating the tool call. If set to true, the model will follow the exact schema defined in the `inputJsonSchema` field.

This is only supported by OpenAI provider at the moment.  And they only support [a subset of JSON Schema](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas) is supported when strict is enabled. Check out [their docs](https://platform.openai.com/docs/guides/structured-outputs) for more info.

