### PR TITLE
feat: Support responseSchema in ChatFirebaseVertexAI

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -35,7 +35,7 @@ command:
       firebase_app_check: ^0.3.0
       firebase_auth: ^5.1.0
       firebase_core: ^3.3.0
-      firebase_vertexai: ^0.2.2
+      firebase_vertexai: ^1.4.0
       flat_buffers: ^23.5.26
       flutter_bloc: ^8.1.6
       flutter_markdown: ^0.7.3

--- a/packages/langchain_firebase/example/pubspec.lock
+++ b/packages/langchain_firebase/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: b1595874fbc8f7a50da90f5d8f327bb0bfd6a95dc906c390efe991540c3b54aa
+      sha256: "7fd72d77a7487c26faab1d274af23fb008763ddc10800261abbfb2c067f183d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.40"
+    version: "1.3.53"
   args:
     dependency: transitive
     description:
@@ -93,82 +93,82 @@ packages:
     dependency: transitive
     description:
       name: firebase_app_check
-      sha256: "8314938830d6b47217e369664567f6d8a1e77603448e1dbdaf4f7d8c2111ff5c"
+      sha256: e46ab7581374274a77ad085432454a591de25423759b16e3c3d6178ccafff8ff
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+4"
+    version: "0.3.2+4"
   firebase_app_check_platform_interface:
     dependency: transitive
     description:
       name: firebase_app_check_platform_interface
-      sha256: edefbd312d2f4c52ab6a62d4efca512012bcc580f152c856a5730bfabcf8a924
+      sha256: a222561ecf82c266f0da36e6053db113a8f416561693cd068b1f8f40559ec1c8
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0+34"
+    version: "0.1.1+4"
   firebase_app_check_web:
     dependency: transitive
     description:
       name: firebase_app_check_web
-      sha256: "2c2377ecf922514c540c2d4a9c06e46830a0706fdfc3d59b7ade9b75843b81c5"
+      sha256: "0603ff696849d0d2e73b6aef0e60509d6ccc8cad3ea090b85d5b2d4e884eca48"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2+12"
+    version: "0.2.0+8"
   firebase_auth:
     dependency: transitive
     description:
       name: firebase_auth
-      sha256: "2457ac6cbc152fa464aad3fb35f98039b0c4ab8e9bedf476672508b291bdbc3a"
+      sha256: "91587615d7d9165c65a030426e3cf40bbec37c486f52ff654af17aba5be3d208"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.4"
+    version: "5.5.1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: "0408e2ed74b1afa0490a93aa041fe90d7573af7ffc59a641edc6c5b5c1b8d2a4"
+      sha256: "1dcf1dbdd90fe97fa37ab3631b561bf584adb88f6be0b0dd915fff799ad53192"
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.3"
+    version: "7.6.1"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: "7e0c6d0fa8c5c1b2ae126a78f2d1a206a77a913f78d20f155487bf746162dccc"
+      sha256: "3774cb13547e28b180fed2a5e696b4b36f97f4b1fadc7b04a0200e5009344d98"
       url: "https://pub.dev"
     source: hosted
-    version: "5.12.5"
+    version: "5.14.1"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "3187f4f8e49968573fd7403011dca67ba95aae419bc0d8131500fae160d94f92"
+      sha256: f4d8f49574a4e396f34567f3eec4d38ab9c3910818dec22ca42b2a467c685d8b
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.12.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "3c3a1e92d6f4916c32deea79c4a7587aa0e9dbbe5889c7a16afcf005a485ee02"
+      sha256: d7253d255ff10f85cfd2adaba9ac17bae878fa3ba577462451163bd9f1d1f0bf
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.4.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: e8d1e22de72cb21cdcfc5eed7acddab3e99cd83f3b317f54f7a96c32f25fd11e
+      sha256: faa5a76f6380a9b90b53bc3bdcb85bc7926a382e0709b9b5edac9f7746651493
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.4"
+    version: "2.21.1"
   firebase_vertexai:
     dependency: transitive
     description:
       name: firebase_vertexai
-      sha256: ad34f7a87d870949e92851f4c73b7e15f808fd4717ed899fa7b4813fffe74831
+      sha256: "2db8b3e028844ef6e7bb54a9246f8887aa4dd8fffb578abd10d53d9f34ca208d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2+4"
+    version: "1.4.0"
   fixnum:
     dependency: transitive
     description:
