### PR TITLE
Add support for multiple tool results in a single chat message

### DIFF
--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
@@ -63,14 +63,21 @@ extension ChatMessagesMapper on List<ChatMessage> {
   }
 
   f.Content _mapToolChatMessage(final ToolChatMessage msg) {
-    Map<String, Object?>? response;
-    try {
-      response = jsonDecode(msg.content) as Map<String, Object?>;
-    } catch (_) {
-      response = {'result': msg.content};
+    if (msg.toolResults.isEmpty) {
+      Map<String, Object?> response;
+      try {
+        response = jsonDecode(msg.content) as Map<String, Object?>;
+      } catch (_) {
+        response = {'result': msg.content};
+      }
+      return f.Content.functionResponse(msg.toolCallId, response);
+    } else {
+      return f.Content.functionResponses(
+        msg.toolResults
+            .map((t) => _mapToolChatMessage(t).parts.first)
+            .cast<f.FunctionResponse>(),
+      );
     }
-
-    return f.Content.functionResponse(msg.toolCallId, response);
   }
 
   f.Content _mapCustomChatMessage(final CustomChatMessage msg) {

--- a/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
@@ -62,16 +62,21 @@ extension ChatMessagesMapper on List<ChatMessage> {
   }
 
   g.Content _mapToolChatMessage(final ToolChatMessage msg) {
-    Map<String, Object?>? response;
-    try {
-      response = jsonDecode(msg.content) as Map<String, Object?>;
-    } catch (_) {
-      response = {'result': msg.content};
+    if (msg.toolResults.isEmpty) {
+      Map<String, Object?> response;
+      try {
+        response = jsonDecode(msg.content) as Map<String, Object?>;
+      } catch (_) {
+        response = {'result': msg.content};
+      }
+      return g.Content.functionResponse(msg.toolCallId, response);
+    } else {
+      return g.Content.functionResponses(
+        msg.toolResults
+            .map((t) => _mapToolChatMessage(t).parts.first)
+            .cast<g.FunctionResponse>(),
+      );
     }
-
-    return g.Content.functionResponses(
-      [g.FunctionResponse(msg.toolCallId, response)],
-    );
   }
 
   g.Content _mapCustomChatMessage(final CustomChatMessage msg) {


### PR DESCRIPTION
This should fix [Issue with Gemini when the chat model replies with multiple tool calls](https://github.com/davidmigloz/langchain_dart/issues/753)

No dependency change. A new factory constructor has been added to the `ToolChatMessage` class. It preserves the `ChatMessage` inheritance tree and should have no impact on other packages.

Mappers have been modified in `langchain_firebase` and `langchain_google` to map the chat messages to proper Google AI `Content`.

I'm unsure for modifications to the `concat` method in `ToolChatMessage` and left comments in the code to express my questions / concerns. If this is incompatible with langchain's approach, a new chat message might be needed in which case it could impact many other packages due to `ChatMessage` being sealed and often used in `switch` expressions or statements.

Maintainer responsibilities:
@davidmigloz
