### PR TITLE
feat(googleai_dart): Add McpServers tool

### DIFF
--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -137,6 +137,8 @@ export 'src/models/tools/function_call.dart';
 export 'src/models/tools/function_calling_config.dart';
 export 'src/models/tools/function_declaration.dart';
 export 'src/models/tools/function_response.dart';
+export 'src/models/tools/mcp_server.dart';
+export 'src/models/tools/streamable_http_transport.dart';
 export 'src/models/tools/tool.dart';
 export 'src/models/tools/tool_config.dart';
 // Utilities

--- a/packages/googleai_dart/lib/src/models/tools/mcp_server.dart
+++ b/packages/googleai_dart/lib/src/models/tools/mcp_server.dart
@@ -1,0 +1,50 @@
+import '../copy_with_sentinel.dart';
+import 'streamable_http_transport.dart';
+
+/// A MCPServer is a server that can be called by the model to perform actions.
+///
+/// It is a server that implements the MCP protocol.
+class McpServer {
+  /// The name of the MCPServer.
+  final String? name;
+
+  /// A transport that can stream HTTP requests and responses.
+  final StreamableHttpTransport? streamableHttpTransport;
+
+  /// Creates a [McpServer].
+  const McpServer({this.name, this.streamableHttpTransport});
+
+  /// Creates a [McpServer] from JSON.
+  factory McpServer.fromJson(Map<String, dynamic> json) => McpServer(
+    name: json['name'] as String?,
+    streamableHttpTransport: json['streamableHttpTransport'] != null
+        ? StreamableHttpTransport.fromJson(
+            json['streamableHttpTransport'] as Map<String, dynamic>,
+          )
+        : null,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (name != null) 'name': name,
+    if (streamableHttpTransport != null)
+      'streamableHttpTransport': streamableHttpTransport!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  McpServer copyWith({
+    Object? name = unsetCopyWithValue,
+    Object? streamableHttpTransport = unsetCopyWithValue,
+  }) {
+    return McpServer(
+      name: name == unsetCopyWithValue ? this.name : name as String?,
+      streamableHttpTransport: streamableHttpTransport == unsetCopyWithValue
+          ? this.streamableHttpTransport
+          : streamableHttpTransport as StreamableHttpTransport?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'McpServer(name: $name, streamableHttpTransport: $streamableHttpTransport)';
+}

--- a/packages/googleai_dart/lib/src/models/tools/streamable_http_transport.dart
+++ b/packages/googleai_dart/lib/src/models/tools/streamable_http_transport.dart
@@ -1,0 +1,80 @@
+import '../copy_with_sentinel.dart';
+
+/// A transport that can stream HTTP requests and responses.
+class StreamableHttpTransport {
+  /// The full URL for the MCPServer endpoint.
+  ///
+  /// Example: "https://api.example.com/mcp"
+  final String? url;
+
+  /// Optional: Fields for authentication headers, timeouts, etc., if needed.
+  final Map<String, String>? headers;
+
+  /// HTTP timeout for regular operations.
+  final String? timeout;
+
+  /// Timeout for SSE read operations.
+  final String? sseReadTimeout;
+
+  /// Whether to close the client session when the transport closes.
+  final bool? terminateOnClose;
+
+  /// Creates a [StreamableHttpTransport].
+  const StreamableHttpTransport({
+    this.url,
+    this.headers,
+    this.timeout,
+    this.sseReadTimeout,
+    this.terminateOnClose,
+  });
+
+  /// Creates a [StreamableHttpTransport] from JSON.
+  factory StreamableHttpTransport.fromJson(Map<String, dynamic> json) =>
+      StreamableHttpTransport(
+        url: json['url'] as String?,
+        headers: (json['headers'] as Map<String, dynamic>?)?.map(
+          (k, v) => MapEntry(k, v as String),
+        ),
+        timeout: json['timeout'] as String?,
+        sseReadTimeout: json['sseReadTimeout'] as String?,
+        terminateOnClose: json['terminateOnClose'] as bool?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (url != null) 'url': url,
+    if (headers != null) 'headers': headers,
+    if (timeout != null) 'timeout': timeout,
+    if (sseReadTimeout != null) 'sseReadTimeout': sseReadTimeout,
+    if (terminateOnClose != null) 'terminateOnClose': terminateOnClose,
+  };
+
+  /// Creates a copy with replaced values.
+  StreamableHttpTransport copyWith({
+    Object? url = unsetCopyWithValue,
+    Object? headers = unsetCopyWithValue,
+    Object? timeout = unsetCopyWithValue,
+    Object? sseReadTimeout = unsetCopyWithValue,
+    Object? terminateOnClose = unsetCopyWithValue,
+  }) {
+    return StreamableHttpTransport(
+      url: url == unsetCopyWithValue ? this.url : url as String?,
+      headers: headers == unsetCopyWithValue
+          ? this.headers
+          : headers as Map<String, String>?,
+      timeout: timeout == unsetCopyWithValue
+          ? this.timeout
+          : timeout as String?,
+      sseReadTimeout: sseReadTimeout == unsetCopyWithValue
+          ? this.sseReadTimeout
+          : sseReadTimeout as String?,
+      terminateOnClose: terminateOnClose == unsetCopyWithValue
+          ? this.terminateOnClose
+          : terminateOnClose as bool?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'StreamableHttpTransport(url: $url, headers: $headers, timeout: $timeout, sseReadTimeout: $sseReadTimeout, terminateOnClose: $terminateOnClose)';
+}

--- a/packages/googleai_dart/lib/src/models/tools/tool.dart
+++ b/packages/googleai_dart/lib/src/models/tools/tool.dart
@@ -1,6 +1,7 @@
 import '../copy_with_sentinel.dart';
 import 'file_search.dart';
 import 'function_declaration.dart';
+import 'mcp_server.dart';
 
 /// Tool that the model may use to generate a response.
 class Tool {
@@ -16,12 +17,16 @@ class Tool {
   /// File search tool that retrieves knowledge from file search stores.
   final FileSearch? fileSearch;
 
+  /// List of MCP servers that can be called by the model.
+  final List<McpServer>? mcpServers;
+
   /// Creates a [Tool].
   const Tool({
     this.functionDeclarations,
     this.codeExecution,
     this.googleSearch,
     this.fileSearch,
+    this.mcpServers,
   });
 
   /// Creates a [Tool] from JSON.
@@ -38,6 +43,11 @@ class Tool {
     fileSearch: json['fileSearch'] != null
         ? FileSearch.fromJson(json['fileSearch'] as Map<String, dynamic>)
         : null,
+    mcpServers: json['mcpServers'] != null
+        ? (json['mcpServers'] as List)
+              .map((e) => McpServer.fromJson(e as Map<String, dynamic>))
+              .toList()
+        : null,
   );
 
   /// Converts to JSON.
@@ -49,6 +59,8 @@ class Tool {
     if (codeExecution != null) 'codeExecution': codeExecution,
     if (googleSearch != null) 'googleSearch': googleSearch,
     if (fileSearch != null) 'fileSearch': fileSearch!.toJson(),
+    if (mcpServers != null)
+      'mcpServers': mcpServers!.map((e) => e.toJson()).toList(),
   };
 
   /// Creates a copy with replaced values.
@@ -57,6 +69,7 @@ class Tool {
     Object? codeExecution = unsetCopyWithValue,
     Object? googleSearch = unsetCopyWithValue,
     Object? fileSearch = unsetCopyWithValue,
+    Object? mcpServers = unsetCopyWithValue,
   }) {
     return Tool(
       functionDeclarations: functionDeclarations == unsetCopyWithValue
@@ -71,6 +84,9 @@ class Tool {
       fileSearch: fileSearch == unsetCopyWithValue
           ? this.fileSearch
           : fileSearch as FileSearch?,
+      mcpServers: mcpServers == unsetCopyWithValue
+          ? this.mcpServers
+          : mcpServers as List<McpServer>?,
     );
   }
 }

--- a/packages/googleai_dart/test/unit/models/tools/mcp_server_test.dart
+++ b/packages/googleai_dart/test/unit/models/tools/mcp_server_test.dart
@@ -1,0 +1,124 @@
+import 'package:googleai_dart/src/models/tools/mcp_server.dart';
+import 'package:googleai_dart/src/models/tools/streamable_http_transport.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('McpServer', () {
+    group('fromJson', () {
+      test('creates McpServer with all fields', () {
+        final json = {
+          'name': 'my-mcp-server',
+          'streamableHttpTransport': {
+            'url': 'https://mcp.example.com/transport',
+          },
+        };
+
+        final server = McpServer.fromJson(json);
+
+        expect(server.name, 'my-mcp-server');
+        expect(server.streamableHttpTransport, isNotNull);
+        expect(
+          server.streamableHttpTransport!.url,
+          'https://mcp.example.com/transport',
+        );
+      });
+
+      test('creates McpServer with minimal fields', () {
+        final json = <String, dynamic>{};
+
+        final server = McpServer.fromJson(json);
+
+        expect(server.name, isNull);
+        expect(server.streamableHttpTransport, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('converts McpServer with all fields to JSON', () {
+        const server = McpServer(
+          name: 'test-server',
+          streamableHttpTransport: StreamableHttpTransport(
+            url: 'https://test.com/mcp',
+          ),
+        );
+
+        final json = server.toJson();
+
+        expect(json['name'], 'test-server');
+        expect(json['streamableHttpTransport'], isNotNull);
+        expect(
+          (json['streamableHttpTransport'] as Map<String, dynamic>)['url'],
+          'https://test.com/mcp',
+        );
+      });
+
+      test('omits null fields from JSON', () {
+        const server = McpServer(name: 'simple-server');
+
+        final json = server.toJson();
+
+        expect(json['name'], 'simple-server');
+        expect(json.containsKey('streamableHttpTransport'), false);
+      });
+    });
+
+    test('round-trip conversion preserves data', () {
+      const original = McpServer(
+        name: 'roundtrip-server',
+        streamableHttpTransport: StreamableHttpTransport(
+          url: 'https://roundtrip.test/mcp',
+        ),
+      );
+
+      final json = original.toJson();
+      final restored = McpServer.fromJson(json);
+
+      expect(restored.name, original.name);
+      expect(
+        restored.streamableHttpTransport!.url,
+        original.streamableHttpTransport!.url,
+      );
+    });
+
+    group('copyWith', () {
+      test('creates copy with replaced values', () {
+        const original = McpServer(name: 'original-name');
+
+        final copy = original.copyWith(name: 'new-name');
+
+        expect(copy.name, 'new-name');
+      });
+    });
+
+    test('toString includes all fields', () {
+      const server = McpServer(name: 'my-server');
+
+      final str = server.toString();
+
+      expect(str, contains('McpServer('));
+      expect(str, contains('name: my-server'));
+    });
+  });
+
+  group('StreamableHttpTransport', () {
+    test('fromJson and toJson work correctly', () {
+      final json = {'url': 'https://mcp.example.com'};
+
+      final transport = StreamableHttpTransport.fromJson(json);
+      expect(transport.url, 'https://mcp.example.com');
+
+      final output = transport.toJson();
+      expect(output['url'], 'https://mcp.example.com');
+    });
+
+    test('handles null url', () {
+      final json = <String, dynamic>{};
+
+      final transport = StreamableHttpTransport.fromJson(json);
+      expect(transport.url, isNull);
+
+      final output = transport.toJson();
+      expect(output.containsKey('url'), false);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds support for MCP (Model Context Protocol) servers, which allow models to call external tools and services through the MCP standard.

### New Models
- `McpServer` - MCP server configuration with URL and tool names
- `StreamableHttpTransport` - HTTP transport configuration for MCP

### Updates
- `Tool` class now includes `mcpServers` property

## Test plan
- [x] `dart analyze` passes
- [x] Unit tests for McpServer model included