### PR TITLE
refactor!: Improve factory names in ollama_dart

### DIFF
--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama/mappers.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama/mappers.dart
@@ -18,7 +18,7 @@ extension _OllamaResponseFormatChatMapper on OllamaResponseFormat {
         .where((final f) => f.name.toLowerCase() == name.toLowerCase())
         .firstOrNull;
     if (format == null) return null;
-    return o.GenerateChatCompletionRequestFormat.enumeration(
+    return o.GenerateChatCompletionRequestFormat.json(
       o.GenerateChatCompletionRequestFormatEnum.values.firstWhere(
         (final e) => e.name == format.name,
       ),
@@ -28,7 +28,7 @@ extension _OllamaResponseFormatChatMapper on OllamaResponseFormat {
 
 extension _OllamaThinkingLevelChatMapper on OllamaThinkingLevel {
   o.GenerateChatCompletionRequestThink toThinkRequest() {
-    return o.GenerateChatCompletionRequestThink.enumeration(
+    return o.GenerateChatCompletionRequestThink.level(
       o.GenerateChatCompletionRequestThinkEnum.values.firstWhere(
         (final e) => e.name == name,
       ),

--- a/packages/langchain_ollama/lib/src/llms/mappers.dart
+++ b/packages/langchain_ollama/lib/src/llms/mappers.dart
@@ -47,7 +47,7 @@ extension OllamaResponseFormatMapper on OllamaResponseFormat {
         .where((final f) => f.name.toLowerCase() == name.toLowerCase())
         .firstOrNull;
     if (format == null) return null;
-    return GenerateCompletionRequestFormat.enumeration(
+    return GenerateCompletionRequestFormat.json(
       GenerateCompletionRequestFormatEnum.values.firstWhere(
         (final e) => e.name == format.name,
       ),
@@ -57,7 +57,7 @@ extension OllamaResponseFormatMapper on OllamaResponseFormat {
 
 extension OllamaThinkingLevelMapper on OllamaThinkingLevel {
   GenerateCompletionRequestThink toThinkRequest() {
-    return GenerateCompletionRequestThink.enumeration(
+    return GenerateCompletionRequestThink.level(
       GenerateCompletionRequestThinkEnum.values.firstWhere(
         (final e) => e.name == name,
       ),

--- a/packages/ollama_dart/example/structured_output_example.dart
+++ b/packages/ollama_dart/example/structured_output_example.dart
@@ -1,0 +1,193 @@
+// ignore_for_file: avoid_print
+import 'package:ollama_dart/ollama_dart.dart';
+
+/// Example demonstrating structured output using JSON schemas with Ollama.
+///
+/// This example shows how to use the `format` parameter to get structured
+/// JSON responses that conform to a specific schema. This feature enables
+/// reliable data extraction and API-like responses from language models.
+///
+/// Requirements:
+/// - Ollama must be running locally (http://localhost:11434)
+/// - A model must be available (e.g., llama3.2)
+///
+/// Run: dart run example/structured_output_example.dart
+void main() async {
+  // Initialize the Ollama client
+  final client = OllamaClient();
+
+  print('='.repeat(80));
+  print('Ollama Structured Output Examples');
+  print('='.repeat(80));
+
+  // Example 1: Basic JSON mode (simple string enum)
+  print('\n📋 Example 1: Basic JSON mode');
+  print('-'.repeat(80));
+  final response1 = await client.generateChatCompletion(
+    request: const GenerateChatCompletionRequest(
+      model: 'llama3.2',
+      messages: [
+        Message(
+          role: MessageRole.user,
+          content: 'Tell me about Paris. Return the response as JSON.',
+        ),
+      ],
+      format: GenerateChatCompletionRequestFormat.json(
+        GenerateChatCompletionRequestFormatEnum.json,
+      ),
+    ),
+  );
+  print('Response: ${response1.message.content}\n');
+
+  // Example 2: JSON Schema for structured output
+  print('📋 Example 2: JSON Schema with structure');
+  print('-'.repeat(80));
+  final response2 = await client.generateChatCompletion(
+    request: const GenerateChatCompletionRequest(
+      model: 'llama3.2',
+      messages: [
+        Message(
+          role: MessageRole.user,
+          content: 'Tell me about Paris.',
+        ),
+      ],
+      format: GenerateChatCompletionRequestFormat.schema({
+        'type': 'object',
+        'properties': {
+          'city': {'type': 'string'},
+          'country': {'type': 'string'},
+          'population': {'type': 'integer'},
+          'famous_landmarks': {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+        },
+        'required': ['city', 'country'],
+      }),
+    ),
+  );
+  print('Structured Response: ${response2.message.content}\n');
+
+  // Example 3: Complex nested schema
+  print('📋 Example 3: Complex nested schema');
+  print('-'.repeat(80));
+  final response3 = await client.generateChatCompletion(
+    request: const GenerateChatCompletionRequest(
+      model: 'llama3.2',
+      messages: [
+        Message(
+          role: MessageRole.user,
+          content: 'Generate information about a fictional person.',
+        ),
+      ],
+      format: GenerateChatCompletionRequestFormat.schema({
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+          'age': {'type': 'integer'},
+          'address': {
+            'type': 'object',
+            'properties': {
+              'street': {'type': 'string'},
+              'city': {'type': 'string'},
+              'country': {'type': 'string'},
+            },
+          },
+          'hobbies': {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+          'is_student': {'type': 'boolean'},
+        },
+        'required': ['name', 'age'],
+      }),
+    ),
+  );
+  print('Complex Response: ${response3.message.content}\n');
+
+  // Example 4: Using with streaming
+  print('📋 Example 4: Streaming with JSON schema');
+  print('-'.repeat(80));
+  final stream = client.generateChatCompletionStream(
+    request: const GenerateChatCompletionRequest(
+      model: 'llama3.2',
+      messages: [
+        Message(
+          role: MessageRole.user,
+          content: 'List 3 programming languages with their year of creation.',
+        ),
+      ],
+      format: GenerateChatCompletionRequestFormat.schema({
+        'type': 'object',
+        'properties': {
+          'languages': {
+            'type': 'array',
+            'items': {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+                'year': {'type': 'integer'},
+              },
+            },
+          },
+        },
+      }),
+    ),
+  );
+
+  print('Streaming response:');
+  await for (final chunk in stream) {
+    if (chunk.message.content.isNotEmpty) {
+      print(chunk.message.content);
+    }
+  }
+
+  // Example 5: Data extraction use case
+  print('\n📋 Example 5: Data extraction from text');
+  print('-'.repeat(80));
+  final response5 = await client.generateChatCompletion(
+    request: const GenerateChatCompletionRequest(
+      model: 'llama3.2',
+      messages: [
+        Message(
+          role: MessageRole.user,
+          content: '''
+Extract the key information from this text:
+
+"Apple Inc. was founded by Steve Jobs, Steve Wozniak, and Ronald Wayne
+in April 1976. The company is headquartered in Cupertino, California
+and is known for products like the iPhone, iPad, and Mac computers."
+''',
+        ),
+      ],
+      format: GenerateChatCompletionRequestFormat.schema({
+        'type': 'object',
+        'properties': {
+          'company_name': {'type': 'string'},
+          'founders': {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+          'founding_year': {'type': 'integer'},
+          'headquarters': {'type': 'string'},
+          'products': {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+        },
+        'required': ['company_name', 'founders', 'founding_year'],
+      }),
+    ),
+  );
+  print('Extracted Data: ${response5.message.content}\n');
+
+  print('='.repeat(80));
+  print('✅ All examples completed!');
+  print('='.repeat(80));
+
+  client.endSession();
+}
+
+extension on String {
+  String repeat(int count) => List.filled(count, this).join();
+}

--- a/packages/ollama_dart/lib/src/generated/schema/generate_chat_completion_request.dart
+++ b/packages/ollama_dart/lib/src/generated/schema/generate_chat_completion_request.dart
@@ -126,12 +126,12 @@ sealed class GenerateChatCompletionRequestFormat
   const GenerateChatCompletionRequestFormat._();
 
   /// Enable JSON mode
-  const factory GenerateChatCompletionRequestFormat.enumeration(
+  const factory GenerateChatCompletionRequestFormat.json(
     GenerateChatCompletionRequestFormatEnum value,
   ) = GenerateChatCompletionRequestFormatEnumeration;
 
   /// JSON schema object for structured output validation
-  const factory GenerateChatCompletionRequestFormat.mapStringDynamic(
+  const factory GenerateChatCompletionRequestFormat.schema(
     Map<String, dynamic> value,
   ) = GenerateChatCompletionRequestFormatMapStringDynamic;
 
@@ -210,7 +210,7 @@ sealed class GenerateChatCompletionRequestThink
   const GenerateChatCompletionRequestThink._();
 
   /// No Description
-  const factory GenerateChatCompletionRequestThink.enumeration(
+  const factory GenerateChatCompletionRequestThink.level(
     GenerateChatCompletionRequestThinkEnum value,
   ) = GenerateChatCompletionRequestThinkEnumeration;
 

--- a/packages/ollama_dart/lib/src/generated/schema/generate_completion_request.dart
+++ b/packages/ollama_dart/lib/src/generated/schema/generate_completion_request.dart
@@ -152,12 +152,12 @@ sealed class GenerateCompletionRequestFormat
   const GenerateCompletionRequestFormat._();
 
   /// Enable JSON mode
-  const factory GenerateCompletionRequestFormat.enumeration(
+  const factory GenerateCompletionRequestFormat.json(
     GenerateCompletionRequestFormatEnum value,
   ) = GenerateCompletionRequestFormatEnumeration;
 
   /// JSON schema object for structured output validation
-  const factory GenerateCompletionRequestFormat.mapStringDynamic(
+  const factory GenerateCompletionRequestFormat.schema(
     Map<String, dynamic> value,
   ) = GenerateCompletionRequestFormatMapStringDynamic;
 
@@ -233,7 +233,7 @@ sealed class GenerateCompletionRequestThink
   const GenerateCompletionRequestThink._();
 
   /// No Description
-  const factory GenerateCompletionRequestThink.enumeration(
+  const factory GenerateCompletionRequestThink.level(
     GenerateCompletionRequestThinkEnum value,
   ) = GenerateCompletionRequestThinkEnumeration;
 

--- a/packages/ollama_dart/lib/src/generated/schema/schema.freezed.dart
+++ b/packages/ollama_dart/lib/src/generated/schema/schema.freezed.dart
@@ -468,11 +468,11 @@ GenerateCompletionRequestFormat _$GenerateCompletionRequestFormatFromJson(
   Map<String, dynamic> json
 ) {
         switch (json['runtimeType']) {
-                  case 'enumeration':
+                  case 'json':
           return GenerateCompletionRequestFormatEnumeration.fromJson(
             json
           );
-                case 'mapStringDynamic':
+                case 'schema':
           return GenerateCompletionRequestFormatMapStringDynamic.fromJson(
             json
           );
@@ -534,12 +534,12 @@ extension GenerateCompletionRequestFormatPatterns on GenerateCompletionRequestFo
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GenerateCompletionRequestFormatEnumeration value)?  enumeration,TResult Function( GenerateCompletionRequestFormatMapStringDynamic value)?  mapStringDynamic,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GenerateCompletionRequestFormatEnumeration value)?  json,TResult Function( GenerateCompletionRequestFormatMapStringDynamic value)?  schema,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
-case GenerateCompletionRequestFormatEnumeration() when enumeration != null:
-return enumeration(_that);case GenerateCompletionRequestFormatMapStringDynamic() when mapStringDynamic != null:
-return mapStringDynamic(_that);case _:
+case GenerateCompletionRequestFormatEnumeration() when json != null:
+return json(_that);case GenerateCompletionRequestFormatMapStringDynamic() when schema != null:
+return schema(_that);case _:
   return orElse();
 
 }
@@ -557,12 +557,12 @@ return mapStringDynamic(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GenerateCompletionRequestFormatEnumeration value)  enumeration,required TResult Function( GenerateCompletionRequestFormatMapStringDynamic value)  mapStringDynamic,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GenerateCompletionRequestFormatEnumeration value)  json,required TResult Function( GenerateCompletionRequestFormatMapStringDynamic value)  schema,}){
 final _that = this;
 switch (_that) {
 case GenerateCompletionRequestFormatEnumeration():
-return enumeration(_that);case GenerateCompletionRequestFormatMapStringDynamic():
-return mapStringDynamic(_that);}
+return json(_that);case GenerateCompletionRequestFormatMapStringDynamic():
+return schema(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -576,12 +576,12 @@ return mapStringDynamic(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GenerateCompletionRequestFormatEnumeration value)?  enumeration,TResult? Function( GenerateCompletionRequestFormatMapStringDynamic value)?  mapStringDynamic,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GenerateCompletionRequestFormatEnumeration value)?  json,TResult? Function( GenerateCompletionRequestFormatMapStringDynamic value)?  schema,}){
 final _that = this;
 switch (_that) {
-case GenerateCompletionRequestFormatEnumeration() when enumeration != null:
-return enumeration(_that);case GenerateCompletionRequestFormatMapStringDynamic() when mapStringDynamic != null:
-return mapStringDynamic(_that);case _:
+case GenerateCompletionRequestFormatEnumeration() when json != null:
+return json(_that);case GenerateCompletionRequestFormatMapStringDynamic() when schema != null:
+return schema(_that);case _:
   return null;
 
 }
@@ -598,11 +598,11 @@ return mapStringDynamic(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( GenerateCompletionRequestFormatEnum value)?  enumeration,TResult Function( Map<String, dynamic> value)?  mapStringDynamic,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( GenerateCompletionRequestFormatEnum value)?  json,TResult Function( Map<String, dynamic> value)?  schema,required TResult orElse(),}) {final _that = this;
 switch (_that) {
-case GenerateCompletionRequestFormatEnumeration() when enumeration != null:
-return enumeration(_that.value);case GenerateCompletionRequestFormatMapStringDynamic() when mapStringDynamic != null:
-return mapStringDynamic(_that.value);case _:
+case GenerateCompletionRequestFormatEnumeration() when json != null:
+return json(_that.value);case GenerateCompletionRequestFormatMapStringDynamic() when schema != null:
+return schema(_that.value);case _:
   return orElse();
 
 }
@@ -620,11 +620,11 @@ return mapStringDynamic(_that.value);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( GenerateCompletionRequestFormatEnum value)  enumeration,required TResult Function( Map<String, dynamic> value)  mapStringDynamic,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( GenerateCompletionRequestFormatEnum value)  json,required TResult Function( Map<String, dynamic> value)  schema,}) {final _that = this;
 switch (_that) {
 case GenerateCompletionRequestFormatEnumeration():
-return enumeration(_that.value);case GenerateCompletionRequestFormatMapStringDynamic():
-return mapStringDynamic(_that.value);}
+return json(_that.value);case GenerateCompletionRequestFormatMapStringDynamic():
+return schema(_that.value);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -638,11 +638,11 @@ return mapStringDynamic(_that.value);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( GenerateCompletionRequestFormatEnum value)?  enumeration,TResult? Function( Map<String, dynamic> value)?  mapStringDynamic,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( GenerateCompletionRequestFormatEnum value)?  json,TResult? Function( Map<String, dynamic> value)?  schema,}) {final _that = this;
 switch (_that) {
-case GenerateCompletionRequestFormatEnumeration() when enumeration != null:
-return enumeration(_that.value);case GenerateCompletionRequestFormatMapStringDynamic() when mapStringDynamic != null:
-return mapStringDynamic(_that.value);case _:
+case GenerateCompletionRequestFormatEnumeration() when json != null:
+return json(_that.value);case GenerateCompletionRequestFormatMapStringDynamic() when schema != null:
+return schema(_that.value);case _:
   return null;
 
 }
@@ -654,7 +654,7 @@ return mapStringDynamic(_that.value);case _:
 @JsonSerializable()
 
 class GenerateCompletionRequestFormatEnumeration extends GenerateCompletionRequestFormat {
-  const GenerateCompletionRequestFormatEnumeration(this.value, {final  String? $type}): $type = $type ?? 'enumeration',super._();
+  const GenerateCompletionRequestFormatEnumeration(this.value, {final  String? $type}): $type = $type ?? 'json',super._();
   factory GenerateCompletionRequestFormatEnumeration.fromJson(Map<String, dynamic> json) => _$GenerateCompletionRequestFormatEnumerationFromJson(json);
 
 @override final  GenerateCompletionRequestFormatEnum value;
@@ -685,7 +685,7 @@ int get hashCode => Object.hash(runtimeType,value);
 
 @override
 String toString() {
-  return 'GenerateCompletionRequestFormat.enumeration(value: $value)';
+  return 'GenerateCompletionRequestFormat.json(value: $value)';
 }
 
 
@@ -727,7 +727,7 @@ as GenerateCompletionRequestFormatEnum,
 @JsonSerializable()
 
 class GenerateCompletionRequestFormatMapStringDynamic extends GenerateCompletionRequestFormat {
-  const GenerateCompletionRequestFormatMapStringDynamic(final  Map<String, dynamic> value, {final  String? $type}): _value = value,$type = $type ?? 'mapStringDynamic',super._();
+  const GenerateCompletionRequestFormatMapStringDynamic(final  Map<String, dynamic> value, {final  String? $type}): _value = value,$type = $type ?? 'schema',super._();
   factory GenerateCompletionRequestFormatMapStringDynamic.fromJson(Map<String, dynamic> json) => _$GenerateCompletionRequestFormatMapStringDynamicFromJson(json);
 
  final  Map<String, dynamic> _value;
@@ -764,7 +764,7 @@ int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(
 
 @override
 String toString() {
-  return 'GenerateCompletionRequestFormat.mapStringDynamic(value: $value)';
+  return 'GenerateCompletionRequestFormat.schema(value: $value)';
 }
 
 
@@ -887,11 +887,11 @@ extension GenerateCompletionRequestThinkPatterns on GenerateCompletionRequestThi
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GenerateCompletionRequestThinkEnumeration value)?  enumeration,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GenerateCompletionRequestThinkEnumeration value)?  level,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
-case GenerateCompletionRequestThinkEnumeration() when enumeration != null:
-return enumeration(_that);case _:
+case GenerateCompletionRequestThinkEnumeration() when level != null:
+return level(_that);case _:
   return orElse();
 
 }
@@ -909,11 +909,11 @@ return enumeration(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GenerateCompletionRequestThinkEnumeration value)  enumeration,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GenerateCompletionRequestThinkEnumeration value)  level,}){
 final _that = this;
 switch (_that) {
 case GenerateCompletionRequestThinkEnumeration():
-return enumeration(_that);}
+return level(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -927,11 +927,11 @@ return enumeration(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GenerateCompletionRequestThinkEnumeration value)?  enumeration,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GenerateCompletionRequestThinkEnumeration value)?  level,}){
 final _that = this;
 switch (_that) {
-case GenerateCompletionRequestThinkEnumeration() when enumeration != null:
-return enumeration(_that);case _:
+case GenerateCompletionRequestThinkEnumeration() when level != null:
+return level(_that);case _:
   return null;
 
 }
@@ -948,10 +948,10 @@ return enumeration(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( GenerateCompletionRequestThinkEnum value)?  enumeration,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( GenerateCompletionRequestThinkEnum value)?  level,required TResult orElse(),}) {final _that = this;
 switch (_that) {
-case GenerateCompletionRequestThinkEnumeration() when enumeration != null:
-return enumeration(_that.value);case _:
+case GenerateCompletionRequestThinkEnumeration() when level != null:
+return level(_that.value);case _:
   return orElse();
 
 }
@@ -969,10 +969,10 @@ return enumeration(_that.value);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( GenerateCompletionRequestThinkEnum value)  enumeration,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( GenerateCompletionRequestThinkEnum value)  level,}) {final _that = this;
 switch (_that) {
 case GenerateCompletionRequestThinkEnumeration():
-return enumeration(_that.value);}
+return level(_that.value);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -986,10 +986,10 @@ return enumeration(_that.value);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( GenerateCompletionRequestThinkEnum value)?  enumeration,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( GenerateCompletionRequestThinkEnum value)?  level,}) {final _that = this;
 switch (_that) {
-case GenerateCompletionRequestThinkEnumeration() when enumeration != null:
-return enumeration(_that.value);case _:
+case GenerateCompletionRequestThinkEnumeration() when level != null:
+return level(_that.value);case _:
   return null;
 
 }
@@ -1028,7 +1028,7 @@ int get hashCode => Object.hash(runtimeType,value);
 
 @override
 String toString() {
-  return 'GenerateCompletionRequestThink.enumeration(value: $value)';
+  return 'GenerateCompletionRequestThink.level(value: $value)';
 }
 
 
@@ -2562,11 +2562,11 @@ GenerateChatCompletionRequestFormat _$GenerateChatCompletionRequestFormatFromJso
   Map<String, dynamic> json
 ) {
         switch (json['runtimeType']) {
-                  case 'enumeration':
+                  case 'json':
           return GenerateChatCompletionRequestFormatEnumeration.fromJson(
             json
           );
-                case 'mapStringDynamic':
+                case 'schema':
           return GenerateChatCompletionRequestFormatMapStringDynamic.fromJson(
             json
           );
@@ -2628,12 +2628,12 @@ extension GenerateChatCompletionRequestFormatPatterns on GenerateChatCompletionR
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GenerateChatCompletionRequestFormatEnumeration value)?  enumeration,TResult Function( GenerateChatCompletionRequestFormatMapStringDynamic value)?  mapStringDynamic,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GenerateChatCompletionRequestFormatEnumeration value)?  json,TResult Function( GenerateChatCompletionRequestFormatMapStringDynamic value)?  schema,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
-case GenerateChatCompletionRequestFormatEnumeration() when enumeration != null:
-return enumeration(_that);case GenerateChatCompletionRequestFormatMapStringDynamic() when mapStringDynamic != null:
-return mapStringDynamic(_that);case _:
+case GenerateChatCompletionRequestFormatEnumeration() when json != null:
+return json(_that);case GenerateChatCompletionRequestFormatMapStringDynamic() when schema != null:
+return schema(_that);case _:
   return orElse();
 
 }
@@ -2651,12 +2651,12 @@ return mapStringDynamic(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GenerateChatCompletionRequestFormatEnumeration value)  enumeration,required TResult Function( GenerateChatCompletionRequestFormatMapStringDynamic value)  mapStringDynamic,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GenerateChatCompletionRequestFormatEnumeration value)  json,required TResult Function( GenerateChatCompletionRequestFormatMapStringDynamic value)  schema,}){
 final _that = this;
 switch (_that) {
 case GenerateChatCompletionRequestFormatEnumeration():
-return enumeration(_that);case GenerateChatCompletionRequestFormatMapStringDynamic():
-return mapStringDynamic(_that);}
+return json(_that);case GenerateChatCompletionRequestFormatMapStringDynamic():
+return schema(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -2670,12 +2670,12 @@ return mapStringDynamic(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GenerateChatCompletionRequestFormatEnumeration value)?  enumeration,TResult? Function( GenerateChatCompletionRequestFormatMapStringDynamic value)?  mapStringDynamic,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GenerateChatCompletionRequestFormatEnumeration value)?  json,TResult? Function( GenerateChatCompletionRequestFormatMapStringDynamic value)?  schema,}){
 final _that = this;
 switch (_that) {
-case GenerateChatCompletionRequestFormatEnumeration() when enumeration != null:
-return enumeration(_that);case GenerateChatCompletionRequestFormatMapStringDynamic() when mapStringDynamic != null:
-return mapStringDynamic(_that);case _:
+case GenerateChatCompletionRequestFormatEnumeration() when json != null:
+return json(_that);case GenerateChatCompletionRequestFormatMapStringDynamic() when schema != null:
+return schema(_that);case _:
   return null;
 
 }
@@ -2692,11 +2692,11 @@ return mapStringDynamic(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( GenerateChatCompletionRequestFormatEnum value)?  enumeration,TResult Function( Map<String, dynamic> value)?  mapStringDynamic,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( GenerateChatCompletionRequestFormatEnum value)?  json,TResult Function( Map<String, dynamic> value)?  schema,required TResult orElse(),}) {final _that = this;
 switch (_that) {
-case GenerateChatCompletionRequestFormatEnumeration() when enumeration != null:
-return enumeration(_that.value);case GenerateChatCompletionRequestFormatMapStringDynamic() when mapStringDynamic != null:
-return mapStringDynamic(_that.value);case _:
+case GenerateChatCompletionRequestFormatEnumeration() when json != null:
+return json(_that.value);case GenerateChatCompletionRequestFormatMapStringDynamic() when schema != null:
+return schema(_that.value);case _:
   return orElse();
 
 }
@@ -2714,11 +2714,11 @@ return mapStringDynamic(_that.value);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( GenerateChatCompletionRequestFormatEnum value)  enumeration,required TResult Function( Map<String, dynamic> value)  mapStringDynamic,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( GenerateChatCompletionRequestFormatEnum value)  json,required TResult Function( Map<String, dynamic> value)  schema,}) {final _that = this;
 switch (_that) {
 case GenerateChatCompletionRequestFormatEnumeration():
-return enumeration(_that.value);case GenerateChatCompletionRequestFormatMapStringDynamic():
-return mapStringDynamic(_that.value);}
+return json(_that.value);case GenerateChatCompletionRequestFormatMapStringDynamic():
+return schema(_that.value);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -2732,11 +2732,11 @@ return mapStringDynamic(_that.value);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( GenerateChatCompletionRequestFormatEnum value)?  enumeration,TResult? Function( Map<String, dynamic> value)?  mapStringDynamic,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( GenerateChatCompletionRequestFormatEnum value)?  json,TResult? Function( Map<String, dynamic> value)?  schema,}) {final _that = this;
 switch (_that) {
-case GenerateChatCompletionRequestFormatEnumeration() when enumeration != null:
-return enumeration(_that.value);case GenerateChatCompletionRequestFormatMapStringDynamic() when mapStringDynamic != null:
-return mapStringDynamic(_that.value);case _:
+case GenerateChatCompletionRequestFormatEnumeration() when json != null:
+return json(_that.value);case GenerateChatCompletionRequestFormatMapStringDynamic() when schema != null:
+return schema(_that.value);case _:
   return null;
 
 }
@@ -2748,7 +2748,7 @@ return mapStringDynamic(_that.value);case _:
 @JsonSerializable()
 
 class GenerateChatCompletionRequestFormatEnumeration extends GenerateChatCompletionRequestFormat {
-  const GenerateChatCompletionRequestFormatEnumeration(this.value, {final  String? $type}): $type = $type ?? 'enumeration',super._();
+  const GenerateChatCompletionRequestFormatEnumeration(this.value, {final  String? $type}): $type = $type ?? 'json',super._();
   factory GenerateChatCompletionRequestFormatEnumeration.fromJson(Map<String, dynamic> json) => _$GenerateChatCompletionRequestFormatEnumerationFromJson(json);
 
 @override final  GenerateChatCompletionRequestFormatEnum value;
@@ -2779,7 +2779,7 @@ int get hashCode => Object.hash(runtimeType,value);
 
 @override
 String toString() {
-  return 'GenerateChatCompletionRequestFormat.enumeration(value: $value)';
+  return 'GenerateChatCompletionRequestFormat.json(value: $value)';
 }
 
 
@@ -2821,7 +2821,7 @@ as GenerateChatCompletionRequestFormatEnum,
 @JsonSerializable()
 
 class GenerateChatCompletionRequestFormatMapStringDynamic extends GenerateChatCompletionRequestFormat {
-  const GenerateChatCompletionRequestFormatMapStringDynamic(final  Map<String, dynamic> value, {final  String? $type}): _value = value,$type = $type ?? 'mapStringDynamic',super._();
+  const GenerateChatCompletionRequestFormatMapStringDynamic(final  Map<String, dynamic> value, {final  String? $type}): _value = value,$type = $type ?? 'schema',super._();
   factory GenerateChatCompletionRequestFormatMapStringDynamic.fromJson(Map<String, dynamic> json) => _$GenerateChatCompletionRequestFormatMapStringDynamicFromJson(json);
 
  final  Map<String, dynamic> _value;
@@ -2858,7 +2858,7 @@ int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(
 
 @override
 String toString() {
-  return 'GenerateChatCompletionRequestFormat.mapStringDynamic(value: $value)';
+  return 'GenerateChatCompletionRequestFormat.schema(value: $value)';
 }
 
 
@@ -2981,11 +2981,11 @@ extension GenerateChatCompletionRequestThinkPatterns on GenerateChatCompletionRe
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GenerateChatCompletionRequestThinkEnumeration value)?  enumeration,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GenerateChatCompletionRequestThinkEnumeration value)?  level,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
-case GenerateChatCompletionRequestThinkEnumeration() when enumeration != null:
-return enumeration(_that);case _:
+case GenerateChatCompletionRequestThinkEnumeration() when level != null:
+return level(_that);case _:
   return orElse();
 
 }
@@ -3003,11 +3003,11 @@ return enumeration(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GenerateChatCompletionRequestThinkEnumeration value)  enumeration,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GenerateChatCompletionRequestThinkEnumeration value)  level,}){
 final _that = this;
 switch (_that) {
 case GenerateChatCompletionRequestThinkEnumeration():
-return enumeration(_that);}
+return level(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -3021,11 +3021,11 @@ return enumeration(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GenerateChatCompletionRequestThinkEnumeration value)?  enumeration,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GenerateChatCompletionRequestThinkEnumeration value)?  level,}){
 final _that = this;
 switch (_that) {
-case GenerateChatCompletionRequestThinkEnumeration() when enumeration != null:
-return enumeration(_that);case _:
+case GenerateChatCompletionRequestThinkEnumeration() when level != null:
+return level(_that);case _:
   return null;
 
 }
@@ -3042,10 +3042,10 @@ return enumeration(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( GenerateChatCompletionRequestThinkEnum value)?  enumeration,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( GenerateChatCompletionRequestThinkEnum value)?  level,required TResult orElse(),}) {final _that = this;
 switch (_that) {
-case GenerateChatCompletionRequestThinkEnumeration() when enumeration != null:
-return enumeration(_that.value);case _:
+case GenerateChatCompletionRequestThinkEnumeration() when level != null:
+return level(_that.value);case _:
   return orElse();
 
 }
@@ -3063,10 +3063,10 @@ return enumeration(_that.value);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( GenerateChatCompletionRequestThinkEnum value)  enumeration,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( GenerateChatCompletionRequestThinkEnum value)  level,}) {final _that = this;
 switch (_that) {
 case GenerateChatCompletionRequestThinkEnumeration():
-return enumeration(_that.value);}
+return level(_that.value);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -3080,10 +3080,10 @@ return enumeration(_that.value);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( GenerateChatCompletionRequestThinkEnum value)?  enumeration,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( GenerateChatCompletionRequestThinkEnum value)?  level,}) {final _that = this;
 switch (_that) {
-case GenerateChatCompletionRequestThinkEnumeration() when enumeration != null:
-return enumeration(_that.value);case _:
+case GenerateChatCompletionRequestThinkEnumeration() when level != null:
+return level(_that.value);case _:
   return null;
 
 }
@@ -3122,7 +3122,7 @@ int get hashCode => Object.hash(runtimeType,value);
 
 @override
 String toString() {
-  return 'GenerateChatCompletionRequestThink.enumeration(value: $value)';
+  return 'GenerateChatCompletionRequestThink.level(value: $value)';
 }
 
 

--- a/packages/ollama_dart/oas/main.dart
+++ b/packages/ollama_dart/oas/main.dart
@@ -11,6 +11,9 @@ void main() async {
     package: 'Ollama',
     destination: 'lib/src/generated/',
     replace: true,
+    schemaOptions: const SchemaGeneratorOptions(
+      onSchemaUnionFactoryName: _onSchemaUnionFactoryName,
+    ),
     clientOptions: const ClientGeneratorOptions(
       enabled: true,
     ),
@@ -21,3 +24,20 @@ void main() async {
     ['run', 'build_runner', 'build', 'lib', '--delete-conflicting-outputs'],
   );
 }
+
+String? _onSchemaUnionFactoryName(
+  final String union,
+  final String unionSubclass,
+) => switch (unionSubclass) {
+  // Format field for chat completion
+  'GenerateChatCompletionRequestFormatEnumeration' => 'json',
+  'GenerateChatCompletionRequestFormatMapStringDynamic' => 'schema',
+  // Format field for completion
+  'GenerateCompletionRequestFormatEnumeration' => 'json',
+  'GenerateCompletionRequestFormatMapStringDynamic' => 'schema',
+  // Think field for chat completion
+  'GenerateChatCompletionRequestThinkEnumeration' => 'level',
+  // Think field for completion
+  'GenerateCompletionRequestThinkEnumeration' => 'level',
+  _ => null,
+};

--- a/packages/ollama_dart/oas/ollama-curated.yaml
+++ b/packages/ollama_dart/oas/ollama-curated.yaml
@@ -308,6 +308,7 @@ components:
           oneOf:
             - type: string
               enum: [json]
+              default: json
               description: Enable JSON mode
             - type: object
               additionalProperties: true
@@ -652,6 +653,7 @@ components:
           oneOf:
             - type: string
               enum: [json]
+              default: json
               description: Enable JSON mode
             - type: object
               additionalProperties: true

--- a/packages/ollama_dart/test/ollama_dart_chat_test.dart
+++ b/packages/ollama_dart/test/ollama_dart_chat_test.dart
@@ -106,7 +106,7 @@ void main() {
                     'NUMBERS: ',
               ),
             ],
