### PR TITLE
feat: Add extended thinking support to langchain_anthropic

### DIFF
--- a/packages/langchain_anthropic/lib/src/chat_models/chat_anthropic.dart
+++ b/packages/langchain_anthropic/lib/src/chat_models/chat_anthropic.dart
@@ -93,6 +93,32 @@ import 'types.dart';
 /// final res = await chain.invoke({'name': 'David'});
 /// ```
 ///
+/// ### Extended Thinking
+///
+/// Claude's extended thinking feature enables the model to show its internal
+/// reasoning process before providing the final answer. This is particularly
+/// useful for complex reasoning tasks.
+///
+/// ```dart
+/// final chatModel = ChatAnthropic(
+///   apiKey: anthropicApiKey,
+///   defaultOptions: ChatAnthropicOptions(
+///     model: 'claude-3-5-sonnet-20241022',
+///     maxTokens: 8192,
+///     thinking: ChatAnthropicThinking.enabled(budgetTokens: 4096),
+///   ),
+/// );
+///
+/// final prompt = PromptValue.string('Solve this complex problem: ...');
+/// final res = await chatModel.invoke(prompt);
+/// // The response will include thinking blocks showing Claude's reasoning
+/// ```
+///
+/// The thinking blocks will appear in the response content and can be
+/// accessed through the message's content blocks. The `budgetTokens` parameter
+/// controls how many tokens Claude can use for thinking (minimum 1024), and
+/// counts towards your `maxTokens` limit.
+///
 /// ### Advance
 ///
 /// #### Custom HTTP client

--- a/packages/langchain_anthropic/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_anthropic/lib/src/chat_models/mappers.dart
@@ -29,6 +29,8 @@ a.CreateMessageRequest createMessageRequest(
   final toolsDtos = (options?.tools ?? defaultOptions.tools)?.toTool(
     toolChoice,
   );
+  final thinking = options?.thinking ?? defaultOptions.thinking;
+  final thinkingDto = thinking?.toThinkingConfig();
 
   return a.CreateMessageRequest(
     model: a.Model.modelId(
@@ -51,6 +53,7 @@ a.CreateMessageRequest createMessageRequest(
     ),
     tools: toolsDtos,
     toolChoice: toolChoiceDto,
+    thinking: thinkingDto,
     stream: stream,
   );
 }
@@ -345,6 +348,7 @@ class MessageStreamEventTransformer
     ),
   ),
   final a.ToolResultBlock tr => (tr.content.text, null),
+  final a.ThinkingBlock t => (t.thinking, null),
 };
 
 (String content, List<AIChatMessageToolCall> toolCalls) _mapContentBlockDelta(
@@ -363,6 +367,7 @@ class MessageStreamEventTransformer
       ),
     ],
   ),
+  final a.ThinkingBlockDelta t => (t.thinking, const <AIChatMessageToolCall>[]),
 };
 
 extension ToolSpecListMapper on List<ToolSpec> {


### PR DESCRIPTION
Claude's extended thinking feature enables the model to show its internal reasoning process before providing the final answer. This is particularly useful for complex reasoning tasks.

```dart
final chatModel = ChatAnthropic(
  apiKey: anthropicApiKey,
  defaultOptions: ChatAnthropicOptions(
    model: 'claude-3-5-sonnet-20241022',
    maxTokens: 8192,
    thinking: ChatAnthropicThinking.enabled(budgetTokens: 4096),
  ),
);

final prompt = PromptValue.string('Solve this complex problem: ...');
final res = await chatModel.invoke(prompt);
// The response will include thinking blocks showing Claude's reasoning
```

The thinking blocks will appear in the response content and can be accessed through the message's content blocks. The `budgetTokens` parameter controls how many tokens Claude can use for thinking (minimum 1024), and counts towards your `maxTokens` limit.