### PR TITLE
feat: Add Verbosity support in openai_dart

### DIFF
--- a/packages/openai_dart/lib/src/generated/schema/create_chat_completion_request.dart
+++ b/packages/openai_dart/lib/src/generated/schema/create_chat_completion_request.dart
@@ -232,6 +232,16 @@ class CreateChatCompletionRequest with _$CreateChatCompletionRequest {
     ///
     /// A list of functions the model may generate JSON inputs for.
     @JsonKey(includeIfNull: false) List<FunctionObject>? functions,
+
+    /// Constrains the verbosity of the model's response. Lower values will result in
+    /// more concise responses, while higher values will result in more verbose responses.
+    /// Currently supported values are `low`, `medium`, and `high`.
+    @JsonKey(
+      includeIfNull: false,
+      unknownEnumValue: JsonKey.nullForUndefinedEnumValue,
+    )
+    @Default(Verbosity.medium)
+    Verbosity? verbosity,
   }) = _CreateChatCompletionRequest;
 
   /// Object construction from a JSON representation
@@ -270,7 +280,8 @@ class CreateChatCompletionRequest with _$CreateChatCompletionRequest {
     'parallel_tool_calls',
     'user',
     'function_call',
-    'functions'
+    'functions',
+    'verbosity'
   ];
 
   /// Validation constants
@@ -364,6 +375,7 @@ class CreateChatCompletionRequest with _$CreateChatCompletionRequest {
       'user': user,
       'function_call': functionCall,
       'functions': functions,
+      'verbosity': verbosity,
     };
   }
 }

--- a/packages/openai_dart/lib/src/generated/schema/schema.dart
+++ b/packages/openai_dart/lib/src/generated/schema/schema.dart
@@ -24,6 +24,7 @@ part 'chat_completion_function_call_option.dart';
 part 'function_object.dart';
 part 'function_parameters.dart';
 part 'reasoning_effort.dart';
+part 'verbosity.dart';
 part 'response_format_type.dart';
 part 'json_schema_object.dart';
 part 'chat_completion_tool.dart';

--- a/packages/openai_dart/lib/src/generated/schema/schema.freezed.dart
+++ b/packages/openai_dart/lib/src/generated/schema/schema.freezed.dart
@@ -3784,6 +3784,13 @@ mixin _$CreateChatCompletionRequest {
   @JsonKey(includeIfNull: false)
   List<FunctionObject>? get functions => throw _privateConstructorUsedError;
 
+  /// Constrains the verbosity of the model's response. Lower values will result in
+  /// more concise responses, while higher values will result in more verbose responses.
+  /// Currently supported values are `low`, `medium`, and `high`.
+  @JsonKey(
+      includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
+  Verbosity? get verbosity => throw _privateConstructorUsedError;
+
   /// Serializes this CreateChatCompletionRequest to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 
@@ -3855,7 +3862,11 @@ abstract class $CreateChatCompletionRequestCopyWith<$Res> {
       @_ChatCompletionFunctionCallConverter()
       @JsonKey(name: 'function_call', includeIfNull: false)
       ChatCompletionFunctionCall? functionCall,
-      @JsonKey(includeIfNull: false) List<FunctionObject>? functions});
+      @JsonKey(includeIfNull: false) List<FunctionObject>? functions,
+      @JsonKey(
+          includeIfNull: false,
+          unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
+      Verbosity? verbosity});
 
   $ChatCompletionModelCopyWith<$Res> get model;
   $PredictionContentCopyWith<$Res>? get prediction;
@@ -3915,6 +3926,7 @@ class _$CreateChatCompletionRequestCopyWithImpl<$Res,
     Object? user = freezed,
     Object? functionCall = freezed,
     Object? functions = freezed,
+    Object? verbosity = freezed,
   }) {
     return _then(_value.copyWith(
       model: null == model
@@ -4041,6 +4053,10 @@ class _$CreateChatCompletionRequestCopyWithImpl<$Res,
           ? _value.functions
           : functions // ignore: cast_nullable_to_non_nullable
               as List<FunctionObject>?,
+      verbosity: freezed == verbosity
+          ? _value.verbosity
+          : verbosity // ignore: cast_nullable_to_non_nullable
+              as Verbosity?,
     ) as $Val);
   }
 
