### PR TITLE
Update langchain_openai & langchain_community for Compatibility freezed 3 

### DIFF
--- a/packages/langchain_community/pubspec.yaml
+++ b/packages/langchain_community/pubspec.yaml
@@ -32,7 +32,12 @@ dependencies:
   meta: ^1.16.0
   objectbox: ^4.3.0
   path: ^1.9.1
-  tavily_dart: ^0.1.1
+  tavily_dart:
+    #TODO: Only for Test Change after sync
+    git:
+      url: https://github.com/davidmigloz/langchain_dart.git
+      ref: 704102ff44ebfc30503d43992ccfb62a29cf95c1
+      path: packages/taivily_dart
   uuid: ^4.5.1
 
 dev_dependencies:

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -18,7 +18,7 @@ topics:
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-resolution: workspace
+#resolution: workspace
 
 dependencies:
   collection: ^1.19.1
@@ -26,10 +26,20 @@ dependencies:
   langchain_core: 0.3.7
   langchain_tiktoken: ^1.0.1
   meta: ^1.16.0
-  openai_dart: ^0.5.2
+  openai_dart:
+    #TODO: Only for Test Change after sync
+    git:
+      url: https://github.com/davidmigloz/langchain_dart.git
+      ref: 704102ff44ebfc30503d43992ccfb62a29cf95c1
+      path: packages/openai_dart
   uuid: ^4.5.1
 
 dev_dependencies:
   langchain: ^0.7.8
-  langchain_community: 0.3.4
+  langchain_community:
+    #TODO: Only for Test Change after sync
+    git:
+      url: https://github.com/davidmigloz/langchain_dart.git
+      ref: b0a8b45799601e43a932ce234b26ce3cbb8e3c68
+      path: packages/langchain_community
   test: ^1.25.15

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -40,6 +40,6 @@ dev_dependencies:
     #TODO: Only for Test Change after sync
     git:
       url: https://github.com/davidmigloz/langchain_dart.git
-      ref: b0a8b45799601e43a932ce234b26ce3cbb8e3c68
+      ref: 7f054ce1d99a89ebba9b1bedbb713b4a92dfe135
       path: packages/langchain_community
   test: ^1.25.15


### PR DESCRIPTION
### 📦 Purpose of this Pull Request

This PR enables the use of `langchain_openai` with `freezed >= 3.0.0`.

---

### 🔧 Changes Made

- Removed the **workspace dependency** from `langchain_openai` and `langchain_community` so they can be updated independently.
- Updated the Git reference for both `langchain_openai` and `langchain_community` to point to the upcoming PR:  
  👉 [`langchain_dart` PR #749](https://github.com/davidmigloz/langchain_dart/pull/749)
- This setup allows migrating these packages to `freezed >= 3` without being blocked by packages that **cannot** be upgraded at the moment (e.g. `langchain_pinecone`).

---

### 📌 Context

Some packages in the workspace cannot currently be updated to `freezed >= 3`, for example:

- `langchain_pinecone` depends on `pinecone: ^0.7.2`, which has **not been updated** in a while and does **not support** `freezed >= 3`.

Because of this, keeping all packages tied to the workspace makes version upgrades difficult or impossible for some of them.

---

### ✅ Recommendation

To ensure long-term maintainability and flexibility, it's recommended to:

> **Avoid circular or strict workspace dependencies**, and allow each package to evolve independently where possible.

---

### ⚙️ How to use the updated package immediately

For those who want to use the updated `langchain_openai` package right away, add the following to your `pubspec.yaml`:

```yaml
langchain_openai:
  git:
    url: https://github.com/davidmigloz/langchain_dart.git
    ref: fc6afedb9ee99ea58747c757c4cc0378e1b8947e
    path: packages/langchain_openai
```

---
