### PR TITLE
refactor: Migrate ChatOpenAI to maxCompletionTokens

### DIFF
--- a/packages/langchain_openai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/mappers.dart
@@ -37,7 +37,7 @@ CreateChatCompletionRequest createChatCompletionRequest(
     frequencyPenalty:
         options?.frequencyPenalty ?? defaultOptions.frequencyPenalty,
     logitBias: options?.logitBias ?? defaultOptions.logitBias,
-    maxTokens: options?.maxTokens ?? defaultOptions.maxTokens,
+    maxCompletionTokens: options?.maxTokens ?? defaultOptions.maxTokens,
     n: options?.n ?? defaultOptions.n,
     presencePenalty: options?.presencePenalty ?? defaultOptions.presencePenalty,
     responseFormat: responseFormatDto,


### PR DESCRIPTION
`maxTokens` is deprecated in favor of `maxCompletionTokens` in the OpenAI API, and is not compatible with [o1 series models](https://platform.openai.com/docs/guides/reasoning).