@@ -4232,7 +4248,11 @@ abstract class _$$CreateChatCompletionRequestImplCopyWith<$Res>
       @_ChatCompletionFunctionCallConverter()
       @JsonKey(name: 'function_call', includeIfNull: false)
       ChatCompletionFunctionCall? functionCall,
-      @JsonKey(includeIfNull: false) List<FunctionObject>? functions});
+      @JsonKey(includeIfNull: false) List<FunctionObject>? functions,
+      @JsonKey(
+          includeIfNull: false,
+          unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
+      Verbosity? verbosity});
 
   @override
   $ChatCompletionModelCopyWith<$Res> get model;
@@ -4300,6 +4320,7 @@ class __$$CreateChatCompletionRequestImplCopyWithImpl<$Res>
     Object? user = freezed,
     Object? functionCall = freezed,
     Object? functions = freezed,
+    Object? verbosity = freezed,
   }) {
     return _then(_$CreateChatCompletionRequestImpl(
       model: null == model
@@ -4426,6 +4447,10 @@ class __$$CreateChatCompletionRequestImplCopyWithImpl<$Res>
           ? _value._functions
           : functions // ignore: cast_nullable_to_non_nullable
               as List<FunctionObject>?,
+      verbosity: freezed == verbosity
+          ? _value.verbosity
+          : verbosity // ignore: cast_nullable_to_non_nullable
+              as Verbosity?,
     ));
   }
 }
@@ -4484,7 +4509,11 @@ class _$CreateChatCompletionRequestImpl extends _CreateChatCompletionRequest {
       @_ChatCompletionFunctionCallConverter()
       @JsonKey(name: 'function_call', includeIfNull: false)
       this.functionCall,
-      @JsonKey(includeIfNull: false) final List<FunctionObject>? functions})
+      @JsonKey(includeIfNull: false) final List<FunctionObject>? functions,
+      @JsonKey(
+          includeIfNull: false,
+          unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
+      this.verbosity = Verbosity.medium})
       : _messages = messages,
         _metadata = metadata,
         _logitBias = logitBias,
@@ -4827,9 +4856,17 @@ class _$CreateChatCompletionRequestImpl extends _CreateChatCompletionRequest {
     return EqualUnmodifiableListView(value);
   }
 
+  /// Constrains the verbosity of the model's response. Lower values will result in
+  /// more concise responses, while higher values will result in more verbose responses.
+  /// Currently supported values are `low`, `medium`, and `high`.
+  @override
+  @JsonKey(
+      includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
+  final Verbosity? verbosity;
+
   @override
   String toString() {
-    return 'CreateChatCompletionRequest(model: $model, messages: $messages, store: $store, reasoningEffort: $reasoningEffort, metadata: $metadata, frequencyPenalty: $frequencyPenalty, logitBias: $logitBias, logprobs: $logprobs, topLogprobs: $topLogprobs, maxTokens: $maxTokens, maxCompletionTokens: $maxCompletionTokens, n: $n, modalities: $modalities, prediction: $prediction, audio: $audio, presencePenalty: $presencePenalty, webSearchOptions: $webSearchOptions, responseFormat: $responseFormat, seed: $seed, serviceTier: $serviceTier, stop: $stop, stream: $stream, streamOptions: $streamOptions, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, parallelToolCalls: $parallelToolCalls, user: $user, functionCall: $functionCall, functions: $functions)';
+    return 'CreateChatCompletionRequest(model: $model, messages: $messages, store: $store, reasoningEffort: $reasoningEffort, metadata: $metadata, frequencyPenalty: $frequencyPenalty, logitBias: $logitBias, logprobs: $logprobs, topLogprobs: $topLogprobs, maxTokens: $maxTokens, maxCompletionTokens: $maxCompletionTokens, n: $n, modalities: $modalities, prediction: $prediction, audio: $audio, presencePenalty: $presencePenalty, webSearchOptions: $webSearchOptions, responseFormat: $responseFormat, seed: $seed, serviceTier: $serviceTier, stop: $stop, stream: $stream, streamOptions: $streamOptions, temperature: $temperature, topP: $topP, tools: $tools, toolChoice: $toolChoice, parallelToolCalls: $parallelToolCalls, user: $user, functionCall: $functionCall, functions: $functions, verbosity: $verbosity)';
   }
 
   @override
@@ -4886,7 +4923,9 @@ class _$CreateChatCompletionRequestImpl extends _CreateChatCompletionRequest {
             (identical(other.functionCall, functionCall) ||
                 other.functionCall == functionCall) &&
             const DeepCollectionEquality()
-                .equals(other._functions, _functions));
+                .equals(other._functions, _functions) &&
+            (identical(other.verbosity, verbosity) ||
+                other.verbosity == verbosity));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -4923,7 +4962,8 @@ class _$CreateChatCompletionRequestImpl extends _CreateChatCompletionRequest {
         parallelToolCalls,
         user,
         functionCall,
-        const DeepCollectionEquality().hash(_functions)
+        const DeepCollectionEquality().hash(_functions),
+        verbosity
       ]);
 
   /// Create a copy of CreateChatCompletionRequest
