### PR TITLE
Fix static instance of objectbox

### DIFF
--- a/examples/docs_examples/bin/modules/retrieval/vector_stores/integrations/objectbox.dart
+++ b/examples/docs_examples/bin/modules/retrieval/vector_stores/integrations/objectbox.dart
@@ -10,7 +10,7 @@ void main() async {
 
 Future<void> _rag() async {
   // 1. Instantiate vector store
-  final vectorStore = ObjectBoxVectorStore(
+  final vectorStore = ObjectBoxVectorStore.open(
     embeddings: OllamaEmbeddings(model: 'jina/jina-embeddings-v2-small-en'),
     dimensions: 512,
     directory: 'bin/modules/retrieval/vector_stores/integrations',

--- a/examples/wikivoyage_eu/bin/injestion.dart
+++ b/examples/wikivoyage_eu/bin/injestion.dart
@@ -9,7 +9,7 @@ void main() async {
   final embeddings = OllamaEmbeddings(
     model: 'jina/jina-embeddings-v2-small-en',
   );
-  final vectorStore = ObjectBoxVectorStore(
+  final vectorStore = ObjectBoxVectorStore.open(
     embeddings: embeddings,
     dimensions: 512,
   );

--- a/examples/wikivoyage_eu/bin/wikivoyage_eu.dart
+++ b/examples/wikivoyage_eu/bin/wikivoyage_eu.dart
@@ -5,7 +5,7 @@ import 'package:langchain_community/langchain_community.dart';
 import 'package:langchain_ollama/langchain_ollama.dart';
 
 void main() async {
-  final vectorStore = ObjectBoxVectorStore(
+  final vectorStore = ObjectBoxVectorStore.open(
     embeddings: OllamaEmbeddings(
       model: 'jina/jina-embeddings-v2-small-en',
     ),

--- a/packages/langchain_community/test/vector_stores/objectbox/objectbox_test.dart
+++ b/packages/langchain_community/test/vector_stores/objectbox/objectbox_test.dart
@@ -6,15 +6,15 @@ import 'package:langchain_openai/langchain_openai.dart';
 import 'package:objectbox/objectbox.dart';
 import 'package:test/test.dart';
 
-void main()  {
+void main() {
   late final OpenAIEmbeddings embeddings;
   late final ObjectBoxVectorStore vectorStore;
 
-  setUpAll(()  {
+  setUpAll(() {
     embeddings = OpenAIEmbeddings(
       apiKey: Platform.environment['OPENAI_API_KEY'],
     );
-    vectorStore = ObjectBoxVectorStore(
+    vectorStore = ObjectBoxVectorStore.open(
       embeddings: embeddings,
       dimensions: 1536,
       directory: 'test/vector_stores/objectbox',


### PR DESCRIPTION
There is a big issue with the current objectbox instance, which is stored in a static reference but bound to the instance lifecycle. The only way (I found) to solve this and being able to open multiple independent boxes is a breaking change and introducing a factory.