### PR TITLE
feat: Add listModels() API for LLMs and Embeddings

### DIFF
--- a/packages/langchain/lib/src/agents/executor.dart
+++ b/packages/langchain/lib/src/agents/executor.dart
@@ -202,7 +202,9 @@ class AgentExecutor extends BaseChain {
       if (tool != null) {
         final toolInput = tool.getInputFromJson(agentAction.toolInput);
         final toolOutput = await tool.invoke(toolInput);
-        observation = toolOutput is String ? toolOutput : jsonEncode(toolOutput);
+        observation = toolOutput is String
+            ? toolOutput
+            : jsonEncode(toolOutput);
       } else {
         observation =
             '${agentAction.tool} is not a valid tool, try another one.';

--- a/packages/langchain/lib/src/embeddings/cache.dart
+++ b/packages/langchain/lib/src/embeddings/cache.dart
@@ -27,7 +27,7 @@ import '../stores/encoder_backed.dart';
 /// The [CacheBackedEmbeddings.embedQuery] method does not support caching at
 /// the moment.
 /// {@endtemplate}
-class CacheBackedEmbeddings implements Embeddings {
+class CacheBackedEmbeddings extends Embeddings {
   /// {@macro cache_backed_embeddings}
   const CacheBackedEmbeddings({
     required this.underlyingEmbeddings,

--- a/packages/langchain/test/agents/executor_test.dart
+++ b/packages/langchain/test/agents/executor_test.dart
@@ -189,10 +189,10 @@ void main() {
       final intermediateSteps =
           result[AgentExecutor.intermediateStepsOutputKey] as List<AgentStep>;
       expect(intermediateSteps.first.observation, jsonEncode(mapOutput));
-      expect(
-        jsonDecode(intermediateSteps.first.observation),
-        {'status': 'ok', 'count': 42},
-      );
+      expect(jsonDecode(intermediateSteps.first.observation), {
+        'status': 'ok',
+        'count': 42,
+      });
     });
 
     test('should JSON-encode List tool output', () async {
@@ -223,10 +223,11 @@ void main() {
       final intermediateSteps =
           result[AgentExecutor.intermediateStepsOutputKey] as List<AgentStep>;
       expect(intermediateSteps.first.observation, jsonEncode(listOutput));
-      expect(
-        jsonDecode(intermediateSteps.first.observation),
-        ['item1', 'item2', 'item3'],
-      );
+      expect(jsonDecode(intermediateSteps.first.observation), [
+        'item1',
+        'item2',
+        'item3',
+      ]);
     });
 
     test('should JSON-encode int tool output', () async {
@@ -266,8 +267,7 @@ void main() {
         ],
         'metadata': {'total': 2, 'page': 1},
       };
-      final tool =
-          _GenericMockTool<Map<String, dynamic>>(output: nestedOutput);
+      final tool = _GenericMockTool<Map<String, dynamic>>(output: nestedOutput);
       final agent = _SequentialActionMockAgent(
         tools: [tool],
         actionSequence: [
@@ -294,7 +294,8 @@ void main() {
           result[AgentExecutor.intermediateStepsOutputKey] as List<AgentStep>;
       expect(intermediateSteps.first.observation, jsonEncode(nestedOutput));
       final decoded =
-          jsonDecode(intermediateSteps.first.observation) as Map<String, dynamic>;
+          jsonDecode(intermediateSteps.first.observation)
+              as Map<String, dynamic>;
       expect(decoded['results'], hasLength(2));
       final metadata = decoded['metadata'] as Map<String, dynamic>;
       expect(metadata['total'], 2);
@@ -428,19 +429,17 @@ final class _SequentialActionMockAgent extends BaseActionAgent {
 /// Used to test tool output serialization in AgentExecutor.
 final class _GenericMockTool<T extends Object>
     extends Tool<String, ToolOptions, T> {
-  _GenericMockTool({
-    required T output,
-    super.name = 'generic_tool',
-  })  : _output = output,
-        super(
-          description: 'A generic mock tool for testing',
-          inputJsonSchema: const {
-            'type': 'object',
-            'properties': {
-              'input': {'type': 'string'},
-            },
+  _GenericMockTool({required T output, super.name = 'generic_tool'})
+    : _output = output,
+      super(
+        description: 'A generic mock tool for testing',
+        inputJsonSchema: const {
+          'type': 'object',
+          'properties': {
+            'input': {'type': 'string'},
           },
-        );
+        },
+      );
 
   final T _output;
 

--- a/packages/langchain/test/chains/retrieval_qa_test.dart
+++ b/packages/langchain/test/chains/retrieval_qa_test.dart
@@ -77,7 +77,7 @@ Helpful Answer:''';
   });
 }
 
-class _FakeEmbeddings implements Embeddings {
+class _FakeEmbeddings extends Embeddings {
   _FakeEmbeddings();
 
   @override

--- a/packages/langchain/test/memory/vector_store_test.dart
+++ b/packages/langchain/test/memory/vector_store_test.dart
@@ -57,7 +57,7 @@ void main() {
   });
 }
 
-class _FakeEmbeddings implements Embeddings {
+class _FakeEmbeddings extends Embeddings {
   @override
   Future<List<List<double>>> embedDocuments(
     final List<Document> documents,

--- a/packages/langchain/test/vector_stores/memory_test.dart
+++ b/packages/langchain/test/vector_stores/memory_test.dart
@@ -193,7 +193,7 @@ void main() {
   });
 }
 
-class _FakeEmbeddings implements Embeddings {
+class _FakeEmbeddings extends Embeddings {
   const _FakeEmbeddings();
 
   @override

--- a/packages/langchain_core/lib/src/embeddings/base.dart
+++ b/packages/langchain_core/lib/src/embeddings/base.dart
@@ -1,9 +1,10 @@
 import '../documents/document.dart';
+import '../language_models/types.dart';
 
 /// {@template embeddings}
 /// Interface for embedding models.
 /// {@endtemplate}
-abstract interface class Embeddings {
+abstract class Embeddings {
   /// {@macro embeddings}
   const Embeddings();
 
@@ -12,4 +13,27 @@ abstract interface class Embeddings {
 
   /// Embed query text.
   Future<List<double>> embedQuery(final String query);
+
+  /// Returns a list of available embedding models from this provider.
+  ///
+  /// This method allows you to programmatically discover which embedding
+  /// models are available from the provider. The returned list contains
+  /// [ModelInfo] objects with metadata about each model.
+  ///
+  /// By default, this returns an empty list. Providers that support
+  /// model listing will override this method to return the actual
+  /// available models.
+  ///
+  /// Example:
+  /// ```dart
+  /// final embeddings = OpenAIEmbeddings(apiKey: '...');
+  /// final models = await embeddings.listModels();
+  /// for (final model in models) {
+  ///   print('${model.id} - ${model.displayName ?? ""}');
+  /// }
+  /// ```
+  ///
+  /// Note: Not all providers support model listing. For providers that
+  /// don't support this feature, this method returns an empty list.
+  Future<List<ModelInfo>> listModels() async => [];
 }

--- a/packages/langchain_core/lib/src/embeddings/fake.dart
+++ b/packages/langchain_core/lib/src/embeddings/fake.dart
@@ -13,7 +13,7 @@ import 'base.dart';
 /// have the same embedding vector). You can change this behavior by setting
 /// [deterministic] to false.
 /// {@endtemplate}
-class FakeEmbeddings implements Embeddings {
+class FakeEmbeddings extends Embeddings {
   /// {@macro fake_embeddings}
   FakeEmbeddings({this.size = 10, this.deterministic = true});
 

--- a/packages/langchain_core/lib/src/language_models/base.dart
+++ b/packages/langchain_core/lib/src/language_models/base.dart
@@ -55,4 +55,27 @@ abstract class BaseLanguageModel<
 
   @override
   String toString() => modelType;
+
+  /// Returns a list of available models from this provider.
+  ///
+  /// This method allows you to programmatically discover which models
+  /// are available from the provider. The returned list contains
+  /// [ModelInfo] objects with metadata about each model.
+  ///
+  /// By default, this returns an empty list. Providers that support
+  /// model listing will override this method to return the actual
+  /// available models.
+  ///
+  /// Example:
+  /// ```dart
+  /// final chatModel = ChatOpenAI(apiKey: '...');
+  /// final models = await chatModel.listModels();
+  /// for (final model in models) {
+  ///   print('${model.id} - ${model.displayName ?? ""}');
+  /// }
+  /// ```
+  ///
+  /// Note: Not all providers support model listing. For providers that
+  /// don't support this feature, this method returns an empty list.
+  Future<List<ModelInfo>> listModels() async => [];
 }

--- a/packages/langchain_core/lib/src/language_models/types.dart
+++ b/packages/langchain_core/lib/src/language_models/types.dart
@@ -211,3 +211,104 @@ enum FinishReason {
   /// The finish reason is unspecified.
   unspecified,
 }
+
+/// {@template model_info}
+/// Information about an available model from a provider.
+///
+/// This class provides a standardized way to represent model metadata
+/// across different providers. Not all providers supply all fields.
+///
+/// Example:
+/// ```dart
+/// final chatModel = ChatOpenAI(apiKey: '...');
+/// final models = await chatModel.listModels();
+/// for (final model in models) {
+///   print('${model.id} - ${model.displayName ?? ""}');
+/// }
+/// ```
+/// {@endtemplate}
+@immutable
+class ModelInfo {
+  /// {@macro model_info}
+  const ModelInfo({
+    required this.id,
+    this.displayName,
+    this.description,
+    this.ownedBy,
+    this.created,
+    this.inputTokenLimit,
+    this.outputTokenLimit,
+  });
+
+  /// The model identifier (e.g., "gpt-4", "llama3.2", "claude-3-sonnet").
+  ///
+  /// This is the value you would pass to the model's `options` when invoking.
+  final String id;
+
+  /// Human-readable display name for the model.
+  ///
+  /// Not all providers supply this field.
+  final String? displayName;
+
+  /// Description of the model's capabilities or purpose.
+  ///
+  /// Not all providers supply this field.
+  final String? description;
+
+  /// The organization or owner of the model.
+  ///
+  /// For example: "openai", "system", "user".
+  final String? ownedBy;
+
+  /// Unix timestamp (in seconds) when the model was created.
+  ///
+  /// Not all providers supply this field.
+  final int? created;
+
+  /// Maximum number of input tokens the model can process.
+  ///
+  /// Not all providers supply this field.
+  final int? inputTokenLimit;
+
+  /// Maximum number of output tokens the model can generate.
+  ///
+  /// Not all providers supply this field.
+  final int? outputTokenLimit;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelInfo &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          displayName == other.displayName &&
+          description == other.description &&
+          ownedBy == other.ownedBy &&
+          created == other.created &&
+          inputTokenLimit == other.inputTokenLimit &&
+          outputTokenLimit == other.outputTokenLimit;
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      displayName.hashCode ^
+      description.hashCode ^
+      ownedBy.hashCode ^
+      created.hashCode ^
+      inputTokenLimit.hashCode ^
+      outputTokenLimit.hashCode;
+
+  @override
+  String toString() {
+    return '''
+ModelInfo{
+  id: $id,
+  displayName: $displayName,
+  description: $description,
+  ownedBy: $ownedBy,
+  created: $created,
+  inputTokenLimit: $inputTokenLimit,
+  outputTokenLimit: $outputTokenLimit,
+}''';
+  }
+}

--- a/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/chat_google_generative_ai.dart
@@ -1,6 +1,7 @@
 import 'package:googleai_dart/googleai_dart.dart' as g;
 import 'package:http/http.dart' as http;
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:uuid/uuid.dart';
 
@@ -356,5 +357,70 @@ class ChatGoogleGenerativeAI
   /// Gets the model to use for the request.
   String _getModel(final ChatGoogleGenerativeAIOptions? options) {
     return options?.model ?? defaultOptions.model ?? defaultModel;
+  }
+
+  /// {@template chat_google_generative_ai_list_models}
+  /// Returns a list of available chat models from Google AI.
+  ///
+  /// This method fetches all models from the Google AI API and filters them
+  /// to only return models that support content generation (chat-capable models).
+  ///
+  /// The returned [ModelInfo] includes rich metadata such as:
+  /// - Token limits (input and output)
+  /// - Description
+  /// - Display name
+  ///
+  /// Example:
+  /// ```dart
+  /// final chatModel = ChatGoogleGenerativeAI(apiKey: '...');
+  /// final models = await chatModel.listModels();
+  /// for (final model in models) {
+  ///   print('${model.id} - ${model.displayName}');
+  ///   print('  Input limit: ${model.inputTokenLimit}');
+  ///   print('  Output limit: ${model.outputTokenLimit}');
+  /// }
+  /// ```
+  /// {@endtemplate}
+  @override
+  Future<List<ModelInfo>> listModels() async {
+    final models = <g.Model>[];
+    String? pageToken;
+
+    // Paginate through all models
+    do {
+      final response = await _googleAiClient.models.list(pageToken: pageToken);
+      models.addAll(response.models);
+      pageToken = response.nextPageToken;
+    } while (pageToken != null);
+
+    // Filter to only chat-capable models (those supporting generateContent)
+    return models
+        .where(_isChatModel)
+        .map(
+          (final m) => ModelInfo(
+            id: _extractModelId(m.name),
+            displayName: m.displayName,
+            description: m.description,
+            inputTokenLimit: m.inputTokenLimit,
+            outputTokenLimit: m.outputTokenLimit,
+          ),
+        )
+        .toList();
+  }
+
+  /// Returns true if the model supports chat (generateContent).
+  static bool _isChatModel(final g.Model model) {
+    return model.supportedGenerationMethods?.contains('generateContent') ??
+        false;
+  }
+
+  /// Extracts the model ID from the full resource name.
+  /// e.g., "models/gemini-1.5-flash" -> "gemini-1.5-flash"
+  static String _extractModelId(final String name) {
+    const prefix = 'models/';
+    if (name.startsWith(prefix)) {
+      return name.substring(prefix.length);
+    }
+    return name;
   }
 }

--- a/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
@@ -1,5 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:mistralai_dart/mistralai_dart.dart';
@@ -252,5 +253,31 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
   @override
   void close() {
     _client.endSession();
+  }
+
+  /// {@template chat_mistralai_list_models}
+  /// Returns a list of available chat models from Mistral AI.
+  ///
+  /// This method fetches all models from the Mistral AI API.
+  /// Mistral AI models are primarily chat models.
+  ///
+  /// Example:
+  /// ```dart
+  /// final chatModel = ChatMistralAI(apiKey: '...');
+  /// final models = await chatModel.listModels();
+  /// for (final model in models) {
+  ///   print('${model.id} - owned by ${model.ownedBy ?? "unknown"}');
+  /// }
+  /// ```
+  /// {@endtemplate}
+  @override
+  Future<List<ModelInfo>> listModels() async {
+    final response = await _client.listModels();
+    return response.data
+        .map(
+          (final m) =>
+              ModelInfo(id: m.id, ownedBy: m.ownedBy, created: m.created),
+        )
+        .toList();
   }
 }

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama/chat_ollama.dart
@@ -1,8 +1,9 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_tiktoken/langchain_tiktoken.dart';
-import 'package:ollama_dart/ollama_dart.dart';
+import 'package:ollama_dart/ollama_dart.dart' hide ModelInfo;
 import 'package:uuid/uuid.dart';
 
 import 'mappers.dart';
@@ -235,5 +236,29 @@ class ChatOllama extends BaseChatModel<ChatOllamaOptions> {
   @override
   void close() {
     _client.endSession();
+  }
+
+  /// {@template chat_ollama_list_models}
+  /// Returns a list of available models from the local Ollama instance.
+  ///
+  /// This method fetches all locally available models from the Ollama API.
+  /// All Ollama models support chat, so no filtering is applied.
+  ///
+  /// Example:
+  /// ```dart
+  /// final chatModel = ChatOllama();
+  /// final models = await chatModel.listModels();
+  /// for (final model in models) {
+  ///   print('${model.id}');
+  /// }
+  /// ```
+  /// {@endtemplate}
+  @override
+  Future<List<ModelInfo>> listModels() async {
+    final response = await _client.listModels();
+    return (response.models ?? [])
+        .where((final m) => m.model != null)
+        .map((final m) => ModelInfo(id: m.model!, ownedBy: m.details?.family))
+        .toList();
   }
 }

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -1,8 +1,9 @@
 import 'package:http/http.dart' as http;
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/llms.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_tiktoken/langchain_tiktoken.dart';
-import 'package:ollama_dart/ollama_dart.dart';
+import 'package:ollama_dart/ollama_dart.dart' hide ModelInfo;
 import 'package:uuid/uuid.dart';
 
 import 'mappers.dart';
@@ -280,6 +281,27 @@ class Ollama extends BaseLLM<OllamaOptions> {
   }) async {
     final encoding = getEncoding(this.encoding);
     return encoding.encode(promptValue.toString());
+  }
+
+  /// {@template ollama_llm_list_models}
+  /// Returns a list of available models from the local Ollama server.
+  ///
+  /// Example:
+  /// ```dart
+  /// final llm = Ollama();
+  /// final models = await llm.listModels();
+  /// for (final model in models) {
+  ///   print('${model.id}');
+  /// }
+  /// ```
+  /// {@endtemplate}
+  @override
+  Future<List<ModelInfo>> listModels() async {
+    final response = await _client.listModels();
+    return (response.models ?? [])
+        .where((final m) => m.model != null)
+        .map((final m) => ModelInfo(id: m.model!, ownedBy: m.details?.family))
+        .toList();
   }
 
   @override

--- a/packages/langchain_openai/lib/src/embeddings/openai.dart
+++ b/packages/langchain_openai/lib/src/embeddings/openai.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:langchain_core/documents.dart';
 import 'package:langchain_core/embeddings.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/utils.dart';
 import 'package:openai_dart/openai_dart.dart';
 
@@ -103,7 +104,7 @@ import 'package:openai_dart/openai_dart.dart';
 /// To use a SOCKS5 proxy, you can use the
 /// [`socks5_proxy`](https://pub.dev/packages/socks5_proxy) package and a
 /// custom `http.Client`.
-class OpenAIEmbeddings implements Embeddings {
+class OpenAIEmbeddings extends Embeddings {
   /// Create a new [OpenAIEmbeddings] instance.
   ///
   /// Main configuration options:
@@ -217,6 +218,39 @@ class OpenAIEmbeddings implements Embeddings {
       ),
     );
     return data.data.first.embeddingVector;
+  }
+
+  /// {@template openai_embeddings_list_models}
+  /// Returns a list of available embedding models from the OpenAI API.
+  ///
+  /// This method filters models to return only those suitable for embeddings
+  /// (models with IDs starting with `text-embedding-`).
+  ///
+  /// Example:
+  /// ```dart
+  /// final embeddings = OpenAIEmbeddings(apiKey: '...');
+  /// final models = await embeddings.listModels();
+  /// for (final model in models) {
+  ///   print('${model.id} - owned by ${model.ownedBy ?? "unknown"}');
+  /// }
+  /// ```
+  /// {@endtemplate}
+  @override
+  Future<List<ModelInfo>> listModels() async {
+    final response = await _client.listModels();
+    return response.data
+        .where(_isEmbeddingModel)
+        .map(
+          (final m) =>
+              ModelInfo(id: m.id, ownedBy: m.ownedBy, created: m.created),
+        )
+        .toList();
+  }
+
+  /// Returns true if the model is an embedding model.
+  static bool _isEmbeddingModel(final Model model) {
+    final id = model.id.toLowerCase();
+    return id.startsWith('text-embedding-');
   }
 
   /// Closes the client and cleans up any resources associated with it.


### PR DESCRIPTION
## Summary

Expands the `listModels()` API to support **Chat Models**, **LLMs**, and **Embeddings**, allowing users to programmatically discover available models from each provider.

Closes #371

## Changes

### Core (langchain_core)
- Added `listModels()` to `BaseLanguageModel` (inherited by Chat Models and LLMs)
- Added `listModels()` to `Embeddings` abstract class
- `ModelInfo` defined in `language_models/types.dart`

### LLM Implementations
| Class | Filter |
|-------|--------|
| `OpenAI` | `gpt-3.5-turbo-instruct`, `davinci-*`, `babbage-*`, `curie-*` |
| `Ollama` | All models |
| `VertexAI` | `generateContent` capable |

### Embeddings Implementations
| Class | Filter |
|-------|--------|
| `OpenAIEmbeddings` | `text-embedding-*` |
| `OllamaEmbeddings` | All models |
| `GoogleGenerativeAIEmbeddings` | `embedContent` capable |
| `VertexAIEmbeddings` | `embedContent` capable |
| `MistralAIEmbeddings` | Contains `embed` |

### Bug Fixes
- Fixed `ChatOpenAI._isChatModel()` to exclude instruct models (e.g., `gpt-3.5-turbo-instruct`)
- Changed Embeddings implementations from `implements` to `extends` to inherit default `listModels()`

## Usage Examples

```dart
// Chat models
final chat = ChatOpenAI(apiKey: '...');
final chatModels = await chat.listModels();
// Returns: gpt-4, gpt-4o, o1-*, etc.

// LLMs
final llm = OpenAI(apiKey: '...');
final llmModels = await llm.listModels();
// Returns: gpt-3.5-turbo-instruct, davinci-*, etc.

// Embeddings
final embeddings = OpenAIEmbeddings(apiKey: '...');
final embeddingModels = await embeddings.listModels();
// Returns: text-embedding-3-small, text-embedding-3-large, etc.
```

## Test plan
- [x] All analyzer checks pass
- [x] Existing tests pass
- [ ] Manual testing with real API keys