@@ -5001,9 +5041,11 @@ abstract class _CreateChatCompletionRequest
       @_ChatCompletionFunctionCallConverter()
       @JsonKey(name: 'function_call', includeIfNull: false)
       final ChatCompletionFunctionCall? functionCall,
-      @JsonKey(includeIfNull: false)
-      final List<FunctionObject>?
-          functions}) = _$CreateChatCompletionRequestImpl;
+      @JsonKey(includeIfNull: false) final List<FunctionObject>? functions,
+      @JsonKey(
+          includeIfNull: false,
+          unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
+      final Verbosity? verbosity}) = _$CreateChatCompletionRequestImpl;
   const _CreateChatCompletionRequest._() : super._();
 
   factory _CreateChatCompletionRequest.fromJson(Map<String, dynamic> json) =
@@ -5272,6 +5314,14 @@ abstract class _CreateChatCompletionRequest
   @override
   @JsonKey(includeIfNull: false)
   List<FunctionObject>? get functions;
+
+  /// Constrains the verbosity of the model's response. Lower values will result in
+  /// more concise responses, while higher values will result in more verbose responses.
+  /// Currently supported values are `low`, `medium`, and `high`.
+  @override
+  @JsonKey(
+      includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
+  Verbosity? get verbosity;
 
   /// Create a copy of CreateChatCompletionRequest
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/openai_dart/lib/src/generated/schema/schema.g.dart
+++ b/packages/openai_dart/lib/src/generated/schema/schema.g.dart
@@ -348,6 +348,9 @@ _$CreateChatCompletionRequestImpl _$$CreateChatCompletionRequestImplFromJson(
       functions: (json['functions'] as List<dynamic>?)
           ?.map((e) => FunctionObject.fromJson(e as Map<String, dynamic>))
           .toList(),
+      verbosity: $enumDecodeNullable(_$VerbosityEnumMap, json['verbosity'],
+              unknownValue: JsonKey.nullForUndefinedEnumValue) ??
+          Verbosity.medium,
     );
 
 Map<String, dynamic> _$$CreateChatCompletionRequestImplToJson(
@@ -407,6 +410,8 @@ Map<String, dynamic> _$$CreateChatCompletionRequestImplToJson(
         'function_call': value,
       if (instance.functions?.map((e) => e.toJson()).toList() case final value?)
         'functions': value,
+      if (_$VerbosityEnumMap[instance.verbosity] case final value?)
+        'verbosity': value,
     };
 
 const _$ReasoningEffortEnumMap = {
@@ -424,6 +429,12 @@ const _$CreateChatCompletionRequestServiceTierEnumMap = {
   CreateChatCompletionRequestServiceTier.auto: 'auto',
   CreateChatCompletionRequestServiceTier.vDefault: 'default',
   CreateChatCompletionRequestServiceTier.flex: 'flex',
+};
+
+const _$VerbosityEnumMap = {
+  Verbosity.low: 'low',
+  Verbosity.medium: 'medium',
+  Verbosity.high: 'high',
 };
 
 _$ChatCompletionModelEnumerationImpl

--- a/packages/openai_dart/lib/src/generated/schema/verbosity.dart
+++ b/packages/openai_dart/lib/src/generated/schema/verbosity.dart
@@ -1,0 +1,21 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
+part of open_a_i_schema;
+
+// ==========================================
+// ENUM: Verbosity
+// ==========================================
+
+/// Constrains the verbosity of the model's response. Lower values will result in
+/// more concise responses, while higher values will result in more verbose responses.
+/// Currently supported values are `low`, `medium`, and `high`.
+enum Verbosity {
+  @JsonValue('low')
+  low,
+  @JsonValue('medium')
+  medium,
+  @JsonValue('high')
+  high,
+}

--- a/packages/openai_dart/oas/openapi_curated.yaml
+++ b/packages/openai_dart/oas/openapi_curated.yaml
@@ -2297,6 +2297,8 @@ components:
           maxItems: 128
           items:
             $ref: "#/components/schemas/FunctionObject"
+        verbosity:
+          $ref: "#/components/schemas/Verbosity"
       required:
         - model
         - messages
@@ -2662,6 +2664,18 @@ components:
         Currently supported values are `low`, `medium`, and `high`. Reducing
         reasoning effort can result in faster responses and fewer tokens used
         on reasoning in a response.
+    Verbosity:
+      type: string
+      enum:
+        - low
+        - medium
+        - high
+      default: medium
+      nullable: true
+      description: |
+        Constrains the verbosity of the model's response. Lower values will result in
+        more concise responses, while higher values will result in more verbose responses.
+        Currently supported values are `low`, `medium`, and `high`.
     ResponseFormat:
       type: object
       description: |

--- a/packages/openai_dart/test/openai_client_chat_test.dart
+++ b/packages/openai_dart/test/openai_client_chat_test.dart
@@ -656,8 +656,10 @@ void main() {
       expect(choice1.message.audio, isNotNull);
       expect(choice1.message.audio!.id, isNotEmpty);
       expect(choice1.message.audio!.expiresAt, greaterThan(0));
-      expect(choice1.message.audio!.transcript,
-          anyOf(contains('two'), contains('2')));
+      expect(
+        choice1.message.audio!.transcript,
+        anyOf(contains('two'), contains('2')),
+      );
       expect(choice1.message.audio!.data, isNotEmpty);
     });
 


### PR DESCRIPTION
Verbosity determines how many output tokens are generated. Lowering the number of tokens reduces overall latency. While the model's reasoning approach stays mostly the same, the model finds ways to answer more concisely—which can either improve or diminish answer quality, depending on your use case. Here are some scenarios for both ends of the verbosity spectrum:

*   **High verbosity:** Use when you need the model to provide thorough explanations of documents or perform extensive code refactoring.
*   **Low verbosity:** Best for situations where you want concise answers or simple code generation, such as SQL queries.

Models before GPT-5 have used `medium` verbosity by default. With GPT-5, we make this option configurable as one of `high`, `medium`, or `low`.

When generating code, `medium` and `high` verbosity levels yield longer, more structured code with inline explanations, while `low` verbosity produces shorter, more concise code with minimal commentary.

Control verbosity

```dart
const request = CreateChatCompletionRequest(
        model: ChatCompletionModel.model(
          ChatCompletionModels.gpt5,
        ),
        verbosity: Verbosity.high,
        messages: [
          ChatCompletionMessage.user(
            content: ChatCompletionUserMessageContent.string('Hello world'),
          ),
        ],
      );
      final res = await client.createChatCompletion(request: request);
```

You can still steer verbosity through prompting after setting it to `low` in the API. The verbosity parameter defines a general token range at the system prompt level, but the actual output is flexible to both developer and user prompts within that range.