### PR TITLE
fix: Fix SSE parser to handle data: without space

### DIFF
--- a/packages/openai_dart/lib/src/client.dart
+++ b/packages/openai_dart/lib/src/client.dart
@@ -200,8 +200,8 @@ class _OpenAIStreamTransformer
     return stream //
         .transform(utf8.decoder) //
         .transform(const LineSplitter()) //
-        .where((final i) => i.startsWith('data: ') && !i.endsWith('[DONE]'))
-        .map((final item) => item.substring(6));
+        .where((final i) => i.startsWith('data:') && !i.endsWith('[DONE]'))
+        .map((final item) => item.substring(5).trim());
   }
 }
 
@@ -275,10 +275,10 @@ class _PairwiseTransformer
       onListen: () {
         subscription = stream.listen(
           (final String data) {
-            if (data.startsWith('event: ')) {
-              event = data.substring(7);
-            } else if (data.startsWith('data: ')) {
-              final dataStr = data.substring(6);
+            if (data.startsWith('event:')) {
+              event = data.substring(6).trim();
+            } else if (data.startsWith('data:')) {
+              final dataStr = data.substring(5).trim();
               controller.add((event, dataStr));
             }
           },


### PR DESCRIPTION
- Description: Updated the streaming response parser to trim payload after data:, so both formats (data:{...} and data: {...}) are supported.
- Issue: https://github.com/davidmigloz/langchain_dart/issues/778 
- Dependencies: No
- Tag maintainer: for a quicker response, tag the relevant maintainer (see below).

Although this issue originates from LongCat’s non-standard SSE formatting, making the parser more tolerant improves overall robustness and compatibility.