@@ -208,14 +208,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  google_generative_ai:
-    dependency: transitive
-    description:
-      name: google_generative_ai
-      sha256: e2f4c0ac13f0898f670ce5ac0dc4501ebe09b96f9d59163724380d9aa82065be
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.4"
   http:
     dependency: transitive
     description:
@@ -438,10 +430,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.1"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.22.0"

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
@@ -150,7 +150,6 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
   /// Firebase configuration options:
   /// - [ChatFirebaseVertexAI.app]
   /// - [ChatFirebaseVertexAI.appCheck]
-  /// - [ChatFirebaseVertexAI.options]
   /// - [ChatFirebaseVertexAI.location]
   ChatFirebaseVertexAI({
     super.defaultOptions = const ChatFirebaseVertexAIOptions(
@@ -159,7 +158,6 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
     this.app,
     this.appCheck,
     this.auth,
-    this.options,
     this.location,
   }) : _currentModel = defaultOptions.model ?? '' {
     _firebaseClient = _createFirebaseClient(
@@ -175,9 +173,6 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
 
   /// The optional [FirebaseAuth] to use for authentication.
   final FirebaseAuth? auth;
-
-  /// Configuration parameters for sending requests to Firebase.
-  final RequestOptions? options;
 
   /// The service location for the [FirebaseVertexAI] instance.
   final String? location;
@@ -268,10 +263,9 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
         topK: options?.topK ?? defaultOptions.topK,
         responseMimeType:
             options?.responseMimeType ?? defaultOptions.responseMimeType,
-        // responseSchema not supported yet
-        // responseSchema:
-        // (options?.responseSchema ?? defaultOptions.responseSchema)
-        //     ?.toSchema(),
+        responseSchema:
+        (options?.responseSchema ?? defaultOptions.responseSchema)
+            ?.toSchema(),
       ),
       (options?.tools ?? defaultOptions.tools)?.toToolList(),
       (options?.toolChoice ?? defaultOptions.toolChoice)?.toToolConfig(),
@@ -307,7 +301,6 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
     return FirebaseVertexAI.instanceFor(
       app: app,
       appCheck: appCheck,
-      options: options,
       location: location,
     ).generativeModel(
       model: model,

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/types.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/types.dart
@@ -21,6 +21,7 @@ class ChatFirebaseVertexAIOptions extends ChatModelOptions {
     this.temperature,
     this.stopSequences,
     this.responseMimeType,
+    this.responseSchema,
     this.safetySettings,
     super.tools,
     super.toolChoice,
@@ -77,6 +78,32 @@ class ChatFirebaseVertexAIOptions extends ChatModelOptions {
   /// - `text/plain`: (default) Text output.
   /// - `application/json`: JSON response in the candidates.
   final String? responseMimeType;
+
+  /// Output response schema of the generated candidate text.
+  /// Following the [JSON Schema specification](https://json-schema.org).
+  ///
+  /// Note: This only applies when the [responseMimeType] supports
+  /// a schema; currently this is limited to `application/json`.
+  ///
+  /// Example:
+  /// ```json
+  /// {
+  ///   'type': 'object',
+  ///   'properties': {
+  ///     'answer': {
+  ///       'type': 'string',
+  ///       'description': 'The answer to the question being asked',
+  ///     },
+  ///     'sources': {
+  ///       'type': 'array',
+  ///       'items': {'type': 'string'},
+  ///       'description': 'The sources used to answer the question',
+  ///     },
+  ///   },
+  ///   'required': ['answer', 'sources'],
+  /// }
+  /// ```
+  final Map<String, dynamic>? responseSchema;
 
   /// A list of unique [ChatFirebaseVertexAISafetySetting] instances for blocking
   /// unsafe content.

--- a/packages/langchain_firebase/pubspec.lock
+++ b/packages/langchain_firebase/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: b1595874fbc8f7a50da90f5d8f327bb0bfd6a95dc906c390efe991540c3b54aa
+      sha256: "7fd72d77a7487c26faab1d274af23fb008763ddc10800261abbfb2c067f183d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.40"
+    version: "1.3.53"
   async:
     dependency: transitive
     description:
@@ -77,82 +77,82 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_app_check
-      sha256: "8314938830d6b47217e369664567f6d8a1e77603448e1dbdaf4f7d8c2111ff5c"
+      sha256: e46ab7581374274a77ad085432454a591de25423759b16e3c3d6178ccafff8ff
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+4"
+    version: "0.3.2+4"
   firebase_app_check_platform_interface:
     dependency: transitive
     description:
       name: firebase_app_check_platform_interface
-      sha256: edefbd312d2f4c52ab6a62d4efca512012bcc580f152c856a5730bfabcf8a924
+      sha256: a222561ecf82c266f0da36e6053db113a8f416561693cd068b1f8f40559ec1c8
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0+34"
+    version: "0.1.1+4"
   firebase_app_check_web:
     dependency: transitive
     description:
       name: firebase_app_check_web
-      sha256: "2c2377ecf922514c540c2d4a9c06e46830a0706fdfc3d59b7ade9b75843b81c5"
+      sha256: "0603ff696849d0d2e73b6aef0e60509d6ccc8cad3ea090b85d5b2d4e884eca48"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2+12"
+    version: "0.2.0+8"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: "2457ac6cbc152fa464aad3fb35f98039b0c4ab8e9bedf476672508b291bdbc3a"
+      sha256: "91587615d7d9165c65a030426e3cf40bbec37c486f52ff654af17aba5be3d208"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.4"
+    version: "5.5.1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: "0408e2ed74b1afa0490a93aa041fe90d7573af7ffc59a641edc6c5b5c1b8d2a4"
+      sha256: "1dcf1dbdd90fe97fa37ab3631b561bf584adb88f6be0b0dd915fff799ad53192"
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.3"
+    version: "7.6.1"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: "7e0c6d0fa8c5c1b2ae126a78f2d1a206a77a913f78d20f155487bf746162dccc"
+      sha256: "3774cb13547e28b180fed2a5e696b4b36f97f4b1fadc7b04a0200e5009344d98"
       url: "https://pub.dev"
     source: hosted
-    version: "5.12.5"
+    version: "5.14.1"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "3187f4f8e49968573fd7403011dca67ba95aae419bc0d8131500fae160d94f92"
+      sha256: f4d8f49574a4e396f34567f3eec4d38ab9c3910818dec22ca42b2a467c685d8b
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.12.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "3c3a1e92d6f4916c32deea79c4a7587aa0e9dbbe5889c7a16afcf005a485ee02"
+      sha256: d7253d255ff10f85cfd2adaba9ac17bae878fa3ba577462451163bd9f1d1f0bf
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.4.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: e8d1e22de72cb21cdcfc5eed7acddab3e99cd83f3b317f54f7a96c32f25fd11e
+      sha256: faa5a76f6380a9b90b53bc3bdcb85bc7926a382e0709b9b5edac9f7746651493
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.4"
+    version: "2.21.1"
   firebase_vertexai:
     dependency: "direct main"
     description:
       name: firebase_vertexai
-      sha256: ad34f7a87d870949e92851f4c73b7e15f808fd4717ed899fa7b4813fffe74831
+      sha256: "2db8b3e028844ef6e7bb54a9246f8887aa4dd8fffb578abd10d53d9f34ca208d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2+4"
+    version: "1.4.0"
   fixnum:
     dependency: transitive
     description:
@@ -176,14 +176,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  google_generative_ai:
-    dependency: transitive
-    description:
-      name: google_generative_ai
-      sha256: e2f4c0ac13f0898f670ce5ac0dc4501ebe09b96f9d59163724380d9aa82065be
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.4"
   http:
     dependency: transitive
     description:
@@ -376,10 +368,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.1"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.22.0"

--- a/packages/langchain_firebase/pubspec.yaml
+++ b/packages/langchain_firebase/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   firebase_app_check: ^0.3.0
   firebase_auth: ^5.1.0
   firebase_core: ^3.3.0
-  firebase_vertexai: ^0.2.2
+  firebase_vertexai: ^1.4.0
   langchain_core: 0.3.6+1
   meta: ^1.11.0
   uuid: ^4.5.1


### PR DESCRIPTION
Fixed some breaking changes they introduced in [the first stable release](https://pub.dev/packages/firebase_vertexai/changelog#100).

Now you can provide a `responseSchema` for structured outputs:

```dart
final options = ChatFirebaseVertexAIOptions(
  //...
  responseSchema: {
    'type': 'object',
    'properties': {
      'answer': {
        'type': 'string',
        'description': 'The answer to the question being asked',
      },
      'sources': {
        'type': 'array',
        'items': {'type': 'string'},
        'description': 'The sources used to answer the question',
      },
    },
    'required': ['answer', 'sources'],
  },
);
```