### PR TITLE
feat(googleai_dart): Add FileSearch tool

### DIFF
--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -131,6 +131,7 @@ export 'src/models/safety/safety_setting.dart';
 // Models - Tools
 export 'src/models/tools/code_execution_result.dart';
 export 'src/models/tools/executable_code.dart';
+export 'src/models/tools/file_search.dart';
 export 'src/models/tools/function_call.dart';
 // Models - Tools (additional)
 export 'src/models/tools/function_calling_config.dart';

--- a/packages/googleai_dart/lib/src/models/tools/file_search.dart
+++ b/packages/googleai_dart/lib/src/models/tools/file_search.dart
@@ -1,0 +1,61 @@
+import '../copy_with_sentinel.dart';
+
+/// The FileSearch tool that retrieves knowledge from Semantic Retrieval
+/// corpora.
+///
+/// Files are imported to Semantic Retrieval corpora using the ImportFile API.
+class FileSearch {
+  /// Required. The names of the file_search_stores to retrieve from.
+  ///
+  /// Example: `fileSearchStores/my-file-search-store-123`
+  final List<String> fileSearchStoreNames;
+
+  /// Optional. The number of semantic retrieval chunks to retrieve.
+  final int? topK;
+
+  /// Optional. Metadata filter to apply to the semantic retrieval documents
+  /// and chunks.
+  final String? metadataFilter;
+
+  /// Creates a [FileSearch].
+  const FileSearch({
+    required this.fileSearchStoreNames,
+    this.topK,
+    this.metadataFilter,
+  });
+
+  /// Creates a [FileSearch] from JSON.
+  factory FileSearch.fromJson(Map<String, dynamic> json) => FileSearch(
+    fileSearchStoreNames: (json['fileSearchStoreNames'] as List)
+        .map((e) => e as String)
+        .toList(),
+    topK: json['topK'] as int?,
+    metadataFilter: json['metadataFilter'] as String?,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'fileSearchStoreNames': fileSearchStoreNames,
+    if (topK != null) 'topK': topK,
+    if (metadataFilter != null) 'metadataFilter': metadataFilter,
+  };
+
+  /// Creates a copy with replaced values.
+  FileSearch copyWith({
+    List<String>? fileSearchStoreNames,
+    Object? topK = unsetCopyWithValue,
+    Object? metadataFilter = unsetCopyWithValue,
+  }) {
+    return FileSearch(
+      fileSearchStoreNames: fileSearchStoreNames ?? this.fileSearchStoreNames,
+      topK: topK == unsetCopyWithValue ? this.topK : topK as int?,
+      metadataFilter: metadataFilter == unsetCopyWithValue
+          ? this.metadataFilter
+          : metadataFilter as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'FileSearch(fileSearchStoreNames: $fileSearchStoreNames, topK: $topK, metadataFilter: $metadataFilter)';
+}

--- a/packages/googleai_dart/lib/src/models/tools/tool.dart
+++ b/packages/googleai_dart/lib/src/models/tools/tool.dart
@@ -1,4 +1,5 @@
 import '../copy_with_sentinel.dart';
+import 'file_search.dart';
 import 'function_declaration.dart';
 
 /// Tool that the model may use to generate a response.
@@ -12,11 +13,15 @@ class Tool {
   /// Google search capability.
   final Map<String, dynamic>? googleSearch;
 
+  /// File search tool that retrieves knowledge from file search stores.
+  final FileSearch? fileSearch;
+
   /// Creates a [Tool].
   const Tool({
     this.functionDeclarations,
     this.codeExecution,
     this.googleSearch,
+    this.fileSearch,
   });
 
   /// Creates a [Tool] from JSON.
@@ -30,6 +35,9 @@ class Tool {
         : null,
     codeExecution: json['codeExecution'] as Map<String, dynamic>?,
     googleSearch: json['googleSearch'] as Map<String, dynamic>?,
+    fileSearch: json['fileSearch'] != null
+        ? FileSearch.fromJson(json['fileSearch'] as Map<String, dynamic>)
+        : null,
   );
 
   /// Converts to JSON.
@@ -40,6 +48,7 @@ class Tool {
           .toList(),
     if (codeExecution != null) 'codeExecution': codeExecution,
     if (googleSearch != null) 'googleSearch': googleSearch,
+    if (fileSearch != null) 'fileSearch': fileSearch!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -47,6 +56,7 @@ class Tool {
     Object? functionDeclarations = unsetCopyWithValue,
     Object? codeExecution = unsetCopyWithValue,
     Object? googleSearch = unsetCopyWithValue,
+    Object? fileSearch = unsetCopyWithValue,
   }) {
     return Tool(
       functionDeclarations: functionDeclarations == unsetCopyWithValue
@@ -58,6 +68,9 @@ class Tool {
       googleSearch: googleSearch == unsetCopyWithValue
           ? this.googleSearch
           : googleSearch as Map<String, dynamic>?,
+      fileSearch: fileSearch == unsetCopyWithValue
+          ? this.fileSearch
+          : fileSearch as FileSearch?,
     );
   }
 }

--- a/packages/googleai_dart/test/unit/models/tools/file_search_test.dart
+++ b/packages/googleai_dart/test/unit/models/tools/file_search_test.dart
@@ -1,0 +1,124 @@
+import 'package:googleai_dart/src/models/tools/file_search.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FileSearch', () {
+    group('fromJson', () {
+      test('creates FileSearch with all fields', () {
+        final json = {
+          'fileSearchStoreNames': [
+            'fileSearchStores/store-1',
+            'fileSearchStores/store-2',
+          ],
+          'topK': 10,
+          'metadataFilter': 'category = "docs"',
+        };
+
+        final fileSearch = FileSearch.fromJson(json);
+
+        expect(fileSearch.fileSearchStoreNames, [
+          'fileSearchStores/store-1',
+          'fileSearchStores/store-2',
+        ]);
+        expect(fileSearch.topK, 10);
+        expect(fileSearch.metadataFilter, 'category = "docs"');
+      });
+
+      test('creates FileSearch with only required fields', () {
+        final json = {
+          'fileSearchStoreNames': ['fileSearchStores/my-store'],
+        };
+
+        final fileSearch = FileSearch.fromJson(json);
+
+        expect(fileSearch.fileSearchStoreNames, ['fileSearchStores/my-store']);
+        expect(fileSearch.topK, isNull);
+        expect(fileSearch.metadataFilter, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('converts FileSearch with all fields to JSON', () {
+        const fileSearch = FileSearch(
+          fileSearchStoreNames: ['fileSearchStores/test-store'],
+          topK: 5,
+          metadataFilter: 'type = "pdf"',
+        );
+
+        final json = fileSearch.toJson();
+
+        expect(json['fileSearchStoreNames'], ['fileSearchStores/test-store']);
+        expect(json['topK'], 5);
+        expect(json['metadataFilter'], 'type = "pdf"');
+      });
+
+      test('omits null fields from JSON', () {
+        const fileSearch = FileSearch(
+          fileSearchStoreNames: ['fileSearchStores/store'],
+        );
+
+        final json = fileSearch.toJson();
+
+        expect(json['fileSearchStoreNames'], ['fileSearchStores/store']);
+        expect(json.containsKey('topK'), false);
+        expect(json.containsKey('metadataFilter'), false);
+      });
+    });
+
+    test('round-trip conversion preserves data', () {
+      const original = FileSearch(
+        fileSearchStoreNames: ['fileSearchStores/roundtrip'],
+        topK: 15,
+        metadataFilter: 'status = "active"',
+      );
+
+      final json = original.toJson();
+      final restored = FileSearch.fromJson(json);
+
+      expect(restored.fileSearchStoreNames, original.fileSearchStoreNames);
+      expect(restored.topK, original.topK);
+      expect(restored.metadataFilter, original.metadataFilter);
+    });
+
+    group('copyWith', () {
+      test('creates copy with replaced values', () {
+        const original = FileSearch(
+          fileSearchStoreNames: ['fileSearchStores/original'],
+          topK: 5,
+        );
+
+        final copy = original.copyWith(topK: 10);
+
+        expect(copy.fileSearchStoreNames, ['fileSearchStores/original']);
+        expect(copy.topK, 10);
+      });
+
+      test('can set optional values to null', () {
+        const original = FileSearch(
+          fileSearchStoreNames: ['fileSearchStores/test'],
+          topK: 5,
+          metadataFilter: 'filter',
+        );
+
+        final copy = original.copyWith(metadataFilter: null);
+
+        expect(copy.fileSearchStoreNames, ['fileSearchStores/test']);
+        expect(copy.topK, 5);
+        expect(copy.metadataFilter, isNull);
+      });
+    });
+
+    test('toString includes all fields', () {
+      const fileSearch = FileSearch(
+        fileSearchStoreNames: ['fileSearchStores/store-1'],
+        topK: 10,
+      );
+
+      final str = fileSearch.toString();
+
+      expect(str, contains('FileSearch('));
+      expect(str, contains('fileSearchStoreNames:'));
+      expect(str, contains('topK: 10'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds support for the FileSearch tool, which enables models to retrieve knowledge from file search stores for grounded responses.

### New Model
- `FileSearch` - Configuration for file search tool with store sources and max results

### Updates
- `Tool` class now includes `fileSearch` property

## Test plan

- [x] `dart analyze` passes
- [x] Unit tests for FileSearch model included