### PR TITLE
feat(googleai_dart): Add grounding models

### DIFF
--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -84,8 +84,20 @@ export 'src/models/generation/thinking_config.dart';
 export 'src/models/generation/thinking_level.dart';
 // Models - Metadata
 export 'src/models/metadata/finish_reason.dart';
+export 'src/models/metadata/grounding_chunk.dart';
+export 'src/models/metadata/grounding_metadata.dart';
+export 'src/models/metadata/grounding_support.dart';
+export 'src/models/metadata/lat_lng.dart';
+export 'src/models/metadata/maps.dart';
 export 'src/models/metadata/modality_token_count.dart';
+export 'src/models/metadata/place_answer_sources.dart';
+export 'src/models/metadata/retrieval_metadata.dart';
+export 'src/models/metadata/retrieved_context.dart';
+export 'src/models/metadata/review_snippet.dart';
+export 'src/models/metadata/search_entry_point.dart';
+export 'src/models/metadata/segment.dart';
 export 'src/models/metadata/usage_metadata.dart';
+export 'src/models/metadata/web.dart';
 // Models - Models API
 export 'src/models/models/dataset.dart';
 export 'src/models/models/hyperparameters.dart';

--- a/packages/googleai_dart/lib/src/models/content/candidate.dart
+++ b/packages/googleai_dart/lib/src/models/content/candidate.dart
@@ -1,5 +1,6 @@
 import '../copy_with_sentinel.dart';
 import '../metadata/finish_reason.dart';
+import '../metadata/grounding_metadata.dart';
 import '../safety/safety_rating.dart';
 import 'citation_metadata.dart';
 import 'content.dart';
