### PR TITLE
fix(langchain_firebase): Handle malformedFunctionCall finish reason

### DIFF
--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
@@ -192,6 +192,7 @@ extension GenerateContentResponseMapper on f.GenerateContentResponse {
         f.FinishReason.safety => FinishReason.contentFilter,
         f.FinishReason.recitation => FinishReason.recitation,
         f.FinishReason.other => FinishReason.unspecified,
+        f.FinishReason.malformedFunctionCall => FinishReason.unspecified,
         null => FinishReason.unspecified,
       };
 }


### PR DESCRIPTION
## Summary
- Add missing case for `FinishReason.malformedFunctionCall` in the switch expression
- Maps the new finish reason to `FinishReason.unspecified` to fix non-exhaustive switch compilation error

## Test plan
- [x] Verified with `dart analyze` that there are no compilation errors