### PR TITLE
refactor: Add stubs for ObjectBox on web platform

### DIFF
--- a/packages/langchain_community/lib/src/vector_stores/objectbox/base_objectbox_stub.dart
+++ b/packages/langchain_community/lib/src/vector_stores/objectbox/base_objectbox_stub.dart
@@ -1,0 +1,40 @@
+// ignore_for_file: public_member_api_docs, avoid_unused_constructor_parameters
+import 'package:langchain_core/documents.dart';
+import 'package:langchain_core/vector_stores.dart';
+
+// This is a stub class
+class BaseObjectBoxVectorStore<T> extends VectorStore {
+  BaseObjectBoxVectorStore({
+    required super.embeddings,
+    required final Object? box,
+    required final Object? createEntity,
+    required final Object? createDocument,
+    required final Object? getIdProperty,
+    required final Object? getEmbeddingProperty,
+  });
+
+  @override
+  Future<List<String>> addVectors({
+    required List<List<double>> vectors,
+    required List<Document> documents,
+  }) {
+    throw UnsupportedError('ObjectBox is not supported on web platform.');
+  }
+
+  @override
+  Future<void> delete({required List<String> ids}) {
+    throw UnsupportedError('ObjectBox is not supported on web platform.');
+  }
+
+  Future<void> deleteWhere(final Object condition) {
+    throw UnsupportedError('ObjectBox is not supported on web platform.');
+  }
+
+  @override
+  Future<List<(Document, double)>> similaritySearchByVectorWithScores({
+    required List<double> embedding,
+    VectorStoreSimilaritySearch config = const VectorStoreSimilaritySearch(),
+  }) {
+    throw UnsupportedError('ObjectBox is not supported on web platform.');
+  }
+}

--- a/packages/langchain_community/lib/src/vector_stores/objectbox/ob.dart
+++ b/packages/langchain_community/lib/src/vector_stores/objectbox/ob.dart
@@ -1,0 +1,7 @@
+export 'ob_io.dart' if (dart.library.js_interop) 'ob_stub.dart'
+    show
+        BaseObjectBoxVectorStore,
+        ObjectBoxDocument,
+        ObjectBoxDocumentProps,
+        ObjectBoxSimilaritySearch,
+        ObjectBoxVectorStore;

--- a/packages/langchain_community/lib/src/vector_stores/objectbox/ob_io.dart
+++ b/packages/langchain_community/lib/src/vector_stores/objectbox/ob_io.dart
@@ -1,0 +1,3 @@
+export 'base_objectbox.dart';
+export 'objectbox.dart';
+export 'types.dart';

--- a/packages/langchain_community/lib/src/vector_stores/objectbox/ob_stub.dart
+++ b/packages/langchain_community/lib/src/vector_stores/objectbox/ob_stub.dart
@@ -1,0 +1,3 @@
+export 'base_objectbox_stub.dart';
+export 'objectbox_stub.dart';
+export 'types_stub.dart';

--- a/packages/langchain_community/lib/src/vector_stores/objectbox/objectbox_stub.dart
+++ b/packages/langchain_community/lib/src/vector_stores/objectbox/objectbox_stub.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: public_member_api_docs, avoid_unused_constructor_parameters
+import 'base_objectbox_stub.dart';
+
+// This is a stub class
+class ObjectBoxVectorStore extends BaseObjectBoxVectorStore<ObjectBoxDocument> {
+  ObjectBoxVectorStore({
+    required super.embeddings,
+    required int dimensions,
+    final String? directory,
+    final int? maxDBSizeInKB,
+    final int? maxDataSizeInKB,
+    final int? fileMode,
+    final int? maxReaders,
+    final bool queriesCaseSensitiveDefault = true,
+    final String? macosApplicationGroup,
+  }) : super(
+          box: null,
+          createEntity: null,
+          createDocument: null,
+          getIdProperty: null,
+          getEmbeddingProperty: null,
+        );
+
+  void close() {
+    throw UnsupportedError('ObjectBox is not supported on web platform.');
+  }
+}
+
+// This is a stub class
+class ObjectBoxDocument {
+  ObjectBoxDocument(
+    this.internalId,
+    this.id,
+    this.content,
+    this.metadata,
+    this.embedding,
+  );
+
+  int internalId = 0;
+  String id;
+  String content;
+  String metadata;
+  List<double> embedding;
+}
+
+// This is a stub class
+class ObjectBoxDocumentProps {
+  static const internalId = null;
+  static const id = null;
+  static const content = null;
+  static const metadata = null;
+  static const embedding = null;
+}

--- a/packages/langchain_community/lib/src/vector_stores/objectbox/types_stub.dart
+++ b/packages/langchain_community/lib/src/vector_stores/objectbox/types_stub.dart
@@ -1,0 +1,11 @@
+// ignore_for_file: public_member_api_docs, avoid_unused_constructor_parameters
+import 'package:langchain_core/vector_stores.dart';
+
+// This is a stub class
+class ObjectBoxSimilaritySearch extends VectorStoreSimilaritySearch {
+  ObjectBoxSimilaritySearch({
+    super.k = 0,
+    super.scoreThreshold,
+    Object? filterCondition,
+  }) : super(filter: null);
+}

--- a/packages/langchain_community/lib/src/vector_stores/vector_stores.dart
+++ b/packages/langchain_community/lib/src/vector_stores/vector_stores.dart
@@ -1,4 +1,1 @@
-export 'objectbox/base_objectbox.dart' show BaseObjectBoxVectorStore;
-export 'objectbox/objectbox.dart'
-    show ObjectBoxDocument, ObjectBoxDocumentProps, ObjectBoxVectorStore;
-export 'objectbox/types.dart' show ObjectBoxSimilaritySearch;
+export 'objectbox/ob.dart';


### PR DESCRIPTION
The langchain_community package is currently displayed as if it doesn't support web.
This is due to the ObjectBox integration, whose package doesn't support web. 
This PR adds web stubs for all classes related to the ObjectBox integration.

<img width="897" alt="image" src="https://github.com/user-attachments/assets/398cba6a-fb24-4bc2-98cd-25827665d27d">
