### PR TITLE
fix: toolChoice required infinite loop in openai_realtime_dart

### DIFF
--- a/packages/openai_realtime_dart/lib/src/client.dart
+++ b/packages/openai_realtime_dart/lib/src/client.dart
@@ -231,7 +231,22 @@ class RealtimeClient extends RealtimeEventHandler {
         ),
       );
     }
-    await createResponse();
+    ResponseConfig? responseConfig;
+    final tc = sessionConfig.toolChoice;
+    if (tc != null) {
+      tc.mapOrNull(
+        mode: (m) {
+          if (m.value == SessionConfigToolChoiceMode.required) {
+            responseConfig = const ResponseConfig(
+              toolChoice: ResponseConfigToolChoice.mode(
+                ResponseConfigToolChoiceMode.auto,
+              ),
+            );
+          }
+        },
+      );
+    }
+    await createResponse(responseConfig: responseConfig);
   }
 
   /// Tells us whether the realtime socket is connected and the session has
@@ -425,7 +440,7 @@ class RealtimeClient extends RealtimeEventHandler {
   }
 
   /// Forces a model response generation.
-  Future<bool> createResponse() async {
+  Future<bool> createResponse({ResponseConfig? responseConfig}) async {
     if (getTurnDetectionType() == null && inputAudioBuffer.isNotEmpty) {
       await realtime.send(
         RealtimeEvent.inputAudioBufferCommit(
@@ -438,6 +453,7 @@ class RealtimeClient extends RealtimeEventHandler {
     await realtime.send(
       RealtimeEvent.responseCreate(
         eventId: RealtimeUtils.generateId(),
+        response: responseConfig,
       ),
     );
     return true;


### PR DESCRIPTION
Resolves #696

- prevent infinite tool invocation when session `toolChoice` is `required`
- allow passing optional `ResponseConfig` to `createResponse`