### PR TITLE
feat: Add support for minimal reasoning effort in openai_dart

### DIFF
--- a/packages/openai_dart/lib/src/generated/schema/create_chat_completion_request.dart
+++ b/packages/openai_dart/lib/src/generated/schema/create_chat_completion_request.dart
@@ -31,11 +31,9 @@ class CreateChatCompletionRequest with _$CreateChatCompletionRequest {
     /// [evals](https://platform.openai.com/docs/guides/evals) products.
     @JsonKey(includeIfNull: false) bool? store,
 
-    /// **o1 models only**
-    ///
     /// Constrains effort on reasoning for
     /// [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-    /// Currently supported values are `low`, `medium`, and `high`. Reducing
+    /// Currently supported values are `minimal`, `low`, `medium`, and `high`. Reducing
     /// reasoning effort can result in faster responses and fewer tokens used
     /// on reasoning in a response.
     @JsonKey(

--- a/packages/openai_dart/lib/src/generated/schema/reasoning_effort.dart
+++ b/packages/openai_dart/lib/src/generated/schema/reasoning_effort.dart
@@ -8,14 +8,14 @@ part of open_a_i_schema;
 // ENUM: ReasoningEffort
 // ==========================================
 
-/// **o1 models only**
-///
 /// Constrains effort on reasoning for
 /// [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-/// Currently supported values are `low`, `medium`, and `high`. Reducing
+/// Currently supported values are `minimal`, `low`, `medium`, and `high`. Reducing
 /// reasoning effort can result in faster responses and fewer tokens used
 /// on reasoning in a response.
 enum ReasoningEffort {
+  @JsonValue('minimal')
+  minimal,
   @JsonValue('low')
   low,
   @JsonValue('medium')

--- a/packages/openai_dart/lib/src/generated/schema/schema.freezed.dart
+++ b/packages/openai_dart/lib/src/generated/schema/schema.freezed.dart
@@ -3564,11 +3564,9 @@ mixin _$CreateChatCompletionRequest {
   @JsonKey(includeIfNull: false)
   bool? get store => throw _privateConstructorUsedError;
 
-  /// **o1 models only**
-  ///
   /// Constrains effort on reasoning for
   /// [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-  /// Currently supported values are `low`, `medium`, and `high`. Reducing
+  /// Currently supported values are `minimal`, `low`, `medium`, and `high`. Reducing
   /// reasoning effort can result in faster responses and fewer tokens used
   /// on reasoning in a response.
   @JsonKey(
@@ -4558,11 +4556,9 @@ class _$CreateChatCompletionRequestImpl extends _CreateChatCompletionRequest {
   @JsonKey(includeIfNull: false)
   final bool? store;
 
-  /// **o1 models only**
-  ///
   /// Constrains effort on reasoning for
   /// [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-  /// Currently supported values are `low`, `medium`, and `high`. Reducing
+  /// Currently supported values are `minimal`, `low`, `medium`, and `high`. Reducing
   /// reasoning effort can result in faster responses and fewer tokens used
   /// on reasoning in a response.
   @override
@@ -5072,11 +5068,9 @@ abstract class _CreateChatCompletionRequest
   @JsonKey(includeIfNull: false)
   bool? get store;
 
-  /// **o1 models only**
-  ///
   /// Constrains effort on reasoning for
   /// [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-  /// Currently supported values are `low`, `medium`, and `high`. Reducing
+  /// Currently supported values are `minimal`, `low`, `medium`, and `high`. Reducing
   /// reasoning effort can result in faster responses and fewer tokens used
   /// on reasoning in a response.
   @override

--- a/packages/openai_dart/lib/src/generated/schema/schema.g.dart
+++ b/packages/openai_dart/lib/src/generated/schema/schema.g.dart
@@ -415,6 +415,7 @@ Map<String, dynamic> _$$CreateChatCompletionRequestImplToJson(
     };
 
 const _$ReasoningEffortEnumMap = {
+  ReasoningEffort.minimal: 'minimal',
   ReasoningEffort.low: 'low',
   ReasoningEffort.medium: 'medium',
   ReasoningEffort.high: 'high',

--- a/packages/openai_dart/oas/openapi_curated.yaml
+++ b/packages/openai_dart/oas/openapi_curated.yaml
@@ -2650,6 +2650,7 @@ components:
     ReasoningEffort:
       type: string
       enum:
+        - minimal
         - low
         - medium
         - high
@@ -2657,11 +2658,9 @@ components:
       default: null
       nullable: true
       description: |
-        **o1 models only**
-
-        Constrains effort on reasoning for
+        Constrains effort on reasoning for 
         [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-        Currently supported values are `low`, `medium`, and `high`. Reducing
+        Currently supported values are `minimal`, `low`, `medium`, and `high`. Reducing
         reasoning effort can result in faster responses and fewer tokens used
         on reasoning in a response.
     Verbosity:


### PR DESCRIPTION
The `reasoning.effort` parameter controls how many reasoning tokens the model generates before producing a response. Earlier reasoning models like o3 supported only `low`, `medium`, and `high`: `low` favored speed and fewer tokens, while `high` favored more thorough reasoning.

The new `minimal` setting produces very few reasoning tokens for cases where you need the fastest possible time-to-first-token. We often see better performance when the model can produce a few tokens when needed versus none. The default is `medium`.

The `minimal` setting performs especially well in coding and instruction following scenarios, adhering closely to given directions. However, it may require prompting to act more proactively. To improve the model's reasoning quality, even at minimal effort, encourage it to “think” or outline its steps before answering.

Minimal reasoning effort

```bash
const request = CreateChatCompletionRequest(
        model: ChatCompletionModel.model(
          ChatCompletionModels.gpt5,
        ),
        reasoningEffort: ReasoningEffort.minimal,
        messages: [
          ChatCompletionMessage.user(
            content: ChatCompletionUserMessageContent.string('Hello world'),
          ),
        ],
      );
final res = await client.createChatCompletion(request: request);
```