### PR TITLE
feat(googleai_dart): Add GoogleMaps tool

### DIFF
--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -137,6 +137,7 @@ export 'src/models/tools/function_call.dart';
 export 'src/models/tools/function_calling_config.dart';
 export 'src/models/tools/function_declaration.dart';
 export 'src/models/tools/function_response.dart';
+export 'src/models/tools/google_maps.dart';
 export 'src/models/tools/mcp_server.dart';
 export 'src/models/tools/streamable_http_transport.dart';
 export 'src/models/tools/tool.dart';

--- a/packages/googleai_dart/lib/src/models/tools/google_maps.dart
+++ b/packages/googleai_dart/lib/src/models/tools/google_maps.dart
@@ -1,0 +1,36 @@
+import '../copy_with_sentinel.dart';
+
+/// The GoogleMaps Tool that provides geospatial context for the user's query.
+class GoogleMaps {
+  /// Optional. Whether to return a widget context token in the
+  /// GroundingMetadata of the response.
+  ///
+  /// Developers can use the widget context token to render a Google Maps
+  /// widget with geospatial context related to the places that the model
+  /// references in the response.
+  final bool? enableWidget;
+
+  /// Creates a [GoogleMaps].
+  const GoogleMaps({this.enableWidget});
+
+  /// Creates a [GoogleMaps] from JSON.
+  factory GoogleMaps.fromJson(Map<String, dynamic> json) =>
+      GoogleMaps(enableWidget: json['enableWidget'] as bool?);
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (enableWidget != null) 'enableWidget': enableWidget,
+  };
+
+  /// Creates a copy with replaced values.
+  GoogleMaps copyWith({Object? enableWidget = unsetCopyWithValue}) {
+    return GoogleMaps(
+      enableWidget: enableWidget == unsetCopyWithValue
+          ? this.enableWidget
+          : enableWidget as bool?,
+    );
+  }
+
+  @override
+  String toString() => 'GoogleMaps(enableWidget: $enableWidget)';
+}

--- a/packages/googleai_dart/lib/src/models/tools/tool.dart
+++ b/packages/googleai_dart/lib/src/models/tools/tool.dart
@@ -1,6 +1,7 @@
 import '../copy_with_sentinel.dart';
 import 'file_search.dart';
 import 'function_declaration.dart';
+import 'google_maps.dart';
 import 'mcp_server.dart';
 
 /// Tool that the model may use to generate a response.
@@ -20,6 +21,9 @@ class Tool {
   /// List of MCP servers that can be called by the model.
   final List<McpServer>? mcpServers;
 
+  /// Google Maps tool that provides geospatial context.
+  final GoogleMaps? googleMaps;
+
   /// Creates a [Tool].
   const Tool({
     this.functionDeclarations,
@@ -27,6 +31,7 @@ class Tool {
     this.googleSearch,
     this.fileSearch,
     this.mcpServers,
+    this.googleMaps,
   });
 
   /// Creates a [Tool] from JSON.
@@ -48,6 +53,9 @@ class Tool {
               .map((e) => McpServer.fromJson(e as Map<String, dynamic>))
               .toList()
         : null,
+    googleMaps: json['googleMaps'] != null
+        ? GoogleMaps.fromJson(json['googleMaps'] as Map<String, dynamic>)
+        : null,
   );
 
   /// Converts to JSON.
@@ -61,6 +69,7 @@ class Tool {
     if (fileSearch != null) 'fileSearch': fileSearch!.toJson(),
     if (mcpServers != null)
       'mcpServers': mcpServers!.map((e) => e.toJson()).toList(),
+    if (googleMaps != null) 'googleMaps': googleMaps!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -70,6 +79,7 @@ class Tool {
     Object? googleSearch = unsetCopyWithValue,
     Object? fileSearch = unsetCopyWithValue,
     Object? mcpServers = unsetCopyWithValue,
+    Object? googleMaps = unsetCopyWithValue,
   }) {
     return Tool(
       functionDeclarations: functionDeclarations == unsetCopyWithValue
@@ -87,6 +97,9 @@ class Tool {
       mcpServers: mcpServers == unsetCopyWithValue
           ? this.mcpServers
           : mcpServers as List<McpServer>?,
+      googleMaps: googleMaps == unsetCopyWithValue
+          ? this.googleMaps
+          : googleMaps as GoogleMaps?,
     );
   }
 }


### PR DESCRIPTION
## Summary

Adds support for the GoogleMaps tool, which enables models to access geospatial context for location-based queries.

### New Model
- `GoogleMaps` - Google Maps tool configuration

### Updates
- `Tool` class now includes `googleMaps` property

## Test plan
- [x] `dart analyze` passes