### PR TITLE
feat(googleai_dart): Add MediaResolution to Part

### DIFF
--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -35,6 +35,7 @@ export 'src/models/content/citation_metadata.dart';
 export 'src/models/content/content.dart';
 export 'src/models/content/file_data.dart';
 export 'src/models/content/logprobs_result.dart';
+export 'src/models/content/media_resolution.dart';
 export 'src/models/content/part.dart';
 // Models - Corpus API
 export 'src/models/corpus/corpus.dart';

--- a/packages/googleai_dart/lib/src/models/content/media_resolution.dart
+++ b/packages/googleai_dart/lib/src/models/content/media_resolution.dart
@@ -1,0 +1,64 @@
+import '../copy_with_sentinel.dart';
+
+/// Media resolution for the input media.
+class MediaResolution {
+  /// The media resolution level.
+  final MediaResolutionLevel? level;
+
+  /// Creates a [MediaResolution].
+  const MediaResolution({this.level});
+
+  /// Creates a [MediaResolution] from JSON.
+  factory MediaResolution.fromJson(Map<String, dynamic> json) =>
+      MediaResolution(
+        level: json['level'] != null
+            ? MediaResolutionLevel.fromString(json['level'] as String)
+            : null,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {if (level != null) 'level': level!.value};
+
+  /// Creates a copy with replaced values.
+  MediaResolution copyWith({Object? level = unsetCopyWithValue}) {
+    return MediaResolution(
+      level: level == unsetCopyWithValue
+          ? this.level
+          : level as MediaResolutionLevel?,
+    );
+  }
+
+  @override
+  String toString() => 'MediaResolution(level: $level)';
+}
+
+/// Media resolution level.
+enum MediaResolutionLevel {
+  /// Media resolution has not been set.
+  unspecified('MEDIA_RESOLUTION_UNSPECIFIED'),
+
+  /// Media resolution set to low.
+  low('MEDIA_RESOLUTION_LOW'),
+
+  /// Media resolution set to medium.
+  medium('MEDIA_RESOLUTION_MEDIUM'),
+
+  /// Media resolution set to high.
+  high('MEDIA_RESOLUTION_HIGH'),
+
+  /// Media resolution set to ultra high.
+  ultraHigh('MEDIA_RESOLUTION_ULTRA_HIGH');
+
+  const MediaResolutionLevel(this.value);
+
+  /// The string value of the enum.
+  final String value;
+
+  /// Creates a [MediaResolutionLevel] from a string value.
+  static MediaResolutionLevel fromString(String value) {
+    return MediaResolutionLevel.values.firstWhere(
+      (e) => e.value == value,
+      orElse: () => MediaResolutionLevel.unspecified,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/content/part.dart
+++ b/packages/googleai_dart/lib/src/models/content/part.dart
@@ -8,6 +8,7 @@ import '../tools/function_call.dart';
 import '../tools/function_response.dart';
 import 'blob.dart';
 import 'file_data.dart';
+import 'media_resolution.dart';
 
 /// A single unit of content (text, media, function call, etc.).
 ///
@@ -24,11 +25,21 @@ sealed class Part {
     if (json.containsKey('inlineData')) {
       return InlineDataPart(
         Blob.fromJson(json['inlineData'] as Map<String, dynamic>),
+        mediaResolution: json['mediaResolution'] != null
+            ? MediaResolution.fromJson(
+                json['mediaResolution'] as Map<String, dynamic>,
+              )
+            : null,
       );
     }
     if (json.containsKey('fileData')) {
       return FileDataPart(
         FileData.fromJson(json['fileData'] as Map<String, dynamic>),
+        mediaResolution: json['mediaResolution'] != null
+            ? MediaResolution.fromJson(
+                json['mediaResolution'] as Map<String, dynamic>,
+              )
+            : null,
       );
     }
     if (json.containsKey('functionCall')) {
@@ -100,16 +111,28 @@ class InlineDataPart extends Part {
   /// Inline binary data.
   final Blob inlineData;
 
+  /// Optional media resolution for the input media.
+  final MediaResolution? mediaResolution;
+
   /// Creates an [InlineDataPart].
-  const InlineDataPart(this.inlineData);
+  const InlineDataPart(this.inlineData, {this.mediaResolution});
 
   @override
-  Map<String, dynamic> toJson() => {'inlineData': inlineData.toJson()};
+  Map<String, dynamic> toJson() => {
+    'inlineData': inlineData.toJson(),
+    if (mediaResolution != null) 'mediaResolution': mediaResolution!.toJson(),
+  };
 
   /// Creates a copy with replaced values.
-  InlineDataPart copyWith({Object? inlineData = unsetCopyWithValue}) {
+  InlineDataPart copyWith({
+    Object? inlineData = unsetCopyWithValue,
+    Object? mediaResolution = unsetCopyWithValue,
+  }) {
     return InlineDataPart(
       inlineData == unsetCopyWithValue ? this.inlineData : inlineData! as Blob,
+      mediaResolution: mediaResolution == unsetCopyWithValue
+          ? this.mediaResolution
+          : mediaResolution as MediaResolution?,
     );
   }
 }
@@ -119,16 +142,28 @@ class FileDataPart extends Part {
   /// File reference.
   final FileData fileData;
 
+  /// Optional media resolution for the input media.
+  final MediaResolution? mediaResolution;
+
   /// Creates a [FileDataPart].
-  const FileDataPart(this.fileData);
+  const FileDataPart(this.fileData, {this.mediaResolution});
 
   @override
-  Map<String, dynamic> toJson() => {'fileData': fileData.toJson()};
+  Map<String, dynamic> toJson() => {
+    'fileData': fileData.toJson(),
+    if (mediaResolution != null) 'mediaResolution': mediaResolution!.toJson(),
+  };
 
   /// Creates a copy with replaced values.
-  FileDataPart copyWith({Object? fileData = unsetCopyWithValue}) {
+  FileDataPart copyWith({
+    Object? fileData = unsetCopyWithValue,
+    Object? mediaResolution = unsetCopyWithValue,
+  }) {
     return FileDataPart(
       fileData == unsetCopyWithValue ? this.fileData : fileData! as FileData,
+      mediaResolution: mediaResolution == unsetCopyWithValue
+          ? this.mediaResolution
+          : mediaResolution as MediaResolution?,
     );
   }
 }

--- a/packages/googleai_dart/test/unit/models/content/part_test.dart
+++ b/packages/googleai_dart/test/unit/models/content/part_test.dart
@@ -83,6 +83,86 @@ void main() {
           equals(original.inlineData.mimeType),
         );
       });
+
+      group('with mediaResolution', () {
+        test('creates with mediaResolution from JSON', () {
+          final json = {
+            'inlineData': {
+              'mimeType': 'image/png',
+              'data': base64.encode([1, 2, 3]),
+            },
+            'mediaResolution': {'level': 'MEDIA_RESOLUTION_HIGH'},
+          };
+          final part = Part.fromJson(json);
+          expect(part, isA<InlineDataPart>());
+          final inlinePart = part as InlineDataPart;
+          expect(inlinePart.mediaResolution, isNotNull);
+          expect(
+            inlinePart.mediaResolution!.level,
+            equals(MediaResolutionLevel.high),
+          );
+        });
+
+        test('serializes mediaResolution to JSON', () {
+          const part = InlineDataPart(
+            Blob(mimeType: 'image/png', data: 'data'),
+            mediaResolution: MediaResolution(
+              level: MediaResolutionLevel.medium,
+            ),
+          );
+          final json = part.toJson();
+          expect(json.containsKey('mediaResolution'), isTrue);
+          expect(
+            json['mediaResolution']['level'],
+            equals('MEDIA_RESOLUTION_MEDIUM'),
+          );
+        });
+
+        test('omits mediaResolution when null', () {
+          const part = InlineDataPart(
+            Blob(mimeType: 'image/png', data: 'data'),
+          );
+          final json = part.toJson();
+          expect(json.containsKey('mediaResolution'), isFalse);
+        });
+
+        test('roundtrip with mediaResolution', () {
+          const original = InlineDataPart(
+            Blob(mimeType: 'video/mp4', data: 'videodata'),
+            mediaResolution: MediaResolution(
+              level: MediaResolutionLevel.ultraHigh,
+            ),
+          );
+          final json = original.toJson();
+          final deserialized = Part.fromJson(json) as InlineDataPart;
+          expect(
+            deserialized.mediaResolution!.level,
+            equals(original.mediaResolution!.level),
+          );
+        });
+
+        test('copyWith can update mediaResolution', () {
+          const original = InlineDataPart(
+            Blob(mimeType: 'image/png', data: 'data'),
+          );
+          final copy = original.copyWith(
+            mediaResolution: const MediaResolution(
+              level: MediaResolutionLevel.low,
+            ),
+          );
+          expect(copy.mediaResolution, isNotNull);
+          expect(copy.mediaResolution!.level, equals(MediaResolutionLevel.low));
+        });
+
+        test('copyWith can set mediaResolution to null', () {
+          const original = InlineDataPart(
+            Blob(mimeType: 'image/png', data: 'data'),
+            mediaResolution: MediaResolution(level: MediaResolutionLevel.high),
+          );
+          final copy = original.copyWith(mediaResolution: null);
+          expect(copy.mediaResolution, isNull);
+        });
+      });
     });
 
     group('FileDataPart', () {
@@ -127,6 +207,85 @@ void main() {
           (deserialized as FileDataPart).fileData.fileUri,
           equals(original.fileData.fileUri),
         );
+      });
+
+      group('with mediaResolution', () {
+        test('creates with mediaResolution from JSON', () {
+          final json = {
+            'fileData': {
+              'fileUri': 'gs://bucket/video.mp4',
+              'mimeType': 'video/mp4',
+            },
+            'mediaResolution': {'level': 'MEDIA_RESOLUTION_LOW'},
+          };
+          final part = Part.fromJson(json);
+          expect(part, isA<FileDataPart>());
+          final filePart = part as FileDataPart;
+          expect(filePart.mediaResolution, isNotNull);
+          expect(
+            filePart.mediaResolution!.level,
+            equals(MediaResolutionLevel.low),
+          );
+        });
+
+        test('serializes mediaResolution to JSON', () {
+          const part = FileDataPart(
+            FileData(fileUri: 'gs://bucket/file'),
+            mediaResolution: MediaResolution(
+              level: MediaResolutionLevel.ultraHigh,
+            ),
+          );
+          final json = part.toJson();
+          expect(json.containsKey('mediaResolution'), isTrue);
+          expect(
+            json['mediaResolution']['level'],
+            equals('MEDIA_RESOLUTION_ULTRA_HIGH'),
+          );
+        });
+
+        test('omits mediaResolution when null', () {
+          const part = FileDataPart(FileData(fileUri: 'gs://bucket/file'));
+          final json = part.toJson();
+          expect(json.containsKey('mediaResolution'), isFalse);
+        });
+
+        test('roundtrip with mediaResolution', () {
+          const original = FileDataPart(
+            FileData(fileUri: 'gs://bucket/video.mp4', mimeType: 'video/mp4'),
+            mediaResolution: MediaResolution(
+              level: MediaResolutionLevel.medium,
+            ),
+          );
+          final json = original.toJson();
+          final deserialized = Part.fromJson(json) as FileDataPart;
+          expect(
+            deserialized.mediaResolution!.level,
+            equals(original.mediaResolution!.level),
+          );
+        });
+
+        test('copyWith can update mediaResolution', () {
+          const original = FileDataPart(FileData(fileUri: 'gs://test'));
+          final copy = original.copyWith(
+            mediaResolution: const MediaResolution(
+              level: MediaResolutionLevel.high,
+            ),
+          );
+          expect(copy.mediaResolution, isNotNull);
+          expect(
+            copy.mediaResolution!.level,
+            equals(MediaResolutionLevel.high),
+          );
+        });
+
+        test('copyWith can set mediaResolution to null', () {
+          const original = FileDataPart(
+            FileData(fileUri: 'gs://test'),
+            mediaResolution: MediaResolution(level: MediaResolutionLevel.low),
+          );
+          final copy = original.copyWith(mediaResolution: null);
+          expect(copy.mediaResolution, isNull);
+        });
       });
     });
 


### PR DESCRIPTION
## Summary

Adds MediaResolution enum for controlling image and video quality settings in Part models.

### New Model
- `MediaResolution` - Enum with low, medium, high resolution options

### Updates
- Part subclasses now support optional `mediaResolution` property
- `InlineDataPart`, `FileDataPart`, and `VideoMetadataPart` include resolution

## Test plan
- [x] `dart analyze` passes
- [x] Unit tests for Part with media resolution included