### PR TITLE
OpenAI: Fix submitThreadToolOutputsToRunStream

### DIFF
--- a/packages/openai_dart/lib/src/client.dart
+++ b/packages/openai_dart/lib/src/client.dart
@@ -183,7 +183,7 @@ class OpenAIClient extends g.OpenAIClient {
       method: g.HttpMethod.post,
       requestType: 'application/json',
       responseType: 'application/json',
-      body: request,
+      body: request.copyWith(stream: true),
     );
     yield* r.stream.transform(const _OpenAIAssistantStreamTransformer());
   }


### PR DESCRIPTION
- Description: `submitThreadToolOutputsToRunStream` was not returning any events.
- Issue: (same as description)
- Dependencies: None.
- Tag maintainer: @davidmigloz