### PR TITLE
feat(googleai_dart): Add FileSearchStores resource

### DIFF
--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -49,13 +49,21 @@ export 'src/models/embeddings/embed_content_request.dart';
 export 'src/models/embeddings/embed_content_response.dart';
 export 'src/models/embeddings/task_type.dart';
 // Models - Files API
+export 'src/models/files/chunking_config.dart';
 export 'src/models/files/file.dart';
+export 'src/models/files/file_search_custom_metadata.dart';
+export 'src/models/files/file_search_store.dart';
 export 'src/models/files/file_state.dart';
 export 'src/models/files/generated_file.dart';
+export 'src/models/files/import_file_request.dart';
+export 'src/models/files/import_file_response.dart';
+export 'src/models/files/list_file_search_stores_response.dart';
 export 'src/models/files/list_files_response.dart';
 export 'src/models/files/list_generated_files_response.dart';
-// Models - Files
+export 'src/models/files/upload_to_file_search_store_request.dart';
+export 'src/models/files/upload_to_file_search_store_response.dart';
 export 'src/models/files/video_metadata.dart';
+export 'src/models/files/white_space_config.dart';
 // Models - Generation
 export 'src/models/generation/answer_style.dart';
 export 'src/models/generation/block_reason.dart';

--- a/packages/googleai_dart/lib/src/client/googleai_client.dart
+++ b/packages/googleai_dart/lib/src/client/googleai_client.dart
@@ -9,6 +9,7 @@ import '../models/models/operation.dart';
 import '../resources/batches_resource.dart';
 import '../resources/cached_contents_resource.dart';
 import '../resources/corpora_resource.dart';
+import '../resources/file_search_stores/file_search_stores_resource.dart';
 import '../resources/files/files_resource.dart';
 import '../resources/generated_files_resource.dart';
 import '../resources/models_resource.dart';
@@ -33,6 +34,7 @@ import 'retry_wrapper.dart';
 /// - [cachedContents] - Context caching for cost/latency optimization
 /// - [batches] - Batch operation management
 /// - [corpora] - Corpus management for semantic retrieval
+/// - [fileSearchStores] - File search store management for file-based retrieval
 ///
 /// ## Example Usage
 ///
