### PR TITLE
fix(langchain): Fix analyzer issues in executor_test

### DIFF
--- a/packages/langchain/test/agents/executor_test.dart
+++ b/packages/langchain/test/agents/executor_test.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:langchain/langchain.dart';
-import 'package:langchain_core/tools.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -294,9 +293,11 @@ void main() {
       final intermediateSteps =
           result[AgentExecutor.intermediateStepsOutputKey] as List<AgentStep>;
       expect(intermediateSteps.first.observation, jsonEncode(nestedOutput));
-      final decoded = jsonDecode(intermediateSteps.first.observation);
+      final decoded =
+          jsonDecode(intermediateSteps.first.observation) as Map<String, dynamic>;
       expect(decoded['results'], hasLength(2));
-      expect(decoded['metadata']['total'], 2);
+      final metadata = decoded['metadata'] as Map<String, dynamic>;
+      expect(metadata['total'], 2);
     });
 
     test('should JSON-encode bool tool output', () async {


### PR DESCRIPTION
## Summary
- Fix 4 analyzer issues in langchain executor_test

## Details
**1 `unnecessary_import` info:**
- Removed `import 'package:langchain_core/tools.dart';` as all used elements are provided by `langchain.dart`

**3 `avoid_dynamic_calls` infos:**
- Cast `jsonDecode` result to `Map<String, dynamic>` before accessing properties

## Files Modified
- `test/agents/executor_test.dart`

## Test plan
- [x] Run `dart analyze packages/langchain` - no issues found