### PR TITLE
fix(langchain_google): Remove ServiceAccountCredentials stub export

### DIFF
--- a/packages/langchain_google/lib/src/utils/auth/http_client_auth_provider_stub.dart
+++ b/packages/langchain_google/lib/src/utils/auth/http_client_auth_provider_stub.dart
@@ -3,18 +3,6 @@
 import 'package:googleai_dart/googleai_dart.dart' as g;
 import 'package:http/http.dart' as http;
 
-/// Stub credentials class for unsupported platforms.
-///
-/// This mimics the googleapis_auth ServiceAccountCredentials API to allow
-/// the code to compile on web/WASM platforms where dart:io is not available.
-class ServiceAccountCredentials {
-  /// Creates credentials from JSON.
-  ///
-  /// On unsupported platforms, this will throw [UnsupportedError] when
-  /// used with [HttpClientAuthProvider].
-  ServiceAccountCredentials.fromJson(Map<String, dynamic> json);
-}
-
 /// {@template http_client_auth_provider}
 /// Authentication provider that bridges googleapis_auth with googleai_dart.
 ///
@@ -27,7 +15,7 @@ class HttpClientAuthProvider implements g.AuthProvider {
   ///
   /// Throws [UnsupportedError] on web/WASM platforms.
   HttpClientAuthProvider({
-    required ServiceAccountCredentials credentials,
+    required Object credentials,
     required List<String> scopes,
     http.Client? httpClient,
   }) {


### PR DESCRIPTION
## Summary
- Remove the stub `ServiceAccountCredentials` class that was causing `ambiguous_import` analyzer errors when used alongside `googleapis_auth`

## Details
The stub file was exporting its own `ServiceAccountCredentials` class to allow the code to compile on web/WASM platforms. However, this caused ambiguous import errors in example and test files that also imported `googleapis_auth`.

The fix removes the stub class entirely:
- On IO platforms, users should import `ServiceAccountCredentials` directly from `googleapis_auth`
- On web platforms, `HttpClientAuthProvider` throws `UnsupportedError` anyway, so no credentials class is needed

## Test plan
- [x] Run `dart analyze packages/langchain_google` - no issues found