### PR TITLE
feat: Support reasoningEffort, verbosity and other new fields in ChatOpenAI

### DIFF
--- a/packages/langchain/lib/src/chains/combine_documents/reduce.dart
+++ b/packages/langchain/lib/src/chains/combine_documents/reduce.dart
@@ -132,7 +132,7 @@ class ReduceDocumentsChain extends BaseCombineDocumentsChain {
   }) async {
     final lengthFunc = combineDocumentsChain.promptLength;
 
-    List<Document> resultDocs = docs;
+    var resultDocs = docs;
     int? numTokens = await lengthFunc(resultDocs, inputs: inputs);
 
     while (numTokens != null && numTokens > tokenMax) {

--- a/packages/langchain_core/lib/src/prompts/template.dart
+++ b/packages/langchain_core/lib/src/prompts/template.dart
@@ -150,7 +150,7 @@ List<ParsedFStringNode> parseFStringTemplate(final String template) {
   final List<ParsedFStringNode> nodes = [];
 
   int nextBracket(final String bracket, final int start) {
-    for (int i = start; i < chars.length; i += 1) {
+    for (var i = start; i < chars.length; i += 1) {
       if (bracket.contains(chars[i])) {
         return i;
       }

--- a/packages/langchain_core/lib/src/utils/reduce.dart
+++ b/packages/langchain_core/lib/src/utils/reduce.dart
@@ -13,7 +13,7 @@ import '../prompts/types.dart';
 /// - A list of lists will be reduced to a single list containing a single reduced item.
 /// - A list of maps will be reduced to a single map containing the reduced items.
 /// - If a type is not recognized, the last item in the list will be returned.
-Type reduce<Type>(final Iterable<Type> input) {
+T reduce<T>(final Iterable<T> input) {
   if (input.isEmpty) {
     throw Exception('Cannot reduce an empty list');
   } else if (input.length == 1) {
@@ -40,7 +40,7 @@ Type reduce<Type>(final Iterable<Type> input) {
     Map<String, dynamic>() => _reduceMap(input.cast<Map<String, dynamic>>()),
     Map<dynamic, dynamic>() => _reduceMap(input.cast<Map<dynamic, dynamic>>()),
     _ => input.last,
-  } as Type;
+  } as T;
 }
 
 Iterable<V> _reduceIterable<V>(final Iterable<Iterable<V>> input) {

--- a/packages/langchain_openai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/mappers.dart
@@ -32,11 +32,18 @@ CreateChatCompletionRequest createChatCompletionRequest(
       options?.model ?? defaultOptions.model ?? ChatOpenAI.defaultModel,
     ),
     messages: messagesDtos,
+    store: options?.store ?? defaultOptions.store,
+    reasoningEffort:
+        (options?.reasoningEffort ?? defaultOptions.reasoningEffort)
+            .toReasoningEffort(),
+    metadata: options?.metadata ?? defaultOptions.metadata,
     tools: toolsDtos,
     toolChoice: toolChoice,
     frequencyPenalty:
         options?.frequencyPenalty ?? defaultOptions.frequencyPenalty,
     logitBias: options?.logitBias ?? defaultOptions.logitBias,
+    logprobs: options?.logprobs ?? defaultOptions.logprobs,
+    topLogprobs: options?.topLogprobs ?? defaultOptions.topLogprobs,
     maxCompletionTokens: options?.maxTokens ?? defaultOptions.maxTokens,
     n: options?.n ?? defaultOptions.n,
     presencePenalty: options?.presencePenalty ?? defaultOptions.presencePenalty,
@@ -51,6 +58,7 @@ CreateChatCompletionRequest createChatCompletionRequest(
         options?.parallelToolCalls ?? defaultOptions.parallelToolCalls,
     serviceTier: serviceTierDto,
     user: options?.user ?? defaultOptions.user,
+    verbosity: (options?.verbosity ?? defaultOptions.verbosity).toVerbosity(),
     streamOptions:
         stream ? const ChatCompletionStreamOptions(includeUsage: true) : null,
   );
@@ -341,6 +349,25 @@ extension ChatOpenAIResponseFormatMapper on ChatOpenAIResponseFormat {
         ),
     };
   }
+}
+
+extension ChatOpenAIReasoningEffortX on ChatOpenAIReasoningEffort? {
+  ReasoningEffort? toReasoningEffort() => switch (this) {
+        ChatOpenAIReasoningEffort.minimal => ReasoningEffort.minimal,
+        ChatOpenAIReasoningEffort.low => ReasoningEffort.low,
+        ChatOpenAIReasoningEffort.medium => ReasoningEffort.medium,
+        ChatOpenAIReasoningEffort.high => ReasoningEffort.high,
+        null => null,
+      };
+}
+
+extension ChatOpenAIVerbosityX on ChatOpenAIVerbosity? {
+  Verbosity? toVerbosity() => switch (this) {
+        ChatOpenAIVerbosity.low => Verbosity.low,
+        ChatOpenAIVerbosity.medium => Verbosity.medium,
+        ChatOpenAIVerbosity.high => Verbosity.high,
+        null => null,
+      };
 }
 
 extension ChatOpenAIServiceTierX on ChatOpenAIServiceTier? {

--- a/packages/langchain_openai/lib/src/chat_models/types.dart
+++ b/packages/langchain_openai/lib/src/chat_models/types.dart
@@ -80,8 +80,13 @@ class ChatOpenAIOptions extends ChatModelOptions {
   /// {@macro chat_openai_options}
   const ChatOpenAIOptions({
     super.model,
+    this.store,
+    this.reasoningEffort,
+    this.metadata,
     this.frequencyPenalty,
     this.logitBias,
+    this.logprobs,
+    this.topLogprobs,
     this.maxTokens,
     this.n,
     this.presencePenalty,
@@ -95,6 +100,7 @@ class ChatOpenAIOptions extends ChatModelOptions {
     this.parallelToolCalls,
     this.serviceTier,
     this.user,
+    this.verbosity,
     super.concurrencyLimit,
   });
 
@@ -109,6 +115,33 @@ class ChatOpenAIOptions extends ChatModelOptions {
   ///
   /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-logit_bias
   final Map<String, int>? logitBias;
+
+  /// Whether or not to store the output of this chat completion request.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-store
+  final bool? store;
+
+  /// Constrains effort on reasoning for reasoning models.
+  /// Supported values are `minimal`, `low`, `medium`, and `high`.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort
+  final ChatOpenAIReasoningEffort? reasoningEffort;
+
+  /// Developer-defined tags and values used for filtering completions.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-metadata
+  final Map<String, String>? metadata;
+
+  /// Whether to return log probabilities of the output tokens.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-logprobs
+  final bool? logprobs;
+
+  /// Number of most likely tokens to return at each token position when
+  /// [logprobs] is set to true.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_logprobs
+  final int? topLogprobs;
 
   /// The maximum number of tokens to generate in the chat completion.
   /// Defaults to inf.
@@ -188,11 +221,23 @@ class ChatOpenAIOptions extends ChatModelOptions {
   /// Ref: https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids
   final String? user;
 
+  /// Constrains the verbosity of the model's response. Lower values will result
+  /// in more concise responses, while higher values will be more verbose.
+  /// Supported values are `low`, `medium`, and `high`.
+  ///
+  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-verbosity
+  final ChatOpenAIVerbosity? verbosity;
+
   @override
   ChatOpenAIOptions copyWith({
     final String? model,
+    final bool? store,
+    final ChatOpenAIReasoningEffort? reasoningEffort,
+    final Map<String, String>? metadata,
     final double? frequencyPenalty,
     final Map<String, int>? logitBias,
+    final bool? logprobs,
+    final int? topLogprobs,
     final int? maxTokens,
     final int? n,
     final double? presencePenalty,
@@ -206,12 +251,18 @@ class ChatOpenAIOptions extends ChatModelOptions {
     final bool? parallelToolCalls,
     final ChatOpenAIServiceTier? serviceTier,
     final String? user,
+    final ChatOpenAIVerbosity? verbosity,
     final int? concurrencyLimit,
   }) {
     return ChatOpenAIOptions(
       model: model ?? this.model,
+      store: store ?? this.store,
+      reasoningEffort: reasoningEffort ?? this.reasoningEffort,
+      metadata: metadata ?? this.metadata,
       frequencyPenalty: frequencyPenalty ?? this.frequencyPenalty,
       logitBias: logitBias ?? this.logitBias,
+      logprobs: logprobs ?? this.logprobs,
+      topLogprobs: topLogprobs ?? this.topLogprobs,
       maxTokens: maxTokens ?? this.maxTokens,
       n: n ?? this.n,
       presencePenalty: presencePenalty ?? this.presencePenalty,
@@ -225,6 +276,7 @@ class ChatOpenAIOptions extends ChatModelOptions {
       parallelToolCalls: parallelToolCalls ?? this.parallelToolCalls,
       serviceTier: serviceTier ?? this.serviceTier,
       user: user ?? this.user,
+      verbosity: verbosity ?? this.verbosity,
       concurrencyLimit: concurrencyLimit ?? this.concurrencyLimit,
     );
   }
@@ -233,8 +285,13 @@ class ChatOpenAIOptions extends ChatModelOptions {
   ChatOpenAIOptions merge(covariant final ChatOpenAIOptions? other) {
     return copyWith(
       model: other?.model,
+      store: other?.store,
+      reasoningEffort: other?.reasoningEffort,
+      metadata: other?.metadata,
       frequencyPenalty: other?.frequencyPenalty,
       logitBias: other?.logitBias,
+      logprobs: other?.logprobs,
+      topLogprobs: other?.topLogprobs,
       maxTokens: other?.maxTokens,
       n: other?.n,
       presencePenalty: other?.presencePenalty,
@@ -248,6 +305,7 @@ class ChatOpenAIOptions extends ChatModelOptions {
       parallelToolCalls: other?.parallelToolCalls,
       serviceTier: other?.serviceTier,
       user: other?.user,
+      verbosity: other?.verbosity,
       concurrencyLimit: other?.concurrencyLimit,
     );
   }
@@ -257,9 +315,15 @@ class ChatOpenAIOptions extends ChatModelOptions {
     return identical(this, other) ||
         runtimeType == other.runtimeType &&
             model == other.model &&
+            store == other.store &&
+            reasoningEffort == other.reasoningEffort &&
+            const MapEquality<String, String>()
+                .equals(metadata, other.metadata) &&
             frequencyPenalty == other.frequencyPenalty &&
             const MapEquality<String, int>()
                 .equals(logitBias, other.logitBias) &&
+            logprobs == other.logprobs &&
+            topLogprobs == other.topLogprobs &&
             maxTokens == other.maxTokens &&
             n == other.n &&
             presencePenalty == other.presencePenalty &&
@@ -273,14 +337,20 @@ class ChatOpenAIOptions extends ChatModelOptions {
             parallelToolCalls == other.parallelToolCalls &&
             serviceTier == other.serviceTier &&
             user == other.user &&
+            verbosity == other.verbosity &&
             concurrencyLimit == other.concurrencyLimit;
   }
 
   @override
   int get hashCode {
     return model.hashCode ^
+        store.hashCode ^
+        reasoningEffort.hashCode ^
+        const MapEquality<String, String>().hash(metadata) ^
         frequencyPenalty.hashCode ^
         const MapEquality<String, int>().hash(logitBias) ^
+        logprobs.hashCode ^
+        topLogprobs.hashCode ^
         maxTokens.hashCode ^
         n.hashCode ^
         presencePenalty.hashCode ^
@@ -294,6 +364,7 @@ class ChatOpenAIOptions extends ChatModelOptions {
         parallelToolCalls.hashCode ^
         serviceTier.hashCode ^
         user.hashCode ^
+        verbosity.hashCode ^
         concurrencyLimit.hashCode;
   }
 }
@@ -406,6 +477,33 @@ class ChatOpenAIJsonSchema {
         const MapEquality<String, dynamic>().hash(schema) ^
         strict.hashCode;
   }
+}
+
+/// Constrains effort on reasoning for reasoning models.
+enum ChatOpenAIReasoningEffort {
+  /// Minimal effort
+  minimal,
+
+  /// Low effort
+  low,
+
+  /// Medium effort
+  medium,
+
+  /// High effort
+  high
+}
+
+/// Constrains the verbosity of the model's response.
+enum ChatOpenAIVerbosity {
+  /// More concise responses
+  low,
+
+  /// Medium verbosity responses
+  medium,
+
+  /// More verbose responses
+  high
 }
 
 /// Specifies the latency tier to use for processing the request.


### PR DESCRIPTION
New fields in `ChatOpenAIOptions`:
```dart
  /// Whether or not to store the output of this chat completion request.
  ///
  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-store
  final bool? store;

  /// Constrains effort on reasoning for reasoning models.
  /// Supported values are `minimal`, `low`, `medium`, and `high`.
  ///
  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort
  final ChatOpenAIReasoningEffort? reasoningEffort;

  /// Developer-defined tags and values used for filtering completions.
  ///
  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-metadata
  final Map<String, String>? metadata;

  /// Whether to return log probabilities of the output tokens.
  ///
  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-logprobs
  final bool? logprobs;

  /// Number of most likely tokens to return at each token position when
  /// [logprobs] is set to true.
  ///
  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_logprobs
  final int? topLogprobs;

  /// Constrains the verbosity of the model's response. Lower values will result
  /// in more concise responses, while higher values will be more verbose.
  /// Supported values are `low`, `medium`, and `high`.
  ///
  /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-verbosity
  final ChatOpenAIVerbosity? verbosity;
```