### PR TITLE
fix(openai_dart): Fix analyzer issues in tests

### DIFF
--- a/packages/openai_dart/test/completion_usage_test.dart
+++ b/packages/openai_dart/test/completion_usage_test.dart
@@ -143,8 +143,10 @@ void main() {
       expect(json['prompt_tokens'], 100);
       expect(json['total_tokens'], 150);
       expect(json['prompt_tokens_details'], isNotNull);
-      expect(json['prompt_tokens_details']['cached_tokens'], 80);
-      expect(json['prompt_tokens_details']['audio_tokens'], 20);
+      final promptDetails =
+          json['prompt_tokens_details'] as Map<String, dynamic>;
+      expect(promptDetails['cached_tokens'], 80);
+      expect(promptDetails['audio_tokens'], 20);
     });
   });
 }

--- a/packages/openai_dart/test/image_gen_stream_event_test.dart
+++ b/packages/openai_dart/test/image_gen_stream_event_test.dart
@@ -103,7 +103,8 @@ void main() {
       expect(json['index'], 0);
       expect(json.containsKey('partial_image'), isFalse);
       expect(json['image'], isNotNull);
-      expect(json['image']['b64_json'], 'base64complete...');
+      final image = json['image'] as Map<String, dynamic>;
+      expect(image['b64_json'], 'base64complete...');
     });
 
     test('deserializes with multiple partial images index', () {

--- a/packages/openai_dart/test/image_gen_usage_test.dart
+++ b/packages/openai_dart/test/image_gen_usage_test.dart
@@ -81,8 +81,10 @@ void main() {
       expect(json['total_tokens'], 1500);
       expect(json['input_tokens'], 1000);
       expect(json['output_tokens'], 500);
-      expect(json['input_tokens_details']['text_tokens'], 700);
-      expect(json['input_tokens_details']['image_tokens'], 300);
+      final inputDetails =
+          json['input_tokens_details'] as Map<String, dynamic>;
+      expect(inputDetails['text_tokens'], 700);
+      expect(inputDetails['image_tokens'], 300);
     });
   });
 
@@ -143,7 +145,7 @@ void main() {
     });
 
     test('deserializes without usage field (backward compatibility)', () {
-      final json = {'created': 1700000000, 'data': []};
+      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[]};
 
       final response = ImagesResponse.fromJson(json);
 
@@ -169,9 +171,10 @@ void main() {
       final json = response.toJson();
 
       expect(json['usage'], isNotNull);
-      expect(json['usage']['total_tokens'], 500);
-      expect(json['usage']['input_tokens'], 400);
-      expect(json['usage']['output_tokens'], 100);
+      final usage = json['usage'] as Map<String, dynamic>;
+      expect(usage['total_tokens'], 500);
+      expect(usage['input_tokens'], 400);
+      expect(usage['output_tokens'], 100);
     });
   });
 }

--- a/packages/openai_dart/test/images_response_test.dart
+++ b/packages/openai_dart/test/images_response_test.dart
@@ -46,7 +46,7 @@ void main() {
     });
 
     test('deserializes with opaque background', () {
-      final json = {'created': 1700000000, 'data': [], 'background': 'opaque'};
+      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'background': 'opaque'};
 
       final response = ImagesResponse.fromJson(json);
 
@@ -54,7 +54,7 @@ void main() {
     });
 
     test('deserializes with webp output format', () {
-      final json = {'created': 1700000000, 'data': [], 'output_format': 'webp'};
+      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'output_format': 'webp'};
 
       final response = ImagesResponse.fromJson(json);
 
@@ -62,7 +62,7 @@ void main() {
     });
 
     test('deserializes with jpeg output format', () {
-      final json = {'created': 1700000000, 'data': [], 'output_format': 'jpeg'};
+      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'output_format': 'jpeg'};
 
       final response = ImagesResponse.fromJson(json);
 
@@ -70,7 +70,7 @@ void main() {
     });
 
     test('deserializes with 1024x1536 size', () {
-      final json = {'created': 1700000000, 'data': [], 'size': '1024x1536'};
+      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'size': '1024x1536'};
 
       final response = ImagesResponse.fromJson(json);
 
@@ -78,7 +78,7 @@ void main() {
     });
 
     test('deserializes with 1536x1024 size', () {
-      final json = {'created': 1700000000, 'data': [], 'size': '1536x1024'};
+      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'size': '1536x1024'};
 
       final response = ImagesResponse.fromJson(json);
 
@@ -86,7 +86,7 @@ void main() {
     });
 
     test('deserializes with low quality', () {
-      final json = {'created': 1700000000, 'data': [], 'quality': 'low'};
+      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'quality': 'low'};
 
       final response = ImagesResponse.fromJson(json);
 
@@ -94,7 +94,7 @@ void main() {
     });
 
     test('deserializes with medium quality', () {
-      final json = {'created': 1700000000, 'data': [], 'quality': 'medium'};
+      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'quality': 'medium'};
 
       final response = ImagesResponse.fromJson(json);
 


### PR DESCRIPTION
## Summary
- Fix 16 analyzer issues in openai_dart tests

## Details
**8 `inference_failure_on_collection_literal` warnings:**
- Added explicit type annotations to empty List literals: `<Map<String, dynamic>>[]`

**8 `avoid_dynamic_calls` infos:**
- Cast dynamic map accesses to `Map<String, dynamic>` before accessing properties

## Files Modified
- `test/images_response_test.dart`
- `test/image_gen_usage_test.dart`
- `test/completion_usage_test.dart`
- `test/image_gen_stream_event_test.dart`

## Test plan
- [x] Run `dart analyze packages/openai_dart` - no issues found