-            format: GenerateChatCompletionRequestFormat.enumeration(
+            format: GenerateChatCompletionRequestFormat.json(
               GenerateChatCompletionRequestFormatEnum.json,
             ),
           ),

--- a/packages/ollama_dart/test/ollama_dart_completions_test.dart
+++ b/packages/ollama_dart/test/ollama_dart_completions_test.dart
@@ -106,7 +106,7 @@ void main() {
           request: const GenerateCompletionRequest(
             model: defaultModel,
             prompt: testPrompt,
-            format: GenerateCompletionRequestFormat.enumeration(
+            format: GenerateCompletionRequestFormat.json(
               GenerateCompletionRequestFormatEnum.json,
             ),
           ),


### PR DESCRIPTION
Relates to #740

Breaking Changes in Factory Names

**From Previous Version → Current Version**

1. GenerateChatCompletionRequestFormat (Chat Completion)

Before:
```dart
.enumeration(GenerateChatCompletionRequestFormatEnum value)
.mapStringDynamic(Map<String, dynamic> value)
```

After:
```dart
.json(GenerateChatCompletionRequestFormatEnum value)  // 
Still requires parameter
.schema(Map<String, dynamic> value)
```

2. GenerateCompletionRequestFormat (Completion)

Before:
```dart
.enumeration(GenerateCompletionRequestFormatEnum value)
.mapStringDynamic(Map<String, dynamic> value)
```
After:
```dart
.json(GenerateCompletionRequestFormatEnum value)  // Still 
requires parameter
.schema(Map<String, dynamic> value)
```

3. GenerateChatCompletionRequestThink (Chat Completion - 
Think)

Before:
```dart
.enumeration(GenerateChatCompletionRequestThinkEnum value)
```
After:
```dart
.level(GenerateChatCompletionRequestThinkEnum value)
```

4. GenerateCompletionRequestThink (Completion - Think)

Before:
```dart
.enumeration(GenerateCompletionRequestThinkEnum value)
```

After:
```dart
.level(GenerateCompletionRequestThinkEnum value)
```
