### PR TITLE
feat(googleai_dart): Add RetrievalConfig to ToolConfig

### DIFF
--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -92,6 +92,7 @@ export 'src/models/metadata/lat_lng.dart';
 export 'src/models/metadata/maps.dart';
 export 'src/models/metadata/modality_token_count.dart';
 export 'src/models/metadata/place_answer_sources.dart';
+export 'src/models/metadata/retrieval_config.dart';
 export 'src/models/metadata/retrieval_metadata.dart';
 export 'src/models/metadata/retrieved_context.dart';
 export 'src/models/metadata/review_snippet.dart';

--- a/packages/googleai_dart/lib/src/models/metadata/retrieval_config.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/retrieval_config.dart
@@ -1,0 +1,49 @@
+import '../copy_with_sentinel.dart';
+import 'lat_lng.dart';
+
+/// Retrieval config.
+class RetrievalConfig {
+  /// Optional. The location of the user.
+  final LatLng? latLng;
+
+  /// Optional. The language code of the user.
+  ///
+  /// Language code for content. Use language tags defined by
+  /// [BCP47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt).
+  final String? languageCode;
+
+  /// Creates a [RetrievalConfig].
+  const RetrievalConfig({this.latLng, this.languageCode});
+
+  /// Creates a [RetrievalConfig] from JSON.
+  factory RetrievalConfig.fromJson(Map<String, dynamic> json) =>
+      RetrievalConfig(
+        latLng: json['latLng'] != null
+            ? LatLng.fromJson(json['latLng'] as Map<String, dynamic>)
+            : null,
+        languageCode: json['languageCode'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (latLng != null) 'latLng': latLng!.toJson(),
+    if (languageCode != null) 'languageCode': languageCode,
+  };
+
+  /// Creates a copy with replaced values.
+  RetrievalConfig copyWith({
+    Object? latLng = unsetCopyWithValue,
+    Object? languageCode = unsetCopyWithValue,
+  }) {
+    return RetrievalConfig(
+      latLng: latLng == unsetCopyWithValue ? this.latLng : latLng as LatLng?,
+      languageCode: languageCode == unsetCopyWithValue
+          ? this.languageCode
+          : languageCode as String?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'RetrievalConfig(latLng: $latLng, languageCode: $languageCode)';
+}

--- a/packages/googleai_dart/lib/src/models/tools/tool_config.dart
+++ b/packages/googleai_dart/lib/src/models/tools/tool_config.dart
@@ -1,4 +1,5 @@
 import '../copy_with_sentinel.dart';
+import '../metadata/retrieval_config.dart';
 import 'function_calling_config.dart';
 
 /// The Tool configuration containing parameters for specifying Tool use
@@ -7,8 +8,11 @@ class ToolConfig {
   /// Function calling config.
   final FunctionCallingConfig? functionCallingConfig;
 
+  /// Retrieval config.
+  final RetrievalConfig? retrievalConfig;
+
   /// Creates a [ToolConfig].
-  const ToolConfig({this.functionCallingConfig});
+  const ToolConfig({this.functionCallingConfig, this.retrievalConfig});
 
   /// Creates a [ToolConfig] from JSON.
   factory ToolConfig.fromJson(Map<String, dynamic> json) => ToolConfig(
@@ -17,20 +21,32 @@ class ToolConfig {
             json['functionCallingConfig'] as Map<String, dynamic>,
           )
         : null,
+    retrievalConfig: json['retrievalConfig'] != null
+        ? RetrievalConfig.fromJson(
+            json['retrievalConfig'] as Map<String, dynamic>,
+          )
+        : null,
   );
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
     if (functionCallingConfig != null)
       'functionCallingConfig': functionCallingConfig!.toJson(),
+    if (retrievalConfig != null) 'retrievalConfig': retrievalConfig!.toJson(),
   };
 
   /// Creates a copy with replaced values.
-  ToolConfig copyWith({Object? functionCallingConfig = unsetCopyWithValue}) {
+  ToolConfig copyWith({
+    Object? functionCallingConfig = unsetCopyWithValue,
+    Object? retrievalConfig = unsetCopyWithValue,
+  }) {
     return ToolConfig(
       functionCallingConfig: functionCallingConfig == unsetCopyWithValue
           ? this.functionCallingConfig
           : functionCallingConfig as FunctionCallingConfig?,
+      retrievalConfig: retrievalConfig == unsetCopyWithValue
+          ? this.retrievalConfig
+          : retrievalConfig as RetrievalConfig?,
     );
   }
 }


### PR DESCRIPTION
## Summary
- Add RetrievalConfig model class with latLng and languageCode fields
- Update ToolConfig with optional retrievalConfig property
- Export RetrievalConfig from barrel file

## Test plan
- [x] `dart analyze` passes
- [x] `dart format` passes