### PR TITLE
Compatible with ByteDance's Bots model:https://ark.cn-beijing.volces.…

### DIFF
--- a/packages/openai_dart/lib/src/client.dart
+++ b/packages/openai_dart/lib/src/client.dart
@@ -200,8 +200,10 @@ class _OpenAIStreamTransformer
     return stream //
         .transform(utf8.decoder) //
         .transform(const LineSplitter()) //
-        .where((final i) => i.startsWith('data: ') && !i.endsWith('[DONE]'))
-        .map((final item) => item.substring(6));
+        .where((final i) =>
+            (i.startsWith('data: ') || i.startsWith('data:')) &&
+            !i.endsWith('[DONE]'))
+        .map((final item) => item.startsWith('data: ') ? item.substring(6) : item.substring(5));
   }
 }
 
@@ -279,6 +281,10 @@ class _PairwiseTransformer
               event = data.substring(7);
             } else if (data.startsWith('data: ')) {
               final dataStr = data.substring(6);
+              controller.add((event, dataStr));
+            }
+            else if (data.startsWith('data:')) {
+              final dataStr = data.substring(5);
               controller.add((event, dataStr));
             }
           },


### PR DESCRIPTION
…com/api/v3/bots

<!-- Thank you for contributing to LangChain.dart!

Replace this comment with:
  - Description: It does not work properly when using ByteDance's Bots model
  - Issue:  When using the model bot-20250719122409-kng26, the returned data cannot be parsed normally. This is because the content starts with data:{, while the code is configured to match *data: * (note the space after the colon).
Sample data: data:{"id":"0217589512176975674dc015728aaac5c2c94c82690e707974e6d","choices":[{"delta":{"content":"!","role":"assistant"},"index":0}],"created":1758951220,"model":"doubao-1-5-pro-32k-character-250715","object":"chat.completion.chunk","metadata":{}}

  - Dependencies: any dependencies required for this change.
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below).

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access.
  2. an example showing its use.

Maintainer responsibilities:
  - General: @davidmigloz

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/davidmigloz/langchain_dart/blob/main/CONTRIBUTING.md
 -->
