### PR TITLE
fix: Character support on web loader

### DIFF
--- a/packages/langchain_community/lib/src/document_loaders/web.dart
+++ b/packages/langchain_community/lib/src/document_loaders/web.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 
 import 'package:langchain_core/document_loaders.dart';
 import 'package:langchain_core/documents.dart';
+import 'dart:convert';
 
 /// {@template web_base_loader}
 /// A document loader that loads [Document]s from web pages.
@@ -57,7 +58,7 @@ class WebBaseLoader extends BaseDocumentLoader {
 
   Future<String> _fetchUrl(final String url) async {
     final response = await http.get(Uri.parse(url), headers: requestHeaders);
-    return response.body;
+    return utf8.decode(response.bodyBytes);
   }
 
   Map<String, dynamic> _buildMetadata(


### PR DESCRIPTION
 - Description: Document loader returns weird characters in some languages.
  
  Sample article: http://web.tccf.org.tw/lib/addon.php?act=post&id=4975
  Sample screenshot: 
<img width="383" alt="image" src="https://github.com/user-attachments/assets/fd3c674e-6066-482e-b32f-08876ebb7840">


Maintainer responsibilities:
  - General: @davidmigloz