@@ -100,6 +102,9 @@ class GoogleAIClient {
   /// Resource for corpora API (semantic retrieval).
   late final CorporaResource corpora;
 
+  /// Resource for file search stores API (file-based retrieval).
+  late final FileSearchStoresResource fileSearchStores;
+
   /// Creates a [GoogleAIClient].
   ///
   /// Optionally accepts custom [config] for authentication and endpoint settings,
@@ -165,6 +170,13 @@ class GoogleAIClient {
     );
 
     corpora = CorporaResource(
+      config: this.config,
+      httpClient: _httpClient,
+      interceptorChain: _interceptorChain,
+      requestBuilder: _requestBuilder,
+    );
+
+    fileSearchStores = FileSearchStoresResource(
       config: this.config,
       httpClient: _httpClient,
       interceptorChain: _interceptorChain,

--- a/packages/googleai_dart/lib/src/models/files/chunking_config.dart
+++ b/packages/googleai_dart/lib/src/models/files/chunking_config.dart
@@ -1,0 +1,38 @@
+import '../copy_with_sentinel.dart';
+import 'white_space_config.dart';
+
+/// Parameters for telling the service how to chunk the file.
+class ChunkingConfig {
+  /// White space chunking configuration.
+  final WhiteSpaceConfig? whiteSpaceConfig;
+
+  /// Creates a [ChunkingConfig].
+  const ChunkingConfig({this.whiteSpaceConfig});
+
+  /// Creates a [ChunkingConfig] from JSON.
+  factory ChunkingConfig.fromJson(Map<String, dynamic> json) => ChunkingConfig(
+    whiteSpaceConfig: json['whiteSpaceConfig'] != null
+        ? WhiteSpaceConfig.fromJson(
+            json['whiteSpaceConfig'] as Map<String, dynamic>,
+          )
+        : null,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (whiteSpaceConfig != null)
+      'whiteSpaceConfig': whiteSpaceConfig!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  ChunkingConfig copyWith({Object? whiteSpaceConfig = unsetCopyWithValue}) {
+    return ChunkingConfig(
+      whiteSpaceConfig: whiteSpaceConfig == unsetCopyWithValue
+          ? this.whiteSpaceConfig
+          : whiteSpaceConfig as WhiteSpaceConfig?,
+    );
+  }
+
+  @override
+  String toString() => 'ChunkingConfig(whiteSpaceConfig: $whiteSpaceConfig)';
+}

--- a/packages/googleai_dart/lib/src/models/files/file_search_custom_metadata.dart
+++ b/packages/googleai_dart/lib/src/models/files/file_search_custom_metadata.dart
@@ -1,0 +1,72 @@
+import '../copy_with_sentinel.dart';
+
+/// User-provided custom metadata stored as key-value pairs for file search.
+class FileSearchCustomMetadata {
+  /// Required. The key of the metadata to store.
+  final String key;
+
+  /// The string value of the metadata to store.
+  final String? stringValue;
+
+  /// The numeric value of the metadata to store.
+  final double? numericValue;
+
+  /// The StringList value of the metadata to store.
+  final List<String>? stringListValue;
+
+  /// Creates a [FileSearchCustomMetadata].
+  const FileSearchCustomMetadata({
+    required this.key,
+    this.stringValue,
+    this.numericValue,
+    this.stringListValue,
+  });
+
+  /// Creates a [FileSearchCustomMetadata] from JSON.
+  factory FileSearchCustomMetadata.fromJson(
+    Map<String, dynamic> json,
+  ) => FileSearchCustomMetadata(
+    key: json['key'] as String,
+    stringValue: json['stringValue'] as String?,
+    numericValue: (json['numericValue'] as num?)?.toDouble(),
+    stringListValue:
+        (json['stringListValue'] as Map<String, dynamic>?)?['values'] != null
+        ? ((json['stringListValue'] as Map<String, dynamic>)['values'] as List)
+              .map((e) => e as String)
+              .toList()
+        : null,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'key': key,
+    if (stringValue != null) 'stringValue': stringValue,
+    if (numericValue != null) 'numericValue': numericValue,
+    if (stringListValue != null) 'stringListValue': {'values': stringListValue},
+  };
+
+  /// Creates a copy with replaced values.
+  FileSearchCustomMetadata copyWith({
+    String? key,
+    Object? stringValue = unsetCopyWithValue,
+    Object? numericValue = unsetCopyWithValue,
+    Object? stringListValue = unsetCopyWithValue,
+  }) {
+    return FileSearchCustomMetadata(
+      key: key ?? this.key,
+      stringValue: stringValue == unsetCopyWithValue
+          ? this.stringValue
+          : stringValue as String?,
+      numericValue: numericValue == unsetCopyWithValue
+          ? this.numericValue
+          : numericValue as double?,
+      stringListValue: stringListValue == unsetCopyWithValue
+          ? this.stringListValue
+          : stringListValue as List<String>?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'FileSearchCustomMetadata(key: $key, stringValue: $stringValue, numericValue: $numericValue, stringListValue: $stringListValue)';
+}

--- a/packages/googleai_dart/lib/src/models/files/file_search_store.dart
+++ b/packages/googleai_dart/lib/src/models/files/file_search_store.dart
@@ -1,0 +1,126 @@
+import '../copy_with_sentinel.dart';
+
+/// A `FileSearchStore` is a collection of `Document`s.
+class FileSearchStore {
+  /// Output only. Immutable. The `FileSearchStore` resource name.
+  ///
+  /// It is an ID (name excluding the "fileSearchStores/" prefix) that can
+  /// contain up to 40 characters that are lowercase alphanumeric or dashes (-).
+  ///
+  /// Example: `fileSearchStores/my-awesome-file-search-store-123a456b789c`
+  final String? name;
+
+  /// Optional. The human-readable display name for the `FileSearchStore`.
+  ///
+  /// The display name must be no more than 512 characters in length,
+  /// including spaces. Example: "Docs on Semantic Retriever"
+  final String? displayName;
+
+  /// Output only. The Timestamp of when the `FileSearchStore` was created.
+  final DateTime? createTime;
+
+  /// Output only. The Timestamp of when the `FileSearchStore` was last updated.
+  final DateTime? updateTime;
+
+  /// Output only. The number of documents in the `FileSearchStore` that are
+  /// active and ready for retrieval.
+  final String? activeDocumentsCount;
+
+  /// Output only. The number of documents in the `FileSearchStore` that are
+  /// being processed.
+  final String? pendingDocumentsCount;
+
+  /// Output only. The number of documents in the `FileSearchStore` that have
+  /// failed processing.
+  final String? failedDocumentsCount;
+
+  /// Output only. The size of raw bytes ingested into the `FileSearchStore`.
+  ///
+  /// This is the total size of all the documents in the `FileSearchStore`.
+  final String? sizeBytes;
+
+  /// Creates a [FileSearchStore].
+  const FileSearchStore({
+    this.name,
+    this.displayName,
+    this.createTime,
+    this.updateTime,
+    this.activeDocumentsCount,
+    this.pendingDocumentsCount,
+    this.failedDocumentsCount,
+    this.sizeBytes,
+  });
+
+  /// Creates a [FileSearchStore] from JSON.
+  factory FileSearchStore.fromJson(Map<String, dynamic> json) =>
+      FileSearchStore(
+        name: json['name'] as String?,
+        displayName: json['displayName'] as String?,
+        createTime: json['createTime'] != null
+            ? DateTime.parse(json['createTime'] as String)
+            : null,
+        updateTime: json['updateTime'] != null
+            ? DateTime.parse(json['updateTime'] as String)
+            : null,
+        activeDocumentsCount: json['activeDocumentsCount'] as String?,
+        pendingDocumentsCount: json['pendingDocumentsCount'] as String?,
+        failedDocumentsCount: json['failedDocumentsCount'] as String?,
+        sizeBytes: json['sizeBytes'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (name != null) 'name': name,
+    if (displayName != null) 'displayName': displayName,
+    if (createTime != null) 'createTime': createTime!.toIso8601String(),
+    if (updateTime != null) 'updateTime': updateTime!.toIso8601String(),
+    if (activeDocumentsCount != null)
+      'activeDocumentsCount': activeDocumentsCount,
+    if (pendingDocumentsCount != null)
+      'pendingDocumentsCount': pendingDocumentsCount,
+    if (failedDocumentsCount != null)
+      'failedDocumentsCount': failedDocumentsCount,
+    if (sizeBytes != null) 'sizeBytes': sizeBytes,
+  };
+
+  /// Creates a copy with replaced values.
+  FileSearchStore copyWith({
+    Object? name = unsetCopyWithValue,
+    Object? displayName = unsetCopyWithValue,
+    Object? createTime = unsetCopyWithValue,
+    Object? updateTime = unsetCopyWithValue,
+    Object? activeDocumentsCount = unsetCopyWithValue,
+    Object? pendingDocumentsCount = unsetCopyWithValue,
+    Object? failedDocumentsCount = unsetCopyWithValue,
+    Object? sizeBytes = unsetCopyWithValue,
+  }) {
+    return FileSearchStore(
+      name: name == unsetCopyWithValue ? this.name : name as String?,
+      displayName: displayName == unsetCopyWithValue
+          ? this.displayName
+          : displayName as String?,
+      createTime: createTime == unsetCopyWithValue
+          ? this.createTime
+          : createTime as DateTime?,
+      updateTime: updateTime == unsetCopyWithValue
+          ? this.updateTime
+          : updateTime as DateTime?,
+      activeDocumentsCount: activeDocumentsCount == unsetCopyWithValue
+          ? this.activeDocumentsCount
+          : activeDocumentsCount as String?,
+      pendingDocumentsCount: pendingDocumentsCount == unsetCopyWithValue
+          ? this.pendingDocumentsCount
+          : pendingDocumentsCount as String?,
+      failedDocumentsCount: failedDocumentsCount == unsetCopyWithValue
+          ? this.failedDocumentsCount
+          : failedDocumentsCount as String?,
+      sizeBytes: sizeBytes == unsetCopyWithValue
+          ? this.sizeBytes
+          : sizeBytes as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'FileSearchStore(name: $name, displayName: $displayName, createTime: $createTime, updateTime: $updateTime, activeDocumentsCount: $activeDocumentsCount, pendingDocumentsCount: $pendingDocumentsCount, failedDocumentsCount: $failedDocumentsCount, sizeBytes: $sizeBytes)';
+}

--- a/packages/googleai_dart/lib/src/models/files/import_file_request.dart
+++ b/packages/googleai_dart/lib/src/models/files/import_file_request.dart
@@ -1,0 +1,72 @@
+import '../copy_with_sentinel.dart';
+import 'chunking_config.dart';
+import 'file_search_custom_metadata.dart';
+
+/// Request for `ImportFile` to import a File API file with a `FileSearchStore`.
+class ImportFileRequest {
+  /// Required. The name of the `File` to import.
+  ///
+  /// Example: `files/abc-123`
+  final String fileName;
+
+  /// Custom metadata to be associated with the file.
+  final List<FileSearchCustomMetadata>? customMetadata;
+
+  /// Optional. Config for telling the service how to chunk the file.
+  ///
+  /// If not provided, the service will use default parameters.
+  final ChunkingConfig? chunkingConfig;
+
+  /// Creates an [ImportFileRequest].
+  const ImportFileRequest({
+    required this.fileName,
+    this.customMetadata,
+    this.chunkingConfig,
+  });
+
+  /// Creates an [ImportFileRequest] from JSON.
+  factory ImportFileRequest.fromJson(Map<String, dynamic> json) =>
+      ImportFileRequest(
+        fileName: json['fileName'] as String,
+        customMetadata: (json['customMetadata'] as List?)
+            ?.map(
+              (e) =>
+                  FileSearchCustomMetadata.fromJson(e as Map<String, dynamic>),
+            )
+            .toList(),
+        chunkingConfig: json['chunkingConfig'] != null
+            ? ChunkingConfig.fromJson(
+                json['chunkingConfig'] as Map<String, dynamic>,
+              )
+            : null,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'fileName': fileName,
+    if (customMetadata != null)
+      'customMetadata': customMetadata!.map((e) => e.toJson()).toList(),
+    if (chunkingConfig != null) 'chunkingConfig': chunkingConfig!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  ImportFileRequest copyWith({
+    String? fileName,
+    Object? customMetadata = unsetCopyWithValue,
+    Object? chunkingConfig = unsetCopyWithValue,
+  }) {
+    return ImportFileRequest(
+      fileName: fileName ?? this.fileName,
+      customMetadata: customMetadata == unsetCopyWithValue
+          ? this.customMetadata
+          : customMetadata as List<FileSearchCustomMetadata>?,
+      chunkingConfig: chunkingConfig == unsetCopyWithValue
+          ? this.chunkingConfig
+          : chunkingConfig as ChunkingConfig?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'ImportFileRequest(fileName: $fileName, customMetadata: $customMetadata, chunkingConfig: $chunkingConfig)';
+}

--- a/packages/googleai_dart/lib/src/models/files/import_file_response.dart
+++ b/packages/googleai_dart/lib/src/models/files/import_file_response.dart
@@ -1,0 +1,48 @@
+import '../copy_with_sentinel.dart';
+
+/// Response for `ImportFile` to import a File API file with a `FileSearchStore`.
+class ImportFileResponse {
+  /// The name of the `FileSearchStore` containing `Document`s.
+  ///
+  /// Example: `fileSearchStores/my-file-search-store-123`
+  final String? parent;
+
+  /// Immutable. Identifier. The identifier for the `Document` imported.
+  ///
+  /// Example:
+  /// `fileSearchStores/my-file-search-store-123/documents/my-awesome-doc-123a456b789c`
+  final String? documentName;
+
+  /// Creates an [ImportFileResponse].
+  const ImportFileResponse({this.parent, this.documentName});
+
+  /// Creates an [ImportFileResponse] from JSON.
+  factory ImportFileResponse.fromJson(Map<String, dynamic> json) =>
+      ImportFileResponse(
+        parent: json['parent'] as String?,
+        documentName: json['documentName'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (parent != null) 'parent': parent,
+    if (documentName != null) 'documentName': documentName,
+  };
+
+  /// Creates a copy with replaced values.
+  ImportFileResponse copyWith({
+    Object? parent = unsetCopyWithValue,
+    Object? documentName = unsetCopyWithValue,
+  }) {
+    return ImportFileResponse(
+      parent: parent == unsetCopyWithValue ? this.parent : parent as String?,
+      documentName: documentName == unsetCopyWithValue
+          ? this.documentName
+          : documentName as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'ImportFileResponse(parent: $parent, documentName: $documentName)';
+}

--- a/packages/googleai_dart/lib/src/models/files/list_file_search_stores_response.dart
+++ b/packages/googleai_dart/lib/src/models/files/list_file_search_stores_response.dart
@@ -1,0 +1,57 @@
+import '../copy_with_sentinel.dart';
+import 'file_search_store.dart';
+
+/// Response from `ListFileSearchStores` containing a paginated list of
+/// `FileSearchStores`.
+///
+/// The results are sorted by ascending `file_search_store.create_time`.
+class ListFileSearchStoresResponse {
+  /// The returned file search stores.
+  final List<FileSearchStore>? fileSearchStores;
+
+  /// A token, which can be sent as `page_token` to retrieve the next page.
+  ///
+  /// If this field is omitted, there are no more pages.
+  final String? nextPageToken;
+
+  /// Creates a [ListFileSearchStoresResponse].
+  const ListFileSearchStoresResponse({
+    this.fileSearchStores,
+    this.nextPageToken,
+  });
+
+  /// Creates a [ListFileSearchStoresResponse] from JSON.
+  factory ListFileSearchStoresResponse.fromJson(Map<String, dynamic> json) =>
+      ListFileSearchStoresResponse(
+        fileSearchStores: (json['fileSearchStores'] as List?)
+            ?.map((e) => FileSearchStore.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        nextPageToken: json['nextPageToken'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (fileSearchStores != null)
+      'fileSearchStores': fileSearchStores!.map((e) => e.toJson()).toList(),
+    if (nextPageToken != null) 'nextPageToken': nextPageToken,
+  };
+
+  /// Creates a copy with replaced values.
+  ListFileSearchStoresResponse copyWith({
+    Object? fileSearchStores = unsetCopyWithValue,
+    Object? nextPageToken = unsetCopyWithValue,
+  }) {
+    return ListFileSearchStoresResponse(
+      fileSearchStores: fileSearchStores == unsetCopyWithValue
+          ? this.fileSearchStores
+          : fileSearchStores as List<FileSearchStore>?,
+      nextPageToken: nextPageToken == unsetCopyWithValue
+          ? this.nextPageToken
+          : nextPageToken as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'ListFileSearchStoresResponse(fileSearchStores: $fileSearchStores, nextPageToken: $nextPageToken)';
+}

--- a/packages/googleai_dart/lib/src/models/files/upload_to_file_search_store_request.dart
+++ b/packages/googleai_dart/lib/src/models/files/upload_to_file_search_store_request.dart
@@ -1,0 +1,84 @@
+import '../copy_with_sentinel.dart';
+import 'chunking_config.dart';
+import 'file_search_custom_metadata.dart';
+
+/// Request for `UploadToFileSearchStore`.
+class UploadToFileSearchStoreRequest {
+  /// Optional. Display name of the created document.
+  final String? displayName;
+
+  /// Custom metadata to be associated with the data.
+  final List<FileSearchCustomMetadata>? customMetadata;
+
+  /// Optional. Config for telling the service how to chunk the data.
+  ///
+  /// If not provided, the service will use default parameters.
+  final ChunkingConfig? chunkingConfig;
+
+  /// Optional. MIME type of the data.
+  ///
+  /// If not provided, it will be inferred from the uploaded content.
+  final String? mimeType;
+
+  /// Creates an [UploadToFileSearchStoreRequest].
+  const UploadToFileSearchStoreRequest({
+    this.displayName,
+    this.customMetadata,
+    this.chunkingConfig,
+    this.mimeType,
+  });
+
+  /// Creates an [UploadToFileSearchStoreRequest] from JSON.
+  factory UploadToFileSearchStoreRequest.fromJson(Map<String, dynamic> json) =>
+      UploadToFileSearchStoreRequest(
+        displayName: json['displayName'] as String?,
+        customMetadata: (json['customMetadata'] as List?)
+            ?.map(
+              (e) =>
+                  FileSearchCustomMetadata.fromJson(e as Map<String, dynamic>),
+            )
+            .toList(),
+        chunkingConfig: json['chunkingConfig'] != null
+            ? ChunkingConfig.fromJson(
+                json['chunkingConfig'] as Map<String, dynamic>,
+              )
+            : null,
+        mimeType: json['mimeType'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (displayName != null) 'displayName': displayName,
+    if (customMetadata != null)
+      'customMetadata': customMetadata!.map((e) => e.toJson()).toList(),
+    if (chunkingConfig != null) 'chunkingConfig': chunkingConfig!.toJson(),
+    if (mimeType != null) 'mimeType': mimeType,
+  };
+
+  /// Creates a copy with replaced values.
+  UploadToFileSearchStoreRequest copyWith({
+    Object? displayName = unsetCopyWithValue,
+    Object? customMetadata = unsetCopyWithValue,
+    Object? chunkingConfig = unsetCopyWithValue,
+    Object? mimeType = unsetCopyWithValue,
+  }) {
+    return UploadToFileSearchStoreRequest(
+      displayName: displayName == unsetCopyWithValue
+          ? this.displayName
+          : displayName as String?,
+      customMetadata: customMetadata == unsetCopyWithValue
+          ? this.customMetadata
+          : customMetadata as List<FileSearchCustomMetadata>?,
+      chunkingConfig: chunkingConfig == unsetCopyWithValue
+          ? this.chunkingConfig
+          : chunkingConfig as ChunkingConfig?,
+      mimeType: mimeType == unsetCopyWithValue
+          ? this.mimeType
+          : mimeType as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'UploadToFileSearchStoreRequest(displayName: $displayName, customMetadata: $customMetadata, chunkingConfig: $chunkingConfig, mimeType: $mimeType)';
+}

--- a/packages/googleai_dart/lib/src/models/files/upload_to_file_search_store_response.dart
+++ b/packages/googleai_dart/lib/src/models/files/upload_to_file_search_store_response.dart
@@ -1,0 +1,70 @@
+import '../copy_with_sentinel.dart';
+
+/// Response from UploadToFileSearchStore.
+class UploadToFileSearchStoreResponse {
+  /// The name of the `FileSearchStore` containing `Document`s.
+  ///
+  /// Example: `fileSearchStores/my-file-search-store-123`
+  final String? parent;
+
+  /// Immutable. Identifier. The identifier for the `Document` imported.
+  ///
+  /// Example: `fileSearchStores/my-file-search-store-123a456b789c`
+  final String? documentName;
+
+  /// MIME type of the file.
+  final String? mimeType;
+
+  /// Size of the file in bytes.
+  final String? sizeBytes;
+
+  /// Creates an [UploadToFileSearchStoreResponse].
+  const UploadToFileSearchStoreResponse({
+    this.parent,
+    this.documentName,
+    this.mimeType,
+    this.sizeBytes,
+  });
+
+  /// Creates an [UploadToFileSearchStoreResponse] from JSON.
+  factory UploadToFileSearchStoreResponse.fromJson(Map<String, dynamic> json) =>
+      UploadToFileSearchStoreResponse(
+        parent: json['parent'] as String?,
+        documentName: json['documentName'] as String?,
+        mimeType: json['mimeType'] as String?,
+        sizeBytes: json['sizeBytes'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (parent != null) 'parent': parent,
+    if (documentName != null) 'documentName': documentName,
+    if (mimeType != null) 'mimeType': mimeType,
+    if (sizeBytes != null) 'sizeBytes': sizeBytes,
+  };
+
+  /// Creates a copy with replaced values.
+  UploadToFileSearchStoreResponse copyWith({
+    Object? parent = unsetCopyWithValue,
+    Object? documentName = unsetCopyWithValue,
+    Object? mimeType = unsetCopyWithValue,
+    Object? sizeBytes = unsetCopyWithValue,
+  }) {
+    return UploadToFileSearchStoreResponse(
+      parent: parent == unsetCopyWithValue ? this.parent : parent as String?,
+      documentName: documentName == unsetCopyWithValue
+          ? this.documentName
+          : documentName as String?,
+      mimeType: mimeType == unsetCopyWithValue
+          ? this.mimeType
+          : mimeType as String?,
+      sizeBytes: sizeBytes == unsetCopyWithValue
+          ? this.sizeBytes
+          : sizeBytes as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'UploadToFileSearchStoreResponse(parent: $parent, documentName: $documentName, mimeType: $mimeType, sizeBytes: $sizeBytes)';
+}

--- a/packages/googleai_dart/lib/src/models/files/white_space_config.dart
+++ b/packages/googleai_dart/lib/src/models/files/white_space_config.dart
@@ -1,0 +1,47 @@
+import '../copy_with_sentinel.dart';
+
+/// Configuration for a white space chunking algorithm.
+class WhiteSpaceConfig {
+  /// Maximum number of tokens per chunk.
+  ///
+  /// Tokens are defined as words for this chunking algorithm.
+  final int? maxTokensPerChunk;
+
+  /// Maximum number of overlapping tokens between two adjacent chunks.
+  final int? maxOverlapTokens;
+
+  /// Creates a [WhiteSpaceConfig].
+  const WhiteSpaceConfig({this.maxTokensPerChunk, this.maxOverlapTokens});
+
+  /// Creates a [WhiteSpaceConfig] from JSON.
+  factory WhiteSpaceConfig.fromJson(Map<String, dynamic> json) =>
+      WhiteSpaceConfig(
+        maxTokensPerChunk: json['maxTokensPerChunk'] as int?,
+        maxOverlapTokens: json['maxOverlapTokens'] as int?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (maxTokensPerChunk != null) 'maxTokensPerChunk': maxTokensPerChunk,
+    if (maxOverlapTokens != null) 'maxOverlapTokens': maxOverlapTokens,
+  };
+
+  /// Creates a copy with replaced values.
+  WhiteSpaceConfig copyWith({
+    Object? maxTokensPerChunk = unsetCopyWithValue,
+    Object? maxOverlapTokens = unsetCopyWithValue,
+  }) {
+    return WhiteSpaceConfig(
+      maxTokensPerChunk: maxTokensPerChunk == unsetCopyWithValue
+          ? this.maxTokensPerChunk
+          : maxTokensPerChunk as int?,
+      maxOverlapTokens: maxOverlapTokens == unsetCopyWithValue
+          ? this.maxOverlapTokens
+          : maxOverlapTokens as int?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'WhiteSpaceConfig(maxTokensPerChunk: $maxTokensPerChunk, maxOverlapTokens: $maxOverlapTokens)';
+}

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource.dart
@@ -1,0 +1,3 @@
+export 'file_search_stores_resource_stub.dart'
+    if (dart.library.io) 'file_search_stores_resource_io.dart'
+    if (dart.library.js_interop) 'file_search_stores_resource_web.dart';

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_io.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_io.dart
@@ -1,0 +1,498 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:http/http.dart' as http;
+
+import '../../auth/auth_provider.dart';
+import '../../client/config.dart';
+import '../../errors/exceptions.dart';
+import '../../models/corpus/document.dart';
+import '../../models/corpus/list_documents_response.dart';
+import '../../models/files/file_search_store.dart';
+import '../../models/files/import_file_request.dart';
+import '../../models/files/import_file_response.dart';
+import '../../models/files/list_file_search_stores_response.dart';
+import '../../models/files/upload_to_file_search_store_request.dart';
+import '../../models/files/upload_to_file_search_store_response.dart';
+import '../base_resource.dart';
+
+/// Resource for the FileSearchStores API (IO implementation).
+///
+/// Provides access to file search store management operations including
+/// creating stores, uploading files, and managing documents.
+///
+/// **Note**: This resource is only available with the Google AI (Gemini) API.
+/// Vertex AI uses RAG stores for similar functionality.
+///
+/// See: https://ai.google.dev/api/files#v1beta.fileSearchStores
+class FileSearchStoresResource extends ResourceBase {
+  /// Creates a [FileSearchStoresResource].
+  FileSearchStoresResource({
+    required super.config,
+    required super.httpClient,
+    required super.interceptorChain,
+    required super.requestBuilder,
+  });
+
+  /// Validates that the FileSearchStores API is only used with Google AI.
+  void _validateGoogleAIOnly() {
+    if (config.apiMode == ApiMode.vertexAI) {
+      throw UnsupportedError(
+        'FileSearchStores API is only available with Google AI (Gemini API). '
+        'Vertex AI uses RAG stores for similar functionality. '
+        'See: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/grounding',
+      );
+    }
+  }
+
+  /// Creates a new [FileSearchStore].
+  ///
+  /// [displayName] is an optional human-readable display name for the store.
+  /// The display name must be no more than 512 characters in length.
+  ///
+  /// POST /v1beta/fileSearchStores
+  Future<FileSearchStore> create({String? displayName}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/fileSearchStores');
+
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'Content-Type': 'application/json'},
+    );
+
+    final body = <String, dynamic>{};
+    if (displayName != null) body['displayName'] = displayName;
+
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(body);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return FileSearchStore.fromJson(responseBody);
+  }
+
+  /// Lists file search stores with pagination support.
+  ///
+  /// The [pageSize] parameter specifies the maximum number of stores to return
+  /// (default is 10, max is 100). The [pageToken] is used for pagination.
+  ///
+  /// GET /v1beta/fileSearchStores
+  Future<ListFileSearchStoresResponse> list({
+    int? pageSize,
+    String? pageToken,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final queryParams = <String, String>{
+      if (pageSize != null) 'pageSize': pageSize.toString(),
+      if (pageToken != null) 'pageToken': pageToken,
+    };
+
+    final url = requestBuilder.buildUrl(
+      '/{version}/fileSearchStores',
+      queryParams: queryParams,
+    );
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return ListFileSearchStoresResponse.fromJson(responseBody);
+  }
+
+  /// Gets information about a specific file search store.
+  ///
+  /// The [name] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// GET /v1beta/{name}
+  Future<FileSearchStore> get({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return FileSearchStore.fromJson(responseBody);
+  }
+
+  /// Deletes a file search store.
+  ///
+  /// The [name] is the resource name of the store to delete
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// DELETE /v1beta/{name}
+  Future<void> delete({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('DELETE', url)..headers.addAll(headers);
+
+    await interceptorChain.execute(httpRequest);
+  }
+
+  /// Imports a file from the Files API into a file search store.
+  ///
+  /// The [parent] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// The [request] contains the file to import and optional configuration.
+  ///
+  /// POST /v1beta/{parent}:importFile
+  Future<ImportFileResponse> importFile({
+    required String parent,
+    required ImportFileRequest request,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$parent:importFile');
+
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'Content-Type': 'application/json'},
+    );
+
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(request.toJson());
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return ImportFileResponse.fromJson(responseBody);
+  }
+
+  /// Uploads data directly to a file search store.
+  ///
+  /// This method supports three input modes (exactly one must be provided):
+  /// - [filePath]: Path to a file on the file system (streaming)
+  /// - [contentStream]: A stream of bytes for streaming uploads (memory efficient)
+  /// - [bytes]: The file content as a list of bytes
+  ///
+  /// The [parent] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// The [mimeType] specifies the MIME type of the content.
+  ///
+  /// POST /v1beta/{parent}:upload (resumable upload)
+  Future<UploadToFileSearchStoreResponse> upload({
+    required String parent,
+    String? filePath,
+    Stream<List<int>>? contentStream,
+    List<int>? bytes,
+    String? fileName,
+    required String mimeType,
+    UploadToFileSearchStoreRequest? request,
+  }) async {
+    _validateGoogleAIOnly();
+
+    // Validate that exactly one input method is provided
+    final inputCount = [
+      filePath,
+      contentStream,
+      bytes,
+    ].where((input) => input != null).length;
+
+    if (inputCount != 1) {
+      throw const ValidationException(
+        message:
+            'Exactly one of filePath, contentStream, or bytes must be provided',
+        fieldErrors: {
+          'upload': [
+            'Provide exactly one of: filePath, contentStream, or bytes',
+          ],
+        },
+      );
+    }
+
+    // Prepare the upload data
+    final Stream<List<int>> dataStream;
+    final int contentLength;
+
+    if (filePath != null) {
+      // File path mode - use streaming
+      final file = io.File(filePath);
+      if (!file.existsSync()) {
+        throw const ValidationException(
+          message: 'File not found',
+          fieldErrors: {
+            'filePath': ['File does not exist'],
+          },
+        );
+      }
+      dataStream = file.openRead();
+      contentLength = await file.length();
+    } else if (contentStream != null) {
+      // Stream mode
+      if (fileName == null) {
+        throw const ValidationException(
+          message: 'fileName is required when using contentStream',
+          fieldErrors: {
+            'fileName': ['fileName must be provided with contentStream'],
+          },
+        );
+      }
+      // For streams, we need to buffer to get length
+      final bufferedBytes = await contentStream.fold<List<int>>(
+        [],
+        (buffer, chunk) => buffer..addAll(chunk),
+      );
+      dataStream = Stream.value(bufferedBytes);
+      contentLength = bufferedBytes.length;
+    } else {
+      // Bytes mode
+      if (fileName == null) {
+        throw const ValidationException(
+          message: 'fileName is required when using bytes',
+          fieldErrors: {
+            'fileName': ['fileName must be provided with bytes'],
+          },
+        );
+      }
+      dataStream = Stream.value(bytes!);
+      contentLength = bytes.length;
+    }
+
+    // FileSearchStores uses resumable upload protocol
+    // Step 1: Initiate the upload and get upload URL
+    final uploadUrl = Uri.parse(
+      '${config.baseUrl}/upload/${config.apiVersion.value}/$parent:upload',
+    );
+
+    final initiationHeaders = <String, String>{
+      'X-Goog-Upload-Protocol': 'resumable',
+      'X-Goog-Upload-Command': 'start',
+      'X-Goog-Upload-Header-Content-Length': contentLength.toString(),
+      'X-Goog-Upload-Header-Content-Type': mimeType,
+      'Content-Type': 'application/json',
+    };
+
+    // Apply authentication to initiation request
+    if (config.authProvider != null) {
+      final credentials = await config.authProvider!.getCredentials();
+      switch (credentials) {
+        case ApiKeyCredentials(:final apiKey, :final placement):
+          if (placement == AuthPlacement.header) {
+            initiationHeaders['X-Goog-Api-Key'] = apiKey;
+          }
+        case BearerTokenCredentials(:final token):
+          initiationHeaders['Authorization'] = 'Bearer $token';
+        case NoAuthCredentials():
+          // No auth needed
+          break;
+      }
+    }
+
+    // Add API key as query param if needed
+    final Uri uploadUrlWithAuth;
+    if (config.authProvider != null) {
+      final credentials = await config.authProvider!.getCredentials();
+      if (credentials is ApiKeyCredentials &&
+          credentials.placement == AuthPlacement.queryParam) {
+        uploadUrlWithAuth = uploadUrl.replace(
+          queryParameters: {'key': credentials.apiKey},
+        );
+      } else {
+        uploadUrlWithAuth = uploadUrl;
+      }
+    } else {
+      uploadUrlWithAuth = uploadUrl;
+    }
+
+    // Build request body with metadata
+    final requestBody = <String, dynamic>{
+      if (request?.displayName != null) 'displayName': request!.displayName,
+      if (request?.customMetadata != null)
+        'customMetadata': request!.customMetadata!
+            .map((e) => e.toJson())
+            .toList(),
+      if (request?.chunkingConfig != null)
+        'chunkingConfig': request!.chunkingConfig!.toJson(),
+      if (request?.mimeType != null) 'mimeType': request!.mimeType,
+    };
+
+    final initiationRequest = http.Request('POST', uploadUrlWithAuth)
+      ..headers.addAll(initiationHeaders)
+      ..body = jsonEncode(requestBody);
+
+    final initiationResponse = await httpClient.send(initiationRequest);
+    final initResponse = await http.Response.fromStream(initiationResponse);
+
+    if (initResponse.statusCode >= 400) {
+      throw _mapHttpErrorForStreaming(initResponse);
+    }
+
+    // Extract upload URL from response headers
+    final uploadUrlHeader = initResponse.headers['x-goog-upload-url'];
+    if (uploadUrlHeader == null) {
+      throw const ApiException(
+        code: 500,
+        message: 'Upload URL not returned in initiation response',
+      );
+    }
+
+    // Step 2: Upload the file bytes (streaming)
+    final uploadHeaders = <String, String>{
+      'Content-Length': contentLength.toString(),
+      'X-Goog-Upload-Offset': '0',
+      'X-Goog-Upload-Command': 'upload, finalize',
+    };
+
+    final uploadRequest =
+        http.StreamedRequest('POST', Uri.parse(uploadUrlHeader))
+          ..headers.addAll(uploadHeaders)
+          ..contentLength = contentLength;
+
+    // Stream the data
+    dataStream.listen(
+      uploadRequest.sink.add,
+      onError: uploadRequest.sink.addError,
+      onDone: uploadRequest.sink.close,
+      cancelOnError: true,
+    );
+
+    final uploadResponse = await httpClient.send(uploadRequest);
+    final finalResponse = await http.Response.fromStream(uploadResponse);
+
+    if (finalResponse.statusCode >= 400) {
+      throw _mapHttpErrorForStreaming(finalResponse);
+    }
+
+    final responseBody = jsonDecode(finalResponse.body) as Map<String, dynamic>;
+    return UploadToFileSearchStoreResponse.fromJson(responseBody);
+  }
+
+  /// Lists documents in a file search store with pagination support.
+  ///
+  /// The [parent] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// GET /v1beta/{parent}/documents
+  Future<ListDocumentsResponse> listDocuments({
+    required String parent,
+    int? pageSize,
+    String? pageToken,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final queryParams = <String, String>{
+      if (pageSize != null) 'pageSize': pageSize.toString(),
+      if (pageToken != null) 'pageToken': pageToken,
+    };
+
+    final url = requestBuilder.buildUrl(
+      '/{version}/$parent/documents',
+      queryParams: queryParams,
+    );
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return ListDocumentsResponse.fromJson(responseBody);
+  }
+
+  /// Gets information about a specific document in a file search store.
+  ///
+  /// The [name] is the resource name of the document
+  /// (e.g., "fileSearchStores/my-store-123/documents/doc-456").
+  ///
+  /// GET /v1beta/{name}
+  Future<Document> getDocument({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return Document.fromJson(responseBody);
+  }
+
+  /// Deletes a document from a file search store.
+  ///
+  /// The [name] is the resource name of the document to delete
+  /// (e.g., "fileSearchStores/my-store-123/documents/doc-456").
+  ///
+  /// DELETE /v1beta/{name}
+  Future<void> deleteDocument({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('DELETE', url)..headers.addAll(headers);
+
+    await interceptorChain.execute(httpRequest);
+  }
+
+  /// Maps HTTP errors for streaming (mirrors ErrorInterceptor logic).
+  GoogleAIException _mapHttpErrorForStreaming(http.Response response) {
+    final statusCode = response.statusCode;
+    final body = response.body;
+
+    // Try to parse error details from response body
+    var message = 'HTTP $statusCode error';
+    final details = <Object>[];
+
+    try {
+      final errorDetails = jsonDecode(body);
+      if (errorDetails is Map<String, dynamic>) {
+        final error = errorDetails['error'] as Map<String, dynamic>?;
+        message = error?['message']?.toString() ?? message;
+        if (error?['details'] != null) {
+          final errorDetailsList = error!['details'];
+          if (errorDetailsList is List) {
+            details.addAll(errorDetailsList.cast<Object>());
+          }
+        }
+      }
+    } catch (_) {
+      if (body.length < 200 && body.isNotEmpty) {
+        message = body;
+      }
+    }
+
+    // Map to specific exception types
+    if (statusCode == 429) {
+      DateTime? retryAfter;
+      final retryHeader = response.headers['retry-after'];
+      if (retryHeader != null) {
+        final seconds = int.tryParse(retryHeader);
+        if (seconds != null) {
+          retryAfter = DateTime.now().add(Duration(seconds: seconds));
+        }
+      }
+
+      return RateLimitException(
+        code: statusCode,
+        message: message,
+        details: details,
+        retryAfter: retryAfter,
+      );
+    }
+
+    return ApiException(code: statusCode, message: message, details: details);
+  }
+}

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_stub.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_stub.dart
@@ -1,0 +1,265 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../client/config.dart';
+import '../../models/corpus/document.dart';
+import '../../models/corpus/list_documents_response.dart';
+import '../../models/files/file_search_store.dart';
+import '../../models/files/import_file_request.dart';
+import '../../models/files/import_file_response.dart';
+import '../../models/files/list_file_search_stores_response.dart';
+import '../../models/files/upload_to_file_search_store_request.dart';
+import '../../models/files/upload_to_file_search_store_response.dart';
+import '../base_resource.dart';
+
+/// Resource for the FileSearchStores API (stub implementation).
+///
+/// Provides access to file search store management operations including
+/// creating stores, uploading files, and managing documents.
+///
+/// **Note**: This resource is only available with the Google AI (Gemini) API.
+/// Vertex AI uses RAG stores for similar functionality.
+///
+/// See: https://ai.google.dev/api/files#v1beta.fileSearchStores
+class FileSearchStoresResource extends ResourceBase {
+  /// Creates a [FileSearchStoresResource].
+  FileSearchStoresResource({
+    required super.config,
+    required super.httpClient,
+    required super.interceptorChain,
+    required super.requestBuilder,
+  });
+
+  /// Validates that the FileSearchStores API is only used with Google AI.
+  void _validateGoogleAIOnly() {
+    if (config.apiMode == ApiMode.vertexAI) {
+      throw UnsupportedError(
+        'FileSearchStores API is only available with Google AI (Gemini API). '
+        'Vertex AI uses RAG stores for similar functionality. '
+        'See: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/grounding',
+      );
+    }
+  }
+
+  /// Creates a new [FileSearchStore].
+  ///
+  /// [displayName] is an optional human-readable display name for the store.
+  /// The display name must be no more than 512 characters in length.
+  ///
+  /// POST /v1beta/fileSearchStores
+  Future<FileSearchStore> create({String? displayName}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/fileSearchStores');
+
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'Content-Type': 'application/json'},
+    );
+
+    final body = <String, dynamic>{};
+    if (displayName != null) body['displayName'] = displayName;
+
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(body);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return FileSearchStore.fromJson(responseBody);
+  }
+
+  /// Lists file search stores with pagination support.
+  ///
+  /// The [pageSize] parameter specifies the maximum number of stores to return
+  /// (default is 10, max is 100). The [pageToken] is used for pagination.
+  ///
+  /// GET /v1beta/fileSearchStores
+  Future<ListFileSearchStoresResponse> list({
+    int? pageSize,
+    String? pageToken,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final queryParams = <String, String>{
+      if (pageSize != null) 'pageSize': pageSize.toString(),
+      if (pageToken != null) 'pageToken': pageToken,
+    };
+
+    final url = requestBuilder.buildUrl(
+      '/{version}/fileSearchStores',
+      queryParams: queryParams,
+    );
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return ListFileSearchStoresResponse.fromJson(responseBody);
+  }
+
+  /// Gets information about a specific file search store.
+  ///
+  /// The [name] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// GET /v1beta/{name}
+  Future<FileSearchStore> get({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return FileSearchStore.fromJson(responseBody);
+  }
+
+  /// Deletes a file search store.
+  ///
+  /// The [name] is the resource name of the store to delete
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// DELETE /v1beta/{name}
+  Future<void> delete({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('DELETE', url)..headers.addAll(headers);
+
+    await interceptorChain.execute(httpRequest);
+  }
+
+  /// Imports a file from the Files API into a file search store.
+  ///
+  /// The [parent] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// The [request] contains the file to import and optional configuration.
+  ///
+  /// POST /v1beta/{parent}:importFile
+  Future<ImportFileResponse> importFile({
+    required String parent,
+    required ImportFileRequest request,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$parent:importFile');
+
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'Content-Type': 'application/json'},
+    );
+
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(request.toJson());
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return ImportFileResponse.fromJson(responseBody);
+  }
+
+  /// Uploads data directly to a file search store.
+  ///
+  /// This method is not supported on this platform.
+  ///
+  /// Throws [UnsupportedError] always.
+  Future<UploadToFileSearchStoreResponse> upload({
+    required String parent,
+    String? filePath,
+    Stream<List<int>>? contentStream,
+    List<int>? bytes,
+    String? fileName,
+    required String mimeType,
+    UploadToFileSearchStoreRequest? request,
+  }) {
+    throw UnsupportedError(
+      'File upload is not supported on this platform. '
+      'Use dart:io or web platform.',
+    );
+  }
+
+  /// Lists documents in a file search store with pagination support.
+  ///
+  /// The [parent] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// GET /v1beta/{parent}/documents
+  Future<ListDocumentsResponse> listDocuments({
+    required String parent,
+    int? pageSize,
+    String? pageToken,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final queryParams = <String, String>{
+      if (pageSize != null) 'pageSize': pageSize.toString(),
+      if (pageToken != null) 'pageToken': pageToken,
+    };
+
+    final url = requestBuilder.buildUrl(
+      '/{version}/$parent/documents',
+      queryParams: queryParams,
+    );
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return ListDocumentsResponse.fromJson(responseBody);
+  }
+
+  /// Gets information about a specific document in a file search store.
+  ///
+  /// The [name] is the resource name of the document
+  /// (e.g., "fileSearchStores/my-store-123/documents/doc-456").
+  ///
+  /// GET /v1beta/{name}
+  Future<Document> getDocument({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return Document.fromJson(responseBody);
+  }
+
+  /// Deletes a document from a file search store.
+  ///
+  /// The [name] is the resource name of the document to delete
+  /// (e.g., "fileSearchStores/my-store-123/documents/doc-456").
+  ///
+  /// DELETE /v1beta/{name}
+  Future<void> deleteDocument({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('DELETE', url)..headers.addAll(headers);
+
+    await interceptorChain.execute(httpRequest);
+  }
+}

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_web.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_web.dart
@@ -1,0 +1,438 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../auth/auth_provider.dart';
+import '../../client/config.dart';
+import '../../errors/exceptions.dart';
+import '../../models/corpus/document.dart';
+import '../../models/corpus/list_documents_response.dart';
+import '../../models/files/file_search_store.dart';
+import '../../models/files/import_file_request.dart';
+import '../../models/files/import_file_response.dart';
+import '../../models/files/list_file_search_stores_response.dart';
+import '../../models/files/upload_to_file_search_store_request.dart';
+import '../../models/files/upload_to_file_search_store_response.dart';
+import '../base_resource.dart';
+
+/// Resource for the FileSearchStores API (Web/WASM implementation).
+///
+/// Provides access to file search store management operations including
+/// creating stores, uploading files, and managing documents.
+///
+/// **Note**: This resource is only available with the Google AI (Gemini) API.
+/// Vertex AI uses RAG stores for similar functionality.
+///
+/// See: https://ai.google.dev/api/files#v1beta.fileSearchStores
+class FileSearchStoresResource extends ResourceBase {
+  /// Creates a [FileSearchStoresResource].
+  FileSearchStoresResource({
+    required super.config,
+    required super.httpClient,
+    required super.interceptorChain,
+    required super.requestBuilder,
+  });
+
+  /// Validates that the FileSearchStores API is only used with Google AI.
+  void _validateGoogleAIOnly() {
+    if (config.apiMode == ApiMode.vertexAI) {
+      throw UnsupportedError(
+        'FileSearchStores API is only available with Google AI (Gemini API). '
+        'Vertex AI uses RAG stores for similar functionality. '
+        'See: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/grounding',
+      );
+    }
+  }
+
+  /// Creates a new [FileSearchStore].
+  ///
+  /// [displayName] is an optional human-readable display name for the store.
+  /// The display name must be no more than 512 characters in length.
+  ///
+  /// POST /v1beta/fileSearchStores
+  Future<FileSearchStore> create({String? displayName}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/fileSearchStores');
+
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'Content-Type': 'application/json'},
+    );
+
+    final body = <String, dynamic>{};
+    if (displayName != null) body['displayName'] = displayName;
+
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(body);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return FileSearchStore.fromJson(responseBody);
+  }
+
+  /// Lists file search stores with pagination support.
+  ///
+  /// The [pageSize] parameter specifies the maximum number of stores to return
+  /// (default is 10, max is 100). The [pageToken] is used for pagination.
+  ///
+  /// GET /v1beta/fileSearchStores
+  Future<ListFileSearchStoresResponse> list({
+    int? pageSize,
+    String? pageToken,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final queryParams = <String, String>{
+      if (pageSize != null) 'pageSize': pageSize.toString(),
+      if (pageToken != null) 'pageToken': pageToken,
+    };
+
+    final url = requestBuilder.buildUrl(
+      '/{version}/fileSearchStores',
+      queryParams: queryParams,
+    );
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return ListFileSearchStoresResponse.fromJson(responseBody);
+  }
+
+  /// Gets information about a specific file search store.
+  ///
+  /// The [name] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// GET /v1beta/{name}
+  Future<FileSearchStore> get({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return FileSearchStore.fromJson(responseBody);
+  }
+
+  /// Deletes a file search store.
+  ///
+  /// The [name] is the resource name of the store to delete
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// DELETE /v1beta/{name}
+  Future<void> delete({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('DELETE', url)..headers.addAll(headers);
+
+    await interceptorChain.execute(httpRequest);
+  }
+
+  /// Imports a file from the Files API into a file search store.
+  ///
+  /// The [parent] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// The [request] contains the file to import and optional configuration.
+  ///
+  /// POST /v1beta/{parent}:importFile
+  Future<ImportFileResponse> importFile({
+    required String parent,
+    required ImportFileRequest request,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$parent:importFile');
+
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'Content-Type': 'application/json'},
+    );
+
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(request.toJson());
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return ImportFileResponse.fromJson(responseBody);
+  }
+
+  /// Uploads data directly to a file search store.
+  ///
+  /// Web/WASM implementation - only supports bytes-based uploads.
+  ///
+  /// Required parameters:
+  /// - [bytes]: The file content as a list of bytes
+  /// - [fileName]: The name of the file
+  /// - [mimeType]: The MIME type of the file
+  ///
+  /// Not supported on web/WASM:
+  /// - [filePath]: Not available (no file system access)
+  /// - [contentStream]: Not available (no streaming from file system)
+  ///
+  /// POST /v1beta/{parent}:upload (resumable upload)
+  Future<UploadToFileSearchStoreResponse> upload({
+    required String parent,
+    String? filePath,
+    Stream<List<int>>? contentStream,
+    List<int>? bytes,
+    String? fileName,
+    required String mimeType,
+    UploadToFileSearchStoreRequest? request,
+  }) async {
+    _validateGoogleAIOnly();
+
+    // Validate web-specific constraints
+    if (filePath != null || contentStream != null) {
+      throw UnsupportedError(
+        'filePath and contentStream are not supported on web/WASM platforms. '
+        'Use bytes parameter instead.',
+      );
+    }
+
+    if (bytes == null || fileName == null) {
+      throw const ValidationException(
+        message: 'bytes and fileName are required on web/WASM platforms',
+        fieldErrors: {
+          'upload': ['Provide both bytes and fileName for web/WASM uploads'],
+        },
+      );
+    }
+
+    // FileSearchStores uses resumable upload protocol
+    // Step 1: Initiate the upload and get upload URL
+    final uploadUrl = Uri.parse(
+      '${config.baseUrl}/upload/${config.apiVersion.value}/$parent:upload',
+    );
+
+    final initiationHeaders = <String, String>{
+      'X-Goog-Upload-Protocol': 'resumable',
+      'X-Goog-Upload-Command': 'start',
+      'X-Goog-Upload-Header-Content-Length': bytes.length.toString(),
+      'X-Goog-Upload-Header-Content-Type': mimeType,
+      'Content-Type': 'application/json',
+    };
+
+    // Apply authentication to initiation request
+    if (config.authProvider != null) {
+      final credentials = await config.authProvider!.getCredentials();
+      switch (credentials) {
+        case ApiKeyCredentials(:final apiKey, :final placement):
+          if (placement == AuthPlacement.header) {
+            initiationHeaders['X-Goog-Api-Key'] = apiKey;
+          }
+        case BearerTokenCredentials(:final token):
+          initiationHeaders['Authorization'] = 'Bearer $token';
+        case NoAuthCredentials():
+          // No auth needed
+          break;
+      }
+    }
+
+    // Add API key as query param if needed
+    final Uri uploadUrlWithAuth;
+    if (config.authProvider != null) {
+      final credentials = await config.authProvider!.getCredentials();
+      if (credentials is ApiKeyCredentials &&
+          credentials.placement == AuthPlacement.queryParam) {
+        uploadUrlWithAuth = uploadUrl.replace(
+          queryParameters: {'key': credentials.apiKey},
+        );
+      } else {
+        uploadUrlWithAuth = uploadUrl;
+      }
+    } else {
+      uploadUrlWithAuth = uploadUrl;
+    }
+
+    // Build request body with metadata
+    final requestBody = <String, dynamic>{
+      if (request?.displayName != null) 'displayName': request!.displayName,
+      if (request?.customMetadata != null)
+        'customMetadata': request!.customMetadata!
+            .map((e) => e.toJson())
+            .toList(),
+      if (request?.chunkingConfig != null)
+        'chunkingConfig': request!.chunkingConfig!.toJson(),
+      if (request?.mimeType != null) 'mimeType': request!.mimeType,
+    };
+
+    final initiationRequest = http.Request('POST', uploadUrlWithAuth)
+      ..headers.addAll(initiationHeaders)
+      ..body = jsonEncode(requestBody);
+
+    final initiationResponse = await httpClient.send(initiationRequest);
+    final initResponse = await http.Response.fromStream(initiationResponse);
+
+    if (initResponse.statusCode >= 400) {
+      throw _mapHttpErrorForStreaming(initResponse);
+    }
+
+    // Extract upload URL from response headers
+    final uploadUrlHeader = initResponse.headers['x-goog-upload-url'];
+    if (uploadUrlHeader == null) {
+      throw const ApiException(
+        code: 500,
+        message: 'Upload URL not returned in initiation response',
+      );
+    }
+
+    // Step 2: Upload the file bytes
+    final uploadHeaders = <String, String>{
+      'Content-Length': bytes.length.toString(),
+      'X-Goog-Upload-Offset': '0',
+      'X-Goog-Upload-Command': 'upload, finalize',
+    };
+
+    final uploadRequest = http.Request('POST', Uri.parse(uploadUrlHeader))
+      ..headers.addAll(uploadHeaders)
+      ..bodyBytes = bytes;
+
+    final uploadResponse = await httpClient.send(uploadRequest);
+    final finalResponse = await http.Response.fromStream(uploadResponse);
+
+    if (finalResponse.statusCode >= 400) {
+      throw _mapHttpErrorForStreaming(finalResponse);
+    }
+
+    final responseBody = jsonDecode(finalResponse.body) as Map<String, dynamic>;
+    return UploadToFileSearchStoreResponse.fromJson(responseBody);
+  }
+
+  /// Lists documents in a file search store with pagination support.
+  ///
+  /// The [parent] is the resource name of the store
+  /// (e.g., "fileSearchStores/my-store-123").
+  ///
+  /// GET /v1beta/{parent}/documents
+  Future<ListDocumentsResponse> listDocuments({
+    required String parent,
+    int? pageSize,
+    String? pageToken,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final queryParams = <String, String>{
+      if (pageSize != null) 'pageSize': pageSize.toString(),
+      if (pageToken != null) 'pageToken': pageToken,
+    };
+
+    final url = requestBuilder.buildUrl(
+      '/{version}/$parent/documents',
+      queryParams: queryParams,
+    );
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return ListDocumentsResponse.fromJson(responseBody);
+  }
+
+  /// Gets information about a specific document in a file search store.
+  ///
+  /// The [name] is the resource name of the document
+  /// (e.g., "fileSearchStores/my-store-123/documents/doc-456").
+  ///
+  /// GET /v1beta/{name}
+  Future<Document> getDocument({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return Document.fromJson(responseBody);
+  }
+
+  /// Deletes a document from a file search store.
+  ///
+  /// The [name] is the resource name of the document to delete
+  /// (e.g., "fileSearchStores/my-store-123/documents/doc-456").
+  ///
+  /// DELETE /v1beta/{name}
+  Future<void> deleteDocument({required String name}) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl('/{version}/$name');
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('DELETE', url)..headers.addAll(headers);
+
+    await interceptorChain.execute(httpRequest);
+  }
+
+  /// Maps HTTP errors for streaming (mirrors ErrorInterceptor logic).
+  GoogleAIException _mapHttpErrorForStreaming(http.Response response) {
+    final statusCode = response.statusCode;
+    final body = response.body;
+
+    // Try to parse error details from response body
+    var message = 'HTTP $statusCode error';
+    final details = <Object>[];
+
+    try {
+      final errorDetails = jsonDecode(body);
+      if (errorDetails is Map<String, dynamic>) {
+        final error = errorDetails['error'] as Map<String, dynamic>?;
+        message = error?['message']?.toString() ?? message;
+        if (error?['details'] != null) {
+          final errorDetailsList = error!['details'];
+          if (errorDetailsList is List) {
+            details.addAll(errorDetailsList.cast<Object>());
+          }
+        }
+      }
+    } catch (_) {
+      if (body.length < 200 && body.isNotEmpty) {
+        message = body;
+      }
+    }
+
+    // Map to specific exception types
+    if (statusCode == 429) {
+      DateTime? retryAfter;
+      final retryHeader = response.headers['retry-after'];
+      if (retryHeader != null) {
+        final seconds = int.tryParse(retryHeader);
+        if (seconds != null) {
+          retryAfter = DateTime.now().add(Duration(seconds: seconds));
+        }
+      }
+
+      return RateLimitException(
+        code: statusCode,
+        message: message,
+        details: details,
+        retryAfter: retryAfter,
+      );
+    }
+
+    return ApiException(code: statusCode, message: message, details: details);
+  }
+}

--- a/packages/googleai_dart/test/unit/models/files/file_search_store_test.dart
+++ b/packages/googleai_dart/test/unit/models/files/file_search_store_test.dart
@@ -1,0 +1,152 @@
+import 'package:googleai_dart/src/models/files/file_search_store.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FileSearchStore', () {
+    group('fromJson', () {
+      test('creates FileSearchStore with all fields', () {
+        final json = {
+          'name': 'fileSearchStores/my-store-123',
+          'displayName': 'My Test Store',
+          'createTime': '2024-01-15T10:30:00Z',
+          'updateTime': '2024-01-16T14:45:00Z',
+          'activeDocumentsCount': '10',
+          'pendingDocumentsCount': '2',
+          'failedDocumentsCount': '1',
+          'sizeBytes': '1048576',
+        };
+
+        final store = FileSearchStore.fromJson(json);
+
+        expect(store.name, 'fileSearchStores/my-store-123');
+        expect(store.displayName, 'My Test Store');
+        expect(store.createTime, DateTime.parse('2024-01-15T10:30:00Z'));
+        expect(store.updateTime, DateTime.parse('2024-01-16T14:45:00Z'));
+        expect(store.activeDocumentsCount, '10');
+        expect(store.pendingDocumentsCount, '2');
+        expect(store.failedDocumentsCount, '1');
+        expect(store.sizeBytes, '1048576');
+      });
+
+      test('creates FileSearchStore with minimal fields', () {
+        final json = <String, dynamic>{};
+
+        final store = FileSearchStore.fromJson(json);
+
+        expect(store.name, isNull);
+        expect(store.displayName, isNull);
+        expect(store.createTime, isNull);
+        expect(store.updateTime, isNull);
+        expect(store.activeDocumentsCount, isNull);
+        expect(store.pendingDocumentsCount, isNull);
+        expect(store.failedDocumentsCount, isNull);
+        expect(store.sizeBytes, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('converts FileSearchStore with all fields to JSON', () {
+        final store = FileSearchStore(
+          name: 'fileSearchStores/my-store-456',
+          displayName: 'Another Store',
+          createTime: DateTime.parse('2024-02-20T08:15:00Z'),
+          updateTime: DateTime.parse('2024-02-21T16:30:00Z'),
+          activeDocumentsCount: '20',
+          pendingDocumentsCount: '3',
+          failedDocumentsCount: '0',
+          sizeBytes: '2097152',
+        );
+
+        final json = store.toJson();
+
+        expect(json['name'], 'fileSearchStores/my-store-456');
+        expect(json['displayName'], 'Another Store');
+        expect(json['createTime'], '2024-02-20T08:15:00.000Z');
+        expect(json['updateTime'], '2024-02-21T16:30:00.000Z');
+        expect(json['activeDocumentsCount'], '20');
+        expect(json['pendingDocumentsCount'], '3');
+        expect(json['failedDocumentsCount'], '0');
+        expect(json['sizeBytes'], '2097152');
+      });
+
+      test('omits null fields from JSON', () {
+        const store = FileSearchStore(name: 'fileSearchStores/test-123');
+
+        final json = store.toJson();
+
+        expect(json['name'], 'fileSearchStores/test-123');
+        expect(json.containsKey('displayName'), false);
+        expect(json.containsKey('activeDocumentsCount'), false);
+      });
+    });
+
+    test('round-trip conversion preserves data', () {
+      final original = FileSearchStore(
+        name: 'fileSearchStores/roundtrip-789',
+        displayName: 'Roundtrip Test',
+        createTime: DateTime.parse('2024-04-05T10:20:30Z'),
+        updateTime: DateTime.parse('2024-04-06T11:21:31Z'),
+        activeDocumentsCount: '5',
+        pendingDocumentsCount: '1',
+        failedDocumentsCount: '0',
+        sizeBytes: '512000',
+      );
+
+      final json = original.toJson();
+      final restored = FileSearchStore.fromJson(json);
+
+      expect(restored.name, original.name);
+      expect(restored.displayName, original.displayName);
+      expect(restored.createTime, original.createTime);
+      expect(restored.updateTime, original.updateTime);
+      expect(restored.activeDocumentsCount, original.activeDocumentsCount);
+      expect(restored.pendingDocumentsCount, original.pendingDocumentsCount);
+      expect(restored.failedDocumentsCount, original.failedDocumentsCount);
+      expect(restored.sizeBytes, original.sizeBytes);
+    });
+
+    group('copyWith', () {
+      test('creates copy with replaced values', () {
+        const original = FileSearchStore(
+          name: 'fileSearchStores/original',
+          displayName: 'Original',
+          activeDocumentsCount: '5',
+        );
+
+        final copy = original.copyWith(
+          displayName: 'Updated',
+          activeDocumentsCount: '10',
+        );
+
+        expect(copy.name, 'fileSearchStores/original');
+        expect(copy.displayName, 'Updated');
+        expect(copy.activeDocumentsCount, '10');
+      });
+
+      test('can set values to null', () {
+        const original = FileSearchStore(
+          name: 'fileSearchStores/test',
+          displayName: 'Test',
+        );
+
+        final copy = original.copyWith(displayName: null);
+
+        expect(copy.name, 'fileSearchStores/test');
+        expect(copy.displayName, isNull);
+      });
+    });
+
+    test('toString includes all fields', () {
+      const store = FileSearchStore(
+        name: 'fileSearchStores/test-456',
+        displayName: 'Test Display',
+      );
+
+      final str = store.toString();
+
+      expect(str, contains('FileSearchStore('));
+      expect(str, contains('name: fileSearchStores/test-456'));
+      expect(str, contains('displayName: Test Display'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds support for Google AI's File Search Stores API, which provides file-based semantic retrieval capabilities as a replacement for the deprecated RAG stores.

### New Resource
- `FileSearchStoresResource` with CRUD, upload, and import operations

### New Models
- `FileSearchStore` - Store configuration and metadata
- `FileSearchCustomMetadata` - Custom metadata for files
- `ImportFileRequest/Response` - File import operations
- `UploadToFileSearchStoreRequest/Response` - File upload operations
- `ChunkingConfig` - Chunking configuration for file processing
- `WhiteSpaceConfig` - Whitespace handling configuration
- `ListFileSearchStoresResponse` - Paginated list response

### Platform Support
- IO implementation for full upload capabilities
- Web implementation with FormData support
- Stub for unsupported platforms

## Test plan

- [x] `dart analyze` passes
- [x] Unit tests for new models included