@@ -12,6 +13,9 @@ class Candidate {
 
   /// Why generation stopped.
   final FinishReason? finishReason;
+
+  /// Human-readable message describing the finish reason.
+  final String? finishMessage;
 
   /// Safety assessment.
   final List<SafetyRating>? safetyRatings;
@@ -31,16 +35,21 @@ class Candidate {
   /// Token-level logprobs.
   final LogprobsResult? logprobsResult;
 
+  /// Grounding metadata for this candidate.
+  final GroundingMetadata? groundingMetadata;
+
   /// Creates a [Candidate].
   const Candidate({
     this.content,
     this.finishReason,
+    this.finishMessage,
     this.safetyRatings,
     this.citationMetadata,
     this.tokenCount,
     this.index,
     this.avgLogprobs,
     this.logprobsResult,
+    this.groundingMetadata,
   });
 
   /// Creates a [Candidate] from JSON.
@@ -51,6 +60,7 @@ class Candidate {
     finishReason: json['finishReason'] != null
         ? finishReasonFromString(json['finishReason'] as String?)
         : null,
+    finishMessage: json['finishMessage'] as String?,
     safetyRatings: json['safetyRatings'] != null
         ? (json['safetyRatings'] as List)
               .map((e) => SafetyRating.fromJson(e as Map<String, dynamic>))
@@ -69,6 +79,11 @@ class Candidate {
             json['logprobsResult'] as Map<String, dynamic>,
           )
         : null,
+    groundingMetadata: json['groundingMetadata'] != null
+        ? GroundingMetadata.fromJson(
+            json['groundingMetadata'] as Map<String, dynamic>,
+          )
+        : null,
   );
 
   /// Converts to JSON.
@@ -76,6 +91,7 @@ class Candidate {
     if (content != null) 'content': content!.toJson(),
     if (finishReason != null)
       'finishReason': finishReasonToString(finishReason!),
+    if (finishMessage != null) 'finishMessage': finishMessage,
     if (safetyRatings != null)
       'safetyRatings': safetyRatings!.map((e) => e.toJson()).toList(),
     if (citationMetadata != null)
@@ -84,18 +100,22 @@ class Candidate {
     if (index != null) 'index': index,
     if (avgLogprobs != null) 'avgLogprobs': avgLogprobs,
     if (logprobsResult != null) 'logprobsResult': logprobsResult!.toJson(),
+    if (groundingMetadata != null)
+      'groundingMetadata': groundingMetadata!.toJson(),
   };
 
   /// Creates a copy with replaced values.
   Candidate copyWith({
     Object? content = unsetCopyWithValue,
     Object? finishReason = unsetCopyWithValue,
+    Object? finishMessage = unsetCopyWithValue,
     Object? safetyRatings = unsetCopyWithValue,
     Object? citationMetadata = unsetCopyWithValue,
     Object? tokenCount = unsetCopyWithValue,
     Object? index = unsetCopyWithValue,
     Object? avgLogprobs = unsetCopyWithValue,
     Object? logprobsResult = unsetCopyWithValue,
+    Object? groundingMetadata = unsetCopyWithValue,
   }) {
     return Candidate(
       content: content == unsetCopyWithValue
@@ -104,6 +124,9 @@ class Candidate {
       finishReason: finishReason == unsetCopyWithValue
           ? this.finishReason
           : finishReason as FinishReason?,
+      finishMessage: finishMessage == unsetCopyWithValue
+          ? this.finishMessage
+          : finishMessage as String?,
       safetyRatings: safetyRatings == unsetCopyWithValue
           ? this.safetyRatings
           : safetyRatings as List<SafetyRating>?,
@@ -120,6 +143,9 @@ class Candidate {
       logprobsResult: logprobsResult == unsetCopyWithValue
           ? this.logprobsResult
           : logprobsResult as LogprobsResult?,
+      groundingMetadata: groundingMetadata == unsetCopyWithValue
+          ? this.groundingMetadata
+          : groundingMetadata as GroundingMetadata?,
     );
   }
 }

--- a/packages/googleai_dart/lib/src/models/metadata/grounding_chunk.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/grounding_chunk.dart
@@ -1,0 +1,61 @@
+import '../copy_with_sentinel.dart';
+import 'maps.dart';
+import 'retrieved_context.dart';
+import 'web.dart';
+
+/// Grounding chunk.
+class GroundingChunk {
+  /// Grounding chunk from the web.
+  final Web? web;
+
+  /// Optional. Grounding chunk from context retrieved by the file search tool.
+  final RetrievedContext? retrievedContext;
+
+  /// Optional. Grounding chunk from Google Maps.
+  final Maps? maps;
+
+  /// Creates a [GroundingChunk].
+  const GroundingChunk({this.web, this.retrievedContext, this.maps});
+
+  /// Creates a [GroundingChunk] from JSON.
+  factory GroundingChunk.fromJson(Map<String, dynamic> json) => GroundingChunk(
+    web: json['web'] != null
+        ? Web.fromJson(json['web'] as Map<String, dynamic>)
+        : null,
+    retrievedContext: json['retrievedContext'] != null
+        ? RetrievedContext.fromJson(
+            json['retrievedContext'] as Map<String, dynamic>,
+          )
+        : null,
+    maps: json['maps'] != null
+        ? Maps.fromJson(json['maps'] as Map<String, dynamic>)
+        : null,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (web != null) 'web': web!.toJson(),
+    if (retrievedContext != null)
+      'retrievedContext': retrievedContext!.toJson(),
+    if (maps != null) 'maps': maps!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  GroundingChunk copyWith({
+    Object? web = unsetCopyWithValue,
+    Object? retrievedContext = unsetCopyWithValue,
+    Object? maps = unsetCopyWithValue,
+  }) {
+    return GroundingChunk(
+      web: web == unsetCopyWithValue ? this.web : web as Web?,
+      retrievedContext: retrievedContext == unsetCopyWithValue
+          ? this.retrievedContext
+          : retrievedContext as RetrievedContext?,
+      maps: maps == unsetCopyWithValue ? this.maps : maps as Maps?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'GroundingChunk(web: $web, retrievedContext: $retrievedContext, maps: $maps)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/grounding_metadata.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/grounding_metadata.dart
@@ -1,0 +1,117 @@
+import '../copy_with_sentinel.dart';
+import 'grounding_chunk.dart';
+import 'grounding_support.dart';
+import 'retrieval_metadata.dart';
+import 'search_entry_point.dart';
+
+/// Metadata returned to client when grounding is enabled.
+class GroundingMetadata {
+  /// Optional. Google search entry for the following-up web searches.
+  final SearchEntryPoint? searchEntryPoint;
+
+  /// List of supporting references retrieved from specified grounding source.
+  final List<GroundingChunk>? groundingChunks;
+
+  /// List of grounding support.
+  final List<GroundingSupport>? groundingSupports;
+
+  /// Metadata related to retrieval in the grounding flow.
+  final RetrievalMetadata? retrievalMetadata;
+
+  /// Web search queries for the following-up web search.
+  final List<String>? webSearchQueries;
+
+  /// Optional. Resource name of the Google Maps widget context token that can
+  /// be used with the PlacesContextElement widget in order to render
+  /// contextual data.
+  ///
+  /// Only populated in the case that grounding with Google Maps is enabled.
+  final String? googleMapsWidgetContextToken;
+
+  /// Creates a [GroundingMetadata].
+  const GroundingMetadata({
+    this.searchEntryPoint,
+    this.groundingChunks,
+    this.groundingSupports,
+    this.retrievalMetadata,
+    this.webSearchQueries,
+    this.googleMapsWidgetContextToken,
+  });
+
+  /// Creates a [GroundingMetadata] from JSON.
+  factory GroundingMetadata.fromJson(Map<String, dynamic> json) =>
+      GroundingMetadata(
+        searchEntryPoint: json['searchEntryPoint'] != null
+            ? SearchEntryPoint.fromJson(
+                json['searchEntryPoint'] as Map<String, dynamic>,
+              )
+            : null,
+        groundingChunks: (json['groundingChunks'] as List?)
+            ?.map((e) => GroundingChunk.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        groundingSupports: (json['groundingSupports'] as List?)
+            ?.map((e) => GroundingSupport.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        retrievalMetadata: json['retrievalMetadata'] != null
+            ? RetrievalMetadata.fromJson(
+                json['retrievalMetadata'] as Map<String, dynamic>,
+              )
+            : null,
+        webSearchQueries: (json['webSearchQueries'] as List?)
+            ?.map((e) => e as String)
+            .toList(),
+        googleMapsWidgetContextToken:
+            json['googleMapsWidgetContextToken'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (searchEntryPoint != null)
+      'searchEntryPoint': searchEntryPoint!.toJson(),
+    if (groundingChunks != null)
+      'groundingChunks': groundingChunks!.map((e) => e.toJson()).toList(),
+    if (groundingSupports != null)
+      'groundingSupports': groundingSupports!.map((e) => e.toJson()).toList(),
+    if (retrievalMetadata != null)
+      'retrievalMetadata': retrievalMetadata!.toJson(),
+    if (webSearchQueries != null) 'webSearchQueries': webSearchQueries,
+    if (googleMapsWidgetContextToken != null)
+      'googleMapsWidgetContextToken': googleMapsWidgetContextToken,
+  };
+
+  /// Creates a copy with replaced values.
+  GroundingMetadata copyWith({
+    Object? searchEntryPoint = unsetCopyWithValue,
+    Object? groundingChunks = unsetCopyWithValue,
+    Object? groundingSupports = unsetCopyWithValue,
+    Object? retrievalMetadata = unsetCopyWithValue,
+    Object? webSearchQueries = unsetCopyWithValue,
+    Object? googleMapsWidgetContextToken = unsetCopyWithValue,
+  }) {
+    return GroundingMetadata(
+      searchEntryPoint: searchEntryPoint == unsetCopyWithValue
+          ? this.searchEntryPoint
+          : searchEntryPoint as SearchEntryPoint?,
+      groundingChunks: groundingChunks == unsetCopyWithValue
+          ? this.groundingChunks
+          : groundingChunks as List<GroundingChunk>?,
+      groundingSupports: groundingSupports == unsetCopyWithValue
+          ? this.groundingSupports
+          : groundingSupports as List<GroundingSupport>?,
+      retrievalMetadata: retrievalMetadata == unsetCopyWithValue
+          ? this.retrievalMetadata
+          : retrievalMetadata as RetrievalMetadata?,
+      webSearchQueries: webSearchQueries == unsetCopyWithValue
+          ? this.webSearchQueries
+          : webSearchQueries as List<String>?,
+      googleMapsWidgetContextToken:
+          googleMapsWidgetContextToken == unsetCopyWithValue
+          ? this.googleMapsWidgetContextToken
+          : googleMapsWidgetContextToken as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'GroundingMetadata(searchEntryPoint: $searchEntryPoint, groundingChunks: $groundingChunks, groundingSupports: $groundingSupports, retrievalMetadata: $retrievalMetadata, webSearchQueries: $webSearchQueries, googleMapsWidgetContextToken: $googleMapsWidgetContextToken)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/grounding_support.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/grounding_support.dart
@@ -1,0 +1,73 @@
+import '../copy_with_sentinel.dart';
+import 'segment.dart';
+
+/// Grounding support.
+class GroundingSupport {
+  /// Segment of the content this support belongs to.
+  final Segment? segment;
+
+  /// Optional. A list of indices (into 'grounding_chunk') specifying the
+  /// citations associated with the claim.
+  ///
+  /// For instance [1,3,4] means that grounding_chunk[1], grounding_chunk[3],
+  /// grounding_chunk[4] are the retrieved content attributed to the claim.
+  final List<int>? groundingChunkIndices;
+
+  /// Optional. Confidence score of the support references.
+  ///
+  /// Ranges from 0 to 1. 1 is the most confident. This list must have the
+  /// same size as the grounding_chunk_indices.
+  final List<double>? confidenceScores;
+
+  /// Creates a [GroundingSupport].
+  const GroundingSupport({
+    this.segment,
+    this.groundingChunkIndices,
+    this.confidenceScores,
+  });
+
+  /// Creates a [GroundingSupport] from JSON.
+  factory GroundingSupport.fromJson(Map<String, dynamic> json) =>
+      GroundingSupport(
+        segment: json['segment'] != null
+            ? Segment.fromJson(json['segment'] as Map<String, dynamic>)
+            : null,
+        groundingChunkIndices: (json['groundingChunkIndices'] as List?)
+            ?.map((e) => e as int)
+            .toList(),
+        confidenceScores: (json['confidenceScores'] as List?)
+            ?.map((e) => (e as num).toDouble())
+            .toList(),
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (segment != null) 'segment': segment!.toJson(),
+    if (groundingChunkIndices != null)
+      'groundingChunkIndices': groundingChunkIndices,
+    if (confidenceScores != null) 'confidenceScores': confidenceScores,
+  };
+
+  /// Creates a copy with replaced values.
+  GroundingSupport copyWith({
+    Object? segment = unsetCopyWithValue,
+    Object? groundingChunkIndices = unsetCopyWithValue,
+    Object? confidenceScores = unsetCopyWithValue,
+  }) {
+    return GroundingSupport(
+      segment: segment == unsetCopyWithValue
+          ? this.segment
+          : segment as Segment?,
+      groundingChunkIndices: groundingChunkIndices == unsetCopyWithValue
+          ? this.groundingChunkIndices
+          : groundingChunkIndices as List<int>?,
+      confidenceScores: confidenceScores == unsetCopyWithValue
+          ? this.confidenceScores
+          : confidenceScores as List<double>?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'GroundingSupport(segment: $segment, groundingChunkIndices: $groundingChunkIndices, confidenceScores: $confidenceScores)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/lat_lng.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/lat_lng.dart
@@ -1,0 +1,47 @@
+import '../copy_with_sentinel.dart';
+
+/// An object that represents a latitude/longitude pair.
+///
+/// This is expressed as a pair of doubles to represent degrees latitude
+/// and degrees longitude. Unless specified otherwise, this object must
+/// conform to the WGS84 standard. Values must be within normalized ranges.
+class LatLng {
+  /// The latitude in degrees. It must be in the range [-90.0, +90.0].
+  final double? latitude;
+
+  /// The longitude in degrees. It must be in the range [-180.0, +180.0].
+  final double? longitude;
+
+  /// Creates a [LatLng].
+  const LatLng({this.latitude, this.longitude});
+
+  /// Creates a [LatLng] from JSON.
+  factory LatLng.fromJson(Map<String, dynamic> json) => LatLng(
+    latitude: (json['latitude'] as num?)?.toDouble(),
+    longitude: (json['longitude'] as num?)?.toDouble(),
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (latitude != null) 'latitude': latitude,
+    if (longitude != null) 'longitude': longitude,
+  };
+
+  /// Creates a copy with replaced values.
+  LatLng copyWith({
+    Object? latitude = unsetCopyWithValue,
+    Object? longitude = unsetCopyWithValue,
+  }) {
+    return LatLng(
+      latitude: latitude == unsetCopyWithValue
+          ? this.latitude
+          : latitude as double?,
+      longitude: longitude == unsetCopyWithValue
+          ? this.longitude
+          : longitude as double?,
+    );
+  }
+
+  @override
+  String toString() => 'LatLng(latitude: $latitude, longitude: $longitude)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/maps.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/maps.dart
@@ -1,0 +1,82 @@
+import '../copy_with_sentinel.dart';
+import 'place_answer_sources.dart';
+
+/// A grounding chunk from Google Maps.
+///
+/// A Maps chunk corresponds to a single place.
+class Maps {
+  /// URI reference of the place.
+  final String? uri;
+
+  /// Title of the place.
+  final String? title;
+
+  /// Text description of the place answer.
+  final String? text;
+
+  /// This ID of the place, in `places/{place_id}` format.
+  ///
+  /// A user can use this ID to look up that place.
+  final String? placeId;
+
+  /// Sources that provide answers about the features of a given place
+  /// in Google Maps.
+  final PlaceAnswerSources? placeAnswerSources;
+
+  /// Creates a [Maps].
+  const Maps({
+    this.uri,
+    this.title,
+    this.text,
+    this.placeId,
+    this.placeAnswerSources,
+  });
+
+  /// Creates a [Maps] from JSON.
+  factory Maps.fromJson(Map<String, dynamic> json) => Maps(
+    uri: json['uri'] as String?,
+    title: json['title'] as String?,
+    text: json['text'] as String?,
+    placeId: json['placeId'] as String?,
+    placeAnswerSources: json['placeAnswerSources'] != null
+        ? PlaceAnswerSources.fromJson(
+            json['placeAnswerSources'] as Map<String, dynamic>,
+          )
+        : null,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (uri != null) 'uri': uri,
+    if (title != null) 'title': title,
+    if (text != null) 'text': text,
+    if (placeId != null) 'placeId': placeId,
+    if (placeAnswerSources != null)
+      'placeAnswerSources': placeAnswerSources!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  Maps copyWith({
+    Object? uri = unsetCopyWithValue,
+    Object? title = unsetCopyWithValue,
+    Object? text = unsetCopyWithValue,
+    Object? placeId = unsetCopyWithValue,
+    Object? placeAnswerSources = unsetCopyWithValue,
+  }) {
+    return Maps(
+      uri: uri == unsetCopyWithValue ? this.uri : uri as String?,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+      text: text == unsetCopyWithValue ? this.text : text as String?,
+      placeId: placeId == unsetCopyWithValue
+          ? this.placeId
+          : placeId as String?,
+      placeAnswerSources: placeAnswerSources == unsetCopyWithValue
+          ? this.placeAnswerSources
+          : placeAnswerSources as PlaceAnswerSources?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'Maps(uri: $uri, title: $title, text: $text, placeId: $placeId, placeAnswerSources: $placeAnswerSources)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/place_answer_sources.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/place_answer_sources.dart
@@ -1,0 +1,46 @@
+import '../copy_with_sentinel.dart';
+import 'review_snippet.dart';
+
+/// Collection of sources that provide answers about the features of a given
+/// place in Google Maps.
+///
+/// Each PlaceAnswerSources message corresponds to a specific place in Google
+/// Maps. The Google Maps tool used these sources in order to answer questions
+/// about features of the place (e.g: "does Bar Foo have Wifi" or "is Foo Bar
+/// wheelchair accessible?").
+///
+/// Currently only review snippets are supported as sources.
+class PlaceAnswerSources {
+  /// Snippets of reviews that are used to generate answers about the
+  /// features of a given place in Google Maps.
+  final List<ReviewSnippet>? reviewSnippets;
+
+  /// Creates a [PlaceAnswerSources].
+  const PlaceAnswerSources({this.reviewSnippets});
+
+  /// Creates a [PlaceAnswerSources] from JSON.
+  factory PlaceAnswerSources.fromJson(Map<String, dynamic> json) =>
+      PlaceAnswerSources(
+        reviewSnippets: (json['reviewSnippets'] as List?)
+            ?.map((e) => ReviewSnippet.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (reviewSnippets != null)
+      'reviewSnippets': reviewSnippets!.map((e) => e.toJson()).toList(),
+  };
+
+  /// Creates a copy with replaced values.
+  PlaceAnswerSources copyWith({Object? reviewSnippets = unsetCopyWithValue}) {
+    return PlaceAnswerSources(
+      reviewSnippets: reviewSnippets == unsetCopyWithValue
+          ? this.reviewSnippets
+          : reviewSnippets as List<ReviewSnippet>?,
+    );
+  }
+
+  @override
+  String toString() => 'PlaceAnswerSources(reviewSnippets: $reviewSnippets)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/retrieval_metadata.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/retrieval_metadata.dart
@@ -1,0 +1,45 @@
+import '../copy_with_sentinel.dart';
+
+/// Metadata related to retrieval in the grounding flow.
+class RetrievalMetadata {
+  /// Optional. Score indicating how likely information from google search
+  /// could help answer the prompt.
+  ///
+  /// The score is in the range [0, 1], where 0 is the least likely and 1
+  /// is the most likely. This score is only populated when google search
+  /// grounding and dynamic retrieval is enabled. It will be compared to
+  /// the threshold to determine whether to trigger google search.
+  final double? googleSearchDynamicRetrievalScore;
+
+  /// Creates a [RetrievalMetadata].
+  const RetrievalMetadata({this.googleSearchDynamicRetrievalScore});
+
+  /// Creates a [RetrievalMetadata] from JSON.
+  factory RetrievalMetadata.fromJson(Map<String, dynamic> json) =>
+      RetrievalMetadata(
+        googleSearchDynamicRetrievalScore:
+            (json['googleSearchDynamicRetrievalScore'] as num?)?.toDouble(),
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (googleSearchDynamicRetrievalScore != null)
+      'googleSearchDynamicRetrievalScore': googleSearchDynamicRetrievalScore,
+  };
+
+  /// Creates a copy with replaced values.
+  RetrievalMetadata copyWith({
+    Object? googleSearchDynamicRetrievalScore = unsetCopyWithValue,
+  }) {
+    return RetrievalMetadata(
+      googleSearchDynamicRetrievalScore:
+          googleSearchDynamicRetrievalScore == unsetCopyWithValue
+          ? this.googleSearchDynamicRetrievalScore
+          : googleSearchDynamicRetrievalScore as double?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'RetrievalMetadata(googleSearchDynamicRetrievalScore: $googleSearchDynamicRetrievalScore)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/retrieved_context.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/retrieved_context.dart
@@ -1,0 +1,64 @@
+import '../copy_with_sentinel.dart';
+
+/// Chunk from context retrieved by the file search tool.
+class RetrievedContext {
+  /// Optional. URI reference of the semantic retrieval document.
+  final String? uri;
+
+  /// Optional. Title of the document.
+  final String? title;
+
+  /// Optional. Text of the chunk.
+  final String? text;
+
+  /// Optional. Name of the `FileSearchStore` containing the document.
+  ///
+  /// Example: `fileSearchStores/123`
+  final String? fileSearchStore;
+
+  /// Creates a [RetrievedContext].
+  const RetrievedContext({
+    this.uri,
+    this.title,
+    this.text,
+    this.fileSearchStore,
+  });
+
+  /// Creates a [RetrievedContext] from JSON.
+  factory RetrievedContext.fromJson(Map<String, dynamic> json) =>
+      RetrievedContext(
+        uri: json['uri'] as String?,
+        title: json['title'] as String?,
+        text: json['text'] as String?,
+        fileSearchStore: json['fileSearchStore'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (uri != null) 'uri': uri,
+    if (title != null) 'title': title,
+    if (text != null) 'text': text,
+    if (fileSearchStore != null) 'fileSearchStore': fileSearchStore,
+  };
+
+  /// Creates a copy with replaced values.
+  RetrievedContext copyWith({
+    Object? uri = unsetCopyWithValue,
+    Object? title = unsetCopyWithValue,
+    Object? text = unsetCopyWithValue,
+    Object? fileSearchStore = unsetCopyWithValue,
+  }) {
+    return RetrievedContext(
+      uri: uri == unsetCopyWithValue ? this.uri : uri as String?,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+      text: text == unsetCopyWithValue ? this.text : text as String?,
+      fileSearchStore: fileSearchStore == unsetCopyWithValue
+          ? this.fileSearchStore
+          : fileSearchStore as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'RetrievedContext(uri: $uri, title: $title, text: $text, fileSearchStore: $fileSearchStore)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/review_snippet.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/review_snippet.dart
@@ -1,0 +1,52 @@
+import '../copy_with_sentinel.dart';
+
+/// Encapsulates a snippet of a user review that answers a question about
+/// the features of a specific place in Google Maps.
+class ReviewSnippet {
+  /// The ID of the review snippet.
+  final String? reviewId;
+
+  /// A link that corresponds to the user review on Google Maps.
+  final String? googleMapsUri;
+
+  /// Title of the review.
+  final String? title;
+
+  /// Creates a [ReviewSnippet].
+  const ReviewSnippet({this.reviewId, this.googleMapsUri, this.title});
+
+  /// Creates a [ReviewSnippet] from JSON.
+  factory ReviewSnippet.fromJson(Map<String, dynamic> json) => ReviewSnippet(
+    reviewId: json['reviewId'] as String?,
+    googleMapsUri: json['googleMapsUri'] as String?,
+    title: json['title'] as String?,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (reviewId != null) 'reviewId': reviewId,
+    if (googleMapsUri != null) 'googleMapsUri': googleMapsUri,
+    if (title != null) 'title': title,
+  };
+
+  /// Creates a copy with replaced values.
+  ReviewSnippet copyWith({
+    Object? reviewId = unsetCopyWithValue,
+    Object? googleMapsUri = unsetCopyWithValue,
+    Object? title = unsetCopyWithValue,
+  }) {
+    return ReviewSnippet(
+      reviewId: reviewId == unsetCopyWithValue
+          ? this.reviewId
+          : reviewId as String?,
+      googleMapsUri: googleMapsUri == unsetCopyWithValue
+          ? this.googleMapsUri
+          : googleMapsUri as String?,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'ReviewSnippet(reviewId: $reviewId, googleMapsUri: $googleMapsUri, title: $title)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/search_entry_point.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/search_entry_point.dart
@@ -1,0 +1,46 @@
+import '../copy_with_sentinel.dart';
+
+/// Google search entry point.
+class SearchEntryPoint {
+  /// Optional. Web content snippet that can be embedded in a web page or
+  /// an app webview.
+  final String? renderedContent;
+
+  /// Optional. Base64 encoded JSON representing array of tuple.
+  final String? sdkBlob;
+
+  /// Creates a [SearchEntryPoint].
+  const SearchEntryPoint({this.renderedContent, this.sdkBlob});
+
+  /// Creates a [SearchEntryPoint] from JSON.
+  factory SearchEntryPoint.fromJson(Map<String, dynamic> json) =>
+      SearchEntryPoint(
+        renderedContent: json['renderedContent'] as String?,
+        sdkBlob: json['sdkBlob'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (renderedContent != null) 'renderedContent': renderedContent,
+    if (sdkBlob != null) 'sdkBlob': sdkBlob,
+  };
+
+  /// Creates a copy with replaced values.
+  SearchEntryPoint copyWith({
+    Object? renderedContent = unsetCopyWithValue,
+    Object? sdkBlob = unsetCopyWithValue,
+  }) {
+    return SearchEntryPoint(
+      renderedContent: renderedContent == unsetCopyWithValue
+          ? this.renderedContent
+          : renderedContent as String?,
+      sdkBlob: sdkBlob == unsetCopyWithValue
+          ? this.sdkBlob
+          : sdkBlob as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'SearchEntryPoint(renderedContent: $renderedContent, sdkBlob: $sdkBlob)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/segment.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/segment.dart
@@ -1,0 +1,64 @@
+import '../copy_with_sentinel.dart';
+
+/// Segment of the content.
+class Segment {
+  /// The index of a Part object within its parent Content object.
+  final int? partIndex;
+
+  /// Start index in the given Part, measured in bytes.
+  ///
+  /// Offset from the start of the Part, inclusive, starting at zero.
+  final int? startIndex;
+
+  /// End index in the given Part, measured in bytes.
+  ///
+  /// Offset from the start of the Part, exclusive, starting at zero.
+  final int? endIndex;
+
+  /// The text corresponding to the segment from the response.
+  final String? text;
+
+  /// Creates a [Segment].
+  const Segment({this.partIndex, this.startIndex, this.endIndex, this.text});
+
+  /// Creates a [Segment] from JSON.
+  factory Segment.fromJson(Map<String, dynamic> json) => Segment(
+    partIndex: json['partIndex'] as int?,
+    startIndex: json['startIndex'] as int?,
+    endIndex: json['endIndex'] as int?,
+    text: json['text'] as String?,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (partIndex != null) 'partIndex': partIndex,
+    if (startIndex != null) 'startIndex': startIndex,
+    if (endIndex != null) 'endIndex': endIndex,
+    if (text != null) 'text': text,
+  };
+
+  /// Creates a copy with replaced values.
+  Segment copyWith({
+    Object? partIndex = unsetCopyWithValue,
+    Object? startIndex = unsetCopyWithValue,
+    Object? endIndex = unsetCopyWithValue,
+    Object? text = unsetCopyWithValue,
+  }) {
+    return Segment(
+      partIndex: partIndex == unsetCopyWithValue
+          ? this.partIndex
+          : partIndex as int?,
+      startIndex: startIndex == unsetCopyWithValue
+          ? this.startIndex
+          : startIndex as int?,
+      endIndex: endIndex == unsetCopyWithValue
+          ? this.endIndex
+          : endIndex as int?,
+      text: text == unsetCopyWithValue ? this.text : text as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'Segment(partIndex: $partIndex, startIndex: $startIndex, endIndex: $endIndex, text: $text)';
+}

--- a/packages/googleai_dart/lib/src/models/metadata/web.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/web.dart
@@ -1,0 +1,37 @@
+import '../copy_with_sentinel.dart';
+
+/// Chunk from the web.
+class Web {
+  /// URI reference of the chunk.
+  final String? uri;
+
+  /// Title of the chunk.
+  final String? title;
+
+  /// Creates a [Web].
+  const Web({this.uri, this.title});
+
+  /// Creates a [Web] from JSON.
+  factory Web.fromJson(Map<String, dynamic> json) =>
+      Web(uri: json['uri'] as String?, title: json['title'] as String?);
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (uri != null) 'uri': uri,
+    if (title != null) 'title': title,
+  };
+
+  /// Creates a copy with replaced values.
+  Web copyWith({
+    Object? uri = unsetCopyWithValue,
+    Object? title = unsetCopyWithValue,
+  }) {
+    return Web(
+      uri: uri == unsetCopyWithValue ? this.uri : uri as String?,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+    );
+  }
+
+  @override
+  String toString() => 'Web(uri: $uri, title: $title)';
+}

--- a/packages/googleai_dart/test/unit/models/metadata/grounding_metadata_test.dart
+++ b/packages/googleai_dart/test/unit/models/metadata/grounding_metadata_test.dart
@@ -1,0 +1,219 @@
+import 'package:googleai_dart/src/models/metadata/grounding_chunk.dart';
+import 'package:googleai_dart/src/models/metadata/grounding_metadata.dart';
+import 'package:googleai_dart/src/models/metadata/grounding_support.dart';
+import 'package:googleai_dart/src/models/metadata/retrieval_metadata.dart';
+import 'package:googleai_dart/src/models/metadata/search_entry_point.dart';
+import 'package:googleai_dart/src/models/metadata/segment.dart';
+import 'package:googleai_dart/src/models/metadata/web.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GroundingMetadata', () {
+    group('fromJson', () {
+      test('creates GroundingMetadata with all fields', () {
+        final json = {
+          'searchEntryPoint': {
+            'renderedContent': '<div>Search content</div>',
+            'sdkBlob': 'base64blob',
+          },
+          'groundingChunks': [
+            {
+              'web': {'uri': 'https://example.com', 'title': 'Example'},
+            },
+          ],
+          'groundingSupports': [
+            {
+              'segment': {
+                'startIndex': 0,
+                'endIndex': 10,
+                'text': 'Sample text',
+              },
+              'groundingChunkIndices': [0],
+              'confidenceScores': [0.95],
+            },
+          ],
+          'retrievalMetadata': {'googleSearchDynamicRetrievalScore': 0.85},
+          'webSearchQueries': ['query1', 'query2'],
+          'googleMapsWidgetContextToken': 'maps-token-123',
+        };
+
+        final metadata = GroundingMetadata.fromJson(json);
+
+        expect(metadata.searchEntryPoint, isNotNull);
+        expect(
+          metadata.searchEntryPoint!.renderedContent,
+          '<div>Search content</div>',
+        );
+        expect(metadata.groundingChunks, hasLength(1));
+        expect(metadata.groundingChunks![0].web!.uri, 'https://example.com');
+        expect(metadata.groundingSupports, hasLength(1));
+        expect(metadata.retrievalMetadata, isNotNull);
+        expect(metadata.webSearchQueries, ['query1', 'query2']);
+        expect(metadata.googleMapsWidgetContextToken, 'maps-token-123');
+      });
+
+      test('creates GroundingMetadata with minimal fields', () {
+        final json = <String, dynamic>{};
+
+        final metadata = GroundingMetadata.fromJson(json);
+
+        expect(metadata.searchEntryPoint, isNull);
+        expect(metadata.groundingChunks, isNull);
+        expect(metadata.groundingSupports, isNull);
+        expect(metadata.retrievalMetadata, isNull);
+        expect(metadata.webSearchQueries, isNull);
+        expect(metadata.googleMapsWidgetContextToken, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('converts GroundingMetadata with all fields to JSON', () {
+        const metadata = GroundingMetadata(
+          searchEntryPoint: SearchEntryPoint(
+            renderedContent: '<div>Content</div>',
+          ),
+          groundingChunks: [
+            GroundingChunk(
+              web: Web(uri: 'https://test.com', title: 'Test'),
+            ),
+          ],
+          groundingSupports: [
+            GroundingSupport(
+              segment: Segment(startIndex: 0, endIndex: 5, text: 'Hello'),
+              groundingChunkIndices: [0],
+              confidenceScores: [0.9],
+            ),
+          ],
+          retrievalMetadata: RetrievalMetadata(
+            googleSearchDynamicRetrievalScore: 0.8,
+          ),
+          webSearchQueries: ['test query'],
+          googleMapsWidgetContextToken: 'token-456',
+        );
+
+        final json = metadata.toJson();
+
+        expect(json['searchEntryPoint'], isNotNull);
+        expect(json['groundingChunks'], isNotNull);
+        expect(json['groundingSupports'], isNotNull);
+        expect(json['retrievalMetadata'], isNotNull);
+        expect(json['webSearchQueries'], ['test query']);
+        expect(json['googleMapsWidgetContextToken'], 'token-456');
+      });
+
+      test('omits null fields from JSON', () {
+        const metadata = GroundingMetadata(webSearchQueries: ['query']);
+
+        final json = metadata.toJson();
+
+        expect(json.containsKey('searchEntryPoint'), false);
+        expect(json.containsKey('groundingChunks'), false);
+        expect(json['webSearchQueries'], ['query']);
+      });
+    });
+
+    test('round-trip conversion preserves data', () {
+      const original = GroundingMetadata(
+        webSearchQueries: ['test', 'query'],
+        googleMapsWidgetContextToken: 'token-roundtrip',
+        retrievalMetadata: RetrievalMetadata(
+          googleSearchDynamicRetrievalScore: 0.75,
+        ),
+      );
+
+      final json = original.toJson();
+      final restored = GroundingMetadata.fromJson(json);
+
+      expect(restored.webSearchQueries, original.webSearchQueries);
+      expect(
+        restored.googleMapsWidgetContextToken,
+        original.googleMapsWidgetContextToken,
+      );
+      expect(
+        restored.retrievalMetadata!.googleSearchDynamicRetrievalScore,
+        original.retrievalMetadata!.googleSearchDynamicRetrievalScore,
+      );
+    });
+  });
+
+  group('GroundingChunk', () {
+    test('fromJson with web chunk', () {
+      final json = {
+        'web': {'uri': 'https://example.com', 'title': 'Example Title'},
+      };
+
+      final chunk = GroundingChunk.fromJson(json);
+
+      expect(chunk.web, isNotNull);
+      expect(chunk.web!.uri, 'https://example.com');
+      expect(chunk.web!.title, 'Example Title');
+      expect(chunk.retrievedContext, isNull);
+    });
+
+    test('toJson serializes correctly', () {
+      const chunk = GroundingChunk(
+        web: Web(uri: 'https://test.com', title: 'Test'),
+      );
+
+      final json = chunk.toJson();
+      final webJson = json['web'] as Map<String, dynamic>?;
+
+      expect(webJson!['uri'], 'https://test.com');
+      expect(webJson['title'], 'Test');
+    });
+  });
+
+  group('GroundingSupport', () {
+    test('fromJson parses all fields', () {
+      final json = {
+        'segment': {'startIndex': 10, 'endIndex': 25, 'text': 'supported text'},
+        'groundingChunkIndices': [0, 1],
+        'confidenceScores': [0.9, 0.8],
+      };
+
+      final support = GroundingSupport.fromJson(json);
+
+      expect(support.segment!.startIndex, 10);
+      expect(support.segment!.endIndex, 25);
+      expect(support.segment!.text, 'supported text');
+      expect(support.groundingChunkIndices, [0, 1]);
+      expect(support.confidenceScores, [0.9, 0.8]);
+    });
+  });
+
+  group('Segment', () {
+    test('fromJson and toJson work correctly', () {
+      final json = {'startIndex': 5, 'endIndex': 15, 'text': 'test segment'};
+
+      final segment = Segment.fromJson(json);
+      expect(segment.startIndex, 5);
+      expect(segment.endIndex, 15);
+      expect(segment.text, 'test segment');
+
+      final output = segment.toJson();
+      expect(output['startIndex'], 5);
+      expect(output['endIndex'], 15);
+      expect(output['text'], 'test segment');
+    });
+  });
+
+  group('RetrievalMetadata', () {
+    test('fromJson parses score correctly', () {
+      final json = {'googleSearchDynamicRetrievalScore': 0.85};
+
+      final metadata = RetrievalMetadata.fromJson(json);
+
+      expect(metadata.googleSearchDynamicRetrievalScore, 0.85);
+    });
+
+    test('toJson serializes correctly', () {
+      const metadata = RetrievalMetadata(
+        googleSearchDynamicRetrievalScore: 0.9,
+      );
+
+      final json = metadata.toJson();
+
+      expect(json['googleSearchDynamicRetrievalScore'], 0.9);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds comprehensive grounding metadata support for Google AI responses, enabling tracking of search grounding, citations, and retrieval context.

### New Models
- `GroundingMetadata` - Main container for grounding information
- `GroundingChunk` - Source chunk information
- `GroundingSupport` - Text segment support with grounding
- `Segment` - Text segment with indices
- `Web` - Web grounding source
- `Maps` - Maps grounding for location queries
- `PlaceAnswerSources` - Place information sources
- `ReviewSnippet` - Review excerpt data
- `LatLng` - Geographic coordinates
- `RetrievalMetadata` - Retrieval operation metadata
- `RetrievedContext` - Retrieved context information
- `SearchEntryPoint` - Search entry point data

### Updates
- `Candidate` now includes `groundingMetadata` and `finishMessage` fields

## Test plan

- [x] `dart analyze` passes
- [x] Unit tests for grounding metadata models included