### PR TITLE
Updated reasoning_effort to be null by default.

### DIFF
--- a/packages/openai_dart/lib/src/generated/schema/create_chat_completion_request.dart
+++ b/packages/openai_dart/lib/src/generated/schema/create_chat_completion_request.dart
@@ -38,9 +38,9 @@ class CreateChatCompletionRequest with _$CreateChatCompletionRequest {
     /// Currently supported values are `low`, `medium`, and `high`. Reducing
     /// reasoning effort can result in faster responses and fewer tokens used
     /// on reasoning in a response.
-    @JsonKey(name: 'reasoning_effort')
-    @Default(ReasoningEffort.medium)
-    ReasoningEffort reasoningEffort,
+    @JsonKey(name: 'reasoning_effort', includeIfNull: false)
+    @Default(null)
+    ReasoningEffort? reasoningEffort,
 
     /// Developer-defined tags and values used for filtering completions
     /// in the [dashboard](https://platform.openai.com/chat-completions).

--- a/packages/openai_dart/lib/src/generated/schema/schema.freezed.dart
+++ b/packages/openai_dart/lib/src/generated/schema/schema.freezed.dart
@@ -3571,8 +3571,8 @@ mixin _$CreateChatCompletionRequest {
   /// Currently supported values are `low`, `medium`, and `high`. Reducing
   /// reasoning effort can result in faster responses and fewer tokens used
   /// on reasoning in a response.
-  @JsonKey(name: 'reasoning_effort')
-  ReasoningEffort get reasoningEffort => throw _privateConstructorUsedError;
+  @JsonKey(name: 'reasoning_effort', includeIfNull: false)
+  ReasoningEffort? get reasoningEffort => throw _privateConstructorUsedError;
 
   /// Developer-defined tags and values used for filtering completions
   /// in the [dashboard](https://platform.openai.com/chat-completions).
@@ -3799,7 +3799,8 @@ abstract class $CreateChatCompletionRequestCopyWith<$Res> {
       {@_ChatCompletionModelConverter() ChatCompletionModel model,
       List<ChatCompletionMessage> messages,
       @JsonKey(includeIfNull: false) bool? store,
-      @JsonKey(name: 'reasoning_effort') ReasoningEffort reasoningEffort,
+      @JsonKey(name: 'reasoning_effort', includeIfNull: false)
+      ReasoningEffort? reasoningEffort,
       @JsonKey(includeIfNull: false) Map<String, String>? metadata,
       @JsonKey(name: 'frequency_penalty', includeIfNull: false)
       double? frequencyPenalty,
@@ -3873,7 +3874,7 @@ class _$CreateChatCompletionRequestCopyWithImpl<$Res,
     Object? model = null,
     Object? messages = null,
     Object? store = freezed,
-    Object? reasoningEffort = null,
+    Object? reasoningEffort = freezed,
     Object? metadata = freezed,
     Object? frequencyPenalty = freezed,
     Object? logitBias = freezed,
@@ -3914,10 +3915,10 @@ class _$CreateChatCompletionRequestCopyWithImpl<$Res,
           ? _value.store
           : store // ignore: cast_nullable_to_non_nullable
               as bool?,
-      reasoningEffort: null == reasoningEffort
+      reasoningEffort: freezed == reasoningEffort
           ? _value.reasoningEffort
           : reasoningEffort // ignore: cast_nullable_to_non_nullable
-              as ReasoningEffort,
+              as ReasoningEffort?,
       metadata: freezed == metadata
           ? _value.metadata
           : metadata // ignore: cast_nullable_to_non_nullable
@@ -4150,7 +4151,8 @@ abstract class _$$CreateChatCompletionRequestImplCopyWith<$Res>
       {@_ChatCompletionModelConverter() ChatCompletionModel model,
       List<ChatCompletionMessage> messages,
       @JsonKey(includeIfNull: false) bool? store,
-      @JsonKey(name: 'reasoning_effort') ReasoningEffort reasoningEffort,
+      @JsonKey(name: 'reasoning_effort', includeIfNull: false)
+      ReasoningEffort? reasoningEffort,
       @JsonKey(includeIfNull: false) Map<String, String>? metadata,
       @JsonKey(name: 'frequency_penalty', includeIfNull: false)
       double? frequencyPenalty,
@@ -4231,7 +4233,7 @@ class __$$CreateChatCompletionRequestImplCopyWithImpl<$Res>
     Object? model = null,
     Object? messages = null,
     Object? store = freezed,
-    Object? reasoningEffort = null,
+    Object? reasoningEffort = freezed,
     Object? metadata = freezed,
     Object? frequencyPenalty = freezed,
     Object? logitBias = freezed,
@@ -4272,10 +4274,10 @@ class __$$CreateChatCompletionRequestImplCopyWithImpl<$Res>
           ? _value.store
           : store // ignore: cast_nullable_to_non_nullable
               as bool?,
-      reasoningEffort: null == reasoningEffort
+      reasoningEffort: freezed == reasoningEffort
           ? _value.reasoningEffort
           : reasoningEffort // ignore: cast_nullable_to_non_nullable
-              as ReasoningEffort,
+              as ReasoningEffort?,
       metadata: freezed == metadata
           ? _value._metadata
           : metadata // ignore: cast_nullable_to_non_nullable
@@ -4391,8 +4393,8 @@ class _$CreateChatCompletionRequestImpl extends _CreateChatCompletionRequest {
       {@_ChatCompletionModelConverter() required this.model,
       required final List<ChatCompletionMessage> messages,
       @JsonKey(includeIfNull: false) this.store,
-      @JsonKey(name: 'reasoning_effort')
-      this.reasoningEffort = ReasoningEffort.medium,
+      @JsonKey(name: 'reasoning_effort', includeIfNull: false)
+      this.reasoningEffort = null,
       @JsonKey(includeIfNull: false) final Map<String, String>? metadata,
       @JsonKey(name: 'frequency_penalty', includeIfNull: false)
       this.frequencyPenalty = 0.0,
@@ -4486,8 +4488,8 @@ class _$CreateChatCompletionRequestImpl extends _CreateChatCompletionRequest {
   /// reasoning effort can result in faster responses and fewer tokens used
   /// on reasoning in a response.
   @override
-  @JsonKey(name: 'reasoning_effort')
-  final ReasoningEffort reasoningEffort;
+  @JsonKey(name: 'reasoning_effort', includeIfNull: false)
+  final ReasoningEffort? reasoningEffort;
 
   /// Developer-defined tags and values used for filtering completions
   /// in the [dashboard](https://platform.openai.com/chat-completions).
@@ -4888,7 +4890,8 @@ abstract class _CreateChatCompletionRequest
       required final ChatCompletionModel model,
       required final List<ChatCompletionMessage> messages,
       @JsonKey(includeIfNull: false) final bool? store,
-      @JsonKey(name: 'reasoning_effort') final ReasoningEffort reasoningEffort,
+      @JsonKey(name: 'reasoning_effort', includeIfNull: false)
+      final ReasoningEffort? reasoningEffort,
       @JsonKey(includeIfNull: false) final Map<String, String>? metadata,
       @JsonKey(name: 'frequency_penalty', includeIfNull: false)
       final double? frequencyPenalty,
@@ -4970,8 +4973,8 @@ abstract class _CreateChatCompletionRequest
   /// reasoning effort can result in faster responses and fewer tokens used
   /// on reasoning in a response.
   @override
-  @JsonKey(name: 'reasoning_effort')
-  ReasoningEffort get reasoningEffort;
+  @JsonKey(name: 'reasoning_effort', includeIfNull: false)
+  ReasoningEffort? get reasoningEffort;
 
   /// Developer-defined tags and values used for filtering completions
   /// in the [dashboard](https://platform.openai.com/chat-completions).

--- a/packages/openai_dart/lib/src/generated/schema/schema.g.dart
+++ b/packages/openai_dart/lib/src/generated/schema/schema.g.dart
@@ -291,7 +291,7 @@ _$CreateChatCompletionRequestImpl _$$CreateChatCompletionRequestImplFromJson(
       store: json['store'] as bool?,
       reasoningEffort: $enumDecodeNullable(
               _$ReasoningEffortEnumMap, json['reasoning_effort']) ??
-          ReasoningEffort.medium,
+          null,
       metadata: (json['metadata'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, e as String),
       ),
@@ -352,7 +352,8 @@ Map<String, dynamic> _$$CreateChatCompletionRequestImplToJson(
       'model': const _ChatCompletionModelConverter().toJson(instance.model),
       'messages': instance.messages.map((e) => e.toJson()).toList(),
       if (instance.store case final value?) 'store': value,
-      'reasoning_effort': _$ReasoningEffortEnumMap[instance.reasoningEffort]!,
+      if (_$ReasoningEffortEnumMap[instance.reasoningEffort] case final value?)
+        'reasoning_effort': value,
       if (instance.metadata case final value?) 'metadata': value,
       if (instance.frequencyPenalty case final value?)
         'frequency_penalty': value,

--- a/packages/openai_dart/oas/openapi_curated.yaml
+++ b/packages/openai_dart/oas/openapi_curated.yaml
@@ -2548,6 +2548,7 @@ components:
       additionalProperties: true
     ReasoningEffort:
       type: string
+      nullable: true
       enum:
         - low
         - medium

--- a/packages/openai_dart/oas/openapi_official.yaml
+++ b/packages/openai_dart/oas/openapi_official.yaml
@@ -13288,6 +13288,7 @@ components:
             [evals](https://platform.openai.com/docs/guides/evals) products.
         reasoning_effort:
           type: string
+          nullable: true
           enum:
             - low
             - medium


### PR DESCRIPTION
### Description
This pull request changes `reasoning_effort` to be nullable as well as null by default. It appears OpenAI is now enforcing that this value is null for non-reasoning models.

OpenAI documentation states that a reasoning of `medium` will be used if this attribute is not supplied.

https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort

### Issue
This resolves issue #712 

### Dependencies
There are no new dependencies

### Maintainer
@davidmigloz 