### PR TITLE
test(openai_dart): Use cheaper models in tests

### DIFF
--- a/packages/openai_dart/test/openai_client_assistants_test.dart
+++ b/packages/openai_dart/test/openai_client_assistants_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 // https://platform.openai.com/docs/assistants/overview
 void main() {
-  const defaultModel = 'gpt-4o';
+  const defaultModel = 'gpt-4o-mini';
 
   group(
     'OpenAI Assistants API tests',

--- a/packages/openai_dart/test/openai_client_chat_test.dart
+++ b/packages/openai_dart/test/openai_client_chat_test.dart
@@ -63,7 +63,7 @@ void main() {
 
     test('Test call chat completion API with stop sequence', () async {
       const request = CreateChatCompletionRequest(
-        model: ChatCompletionModel.model(ChatCompletionModels.gpt4o),
+        model: ChatCompletionModel.model(ChatCompletionModels.gpt5Nano),
         messages: [
           ChatCompletionMessage.developer(
             content: ChatCompletionDeveloperMessageContent.text(
@@ -91,7 +91,7 @@ void main() {
 
     test('Test call chat completions API with max tokens', () async {
       const request = CreateChatCompletionRequest(
-        model: ChatCompletionModel.model(ChatCompletionModels.gpt4o),
+        model: ChatCompletionModel.model(ChatCompletionModels.gpt5Nano),
         messages: [
           ChatCompletionMessage.developer(
             content: ChatCompletionDeveloperMessageContent.text(
@@ -112,7 +112,7 @@ void main() {
 
     test('Test call chat completions API with other parameters', () async {
       const request = CreateChatCompletionRequest(
-        model: ChatCompletionModel.model(ChatCompletionModels.gpt4o),
+        model: ChatCompletionModel.model(ChatCompletionModels.gpt5Nano),
         messages: [
           ChatCompletionMessage.developer(
             content: ChatCompletionDeveloperMessageContent.text(
@@ -621,7 +621,7 @@ class User {
 
 export default User;''';
       const request = CreateChatCompletionRequest(
-        model: ChatCompletionModel.model(ChatCompletionModels.gpt4o),
+        model: ChatCompletionModel.model(ChatCompletionModels.gpt5Nano),
         messages: [
           ChatCompletionMessage.user(
             content: ChatCompletionUserMessageContent.string(


### PR DESCRIPTION
## Summary
Replace expensive models with cheaper alternatives in tests for cost savings:

### Chat Tests (`openai_client_chat_test.dart`)
- `gpt-4o` → `gpt-5-nano` in 4 tests:
  - Stop sequence test
  - Max tokens test
  - Other parameters test  
  - Predicted outputs test

### Assistants Tests (`openai_client_assistants_test.dart`)
- `gpt-4o` → `gpt-4o-mini` as default model

## Cost Impact
| Model | Input | Output |
|-------|-------|--------|
| gpt-4o | $2.50/1M | $10.00/1M |
| gpt-4o-mini | $0.15/1M | $0.60/1M |
| gpt-5-nano | Cheapest tier | - |

**gpt-4o-mini is 16x cheaper than gpt-4o**

## Kept As-Is
- `gpt-4o-audio-preview` - Required for audio tests
- `gpt-4o-mini-search-preview` - Required for web search tests
- `gpt-3.5-turbo-instruct` - Legacy API, no alternative

## Test plan
- [x] Analyzer passes
- [ ] CI passes