### PR TITLE
feat(googleai_dart): Enhance openapi-updater skill with multi-spec support

### DIFF
--- a/packages/googleai_dart/.claude/skills/openapi-updater/SKILL.md
+++ b/packages/googleai_dart/.claude/skills/openapi-updater/SKILL.md
@@ -9,33 +9,62 @@ Automates `googleai_dart` updates when the Google AI OpenAPI specification chang
 
 ## Prerequisites
 
-- `GEMINI_API_KEY` or `GOOGLE_AI_API_KEY` environment variable set
+- `GEMINI_API_KEY` or `GOOGLE_AI_API_KEY` environment variable set (for main spec)
 - Working directory: `packages/googleai_dart`
 - Python 3
 
+## Spec Registry
+
+The skill supports multiple OpenAPI specs via `specs.json`:
+
+| Spec | Description | Auth Required |
+|------|-------------|---------------|
+| `main` | Core Gemini API (generation, embeddings, files, models, etc.) | Yes |
+| `interactions` | Experimental Interactions API (server-side state, agents) | No |
+
 ## Workflow
 
-### 1. Fetch Latest Spec
+### 1. Fetch Latest Specs
 
 ```bash
+# Fetch all specs + auto-discover new ones
 python3 .claude/skills/openapi-updater/scripts/fetch_spec.py
+
+# Fetch specific spec only
+python3 .claude/skills/openapi-updater/scripts/fetch_spec.py --spec main
+python3 .claude/skills/openapi-updater/scripts/fetch_spec.py --spec interactions
+
+# Skip discovery probing
+python3 .claude/skills/openapi-updater/scripts/fetch_spec.py --no-discover
 ```
 
-Output: `/tmp/openapi-updater/latest.json`
+Output:
+- `/tmp/openapi-updater/latest-main.json`
+- `/tmp/openapi-updater/latest-interactions.json`
 
 ### 2. Analyze Changes
 
+For main spec:
 ```bash
 python3 .claude/skills/openapi-updater/scripts/analyze_changes.py \
-  openapi.json /tmp/openapi-updater/latest.json \
+  openapi.json /tmp/openapi-updater/latest-main.json \
   --format all \
-  --changelog-out /tmp/openapi-updater/changelog.md \
-  --plan-out /tmp/openapi-updater/plan.md
+  --changelog-out /tmp/openapi-updater/changelog-main.md \
+  --plan-out /tmp/openapi-updater/plan-main.md
+```
+
+For interactions spec:
+```bash
+python3 .claude/skills/openapi-updater/scripts/analyze_changes.py \
+  openapi-interactions.json /tmp/openapi-updater/latest-interactions.json \
+  --format all \
+  --changelog-out /tmp/openapi-updater/changelog-interactions.md \
+  --plan-out /tmp/openapi-updater/plan-interactions.md
 ```
 
 Generates:
-- `changelog.md` - Human-readable change summary
-- `plan.md` - Prioritized implementation plan (P0-P4)
+- `changelog-{spec}.md` - Human-readable change summary
+- `plan-{spec}.md` - Prioritized implementation plan (P0-P4)
 
 ### 3. Implement Changes
 
@@ -52,11 +81,64 @@ Use templates from `assets/`:
 
 Implement each change as a separate PR following the plan's priority order.
 
-### 4. Finalize
+### 3.5 Review & Validate (MANDATORY)
+
+Perform the three-pass review documented in `references/REVIEW_CHECKLIST.md`:
+
+1. **Pass 1**: Implementation review against generated plan
+2. **Pass 2**: Barrel file verification (`verify_exports.py`)
+3. **Pass 3**: README accuracy (`verify_readme.py`)
+
+All passes must complete with zero issues before finalizing.
 
 ```bash
-cp /tmp/openapi-updater/latest.json openapi.json
+python3 .claude/skills/openapi-updater/scripts/verify_exports.py
+python3 .claude/skills/openapi-updater/scripts/verify_readme.py
+dart analyze --fatal-infos && dart format --set-exit-if-changed . && dart test test/unit/
+```
+
+If gaps are found, fix them using patterns in `references/implementation-patterns.md` and re-run verification.
+
+### 4. Finalize
+
+Copy fetched specs to their persisted locations:
+
+```bash
+# For main spec
+cp /tmp/openapi-updater/latest-main.json openapi.json
+
+# For interactions spec
+cp /tmp/openapi-updater/latest-interactions.json openapi-interactions.json
+
+# Run quality checks
 dart test && dart analyze && dart format --set-exit-if-changed .
+```
+
+## Auto-Discovery
+
+The skill automatically probes for new API specs on each fetch. Known discovery patterns:
+
+- `https://ai.google.dev/static/api/{name}.openapi.json`
+
+If new specs are found, you'll see a warning with instructions to add them to `specs.json`.
+
+## Adding New Specs
+
+Edit `specs.json` to add a new spec:
+
+```json
+{
+  "specs": {
+    "new-api": {
+      "name": "New API",
+      "url": "https://example.com/new-api.openapi.json",
+      "local_file": "openapi-new-api.json",
+      "requires_auth": false,
+      "experimental": true,
+      "description": "Description of the new API"
+    }
+  }
+}
 ```
 
 ## Troubleshooting
@@ -64,3 +146,5 @@ dart test && dart analyze && dart format --set-exit-if-changed .
 - **API key error**: Export `GEMINI_API_KEY` or `GOOGLE_AI_API_KEY`
 - **Network errors**: Check connectivity; retry after a few seconds
 - **No changes detected**: Summary shows all zeros; no action needed
+- **New specs discovered**: Add them to `specs.json` and re-run
+

--- a/packages/googleai_dart/.claude/skills/openapi-updater/references/REVIEW_CHECKLIST.md
+++ b/packages/googleai_dart/.claude/skills/openapi-updater/references/REVIEW_CHECKLIST.md
@@ -1,0 +1,249 @@
+# Implementation Review Checklist
+
+Systematic verification after implementing OpenAPI changes.
+
+## Contents
+
+1. [Pre-Review](#pre-review) - Re-run analysis for fresh comparison
+2. [Verification by Category](#verification-by-category) - P0-P4 priority checks
+3. [Cross-Reference Verification](#cross-reference-verification) - Sealed classes, nested types
+4. [Common Gaps](#common-gaps) - Frequently missed items
+5. [Barrel File Completeness (PASS 2)](#barrel-file-completeness-pass-2) - Export verification
+6. [README Documentation (PASS 3)](#readme-documentation-pass-3) - Documentation accuracy
+7. [Quality Gates](#quality-gates) - Required checks before finalization
+8. [Review Output Template](#review-output-template) - Standard format for findings
+9. [Fix Loop Process](#fix-loop-process) - Gap resolution workflow
+
+---
+
+## Pre-Review
+
+Re-run the analysis to get a fresh spec comparison:
+```bash
+python3 .claude/skills/openapi-updater/scripts/analyze_changes.py \
+  openapi.json /tmp/openapi-updater/latest.json --format all \
+  --changelog-out /tmp/openapi-updater/review-changelog.md \
+  --plan-out /tmp/openapi-updater/review-plan.md
+```
+
+Use the generated plan as your verification source.
+
+---
+
+## Verification by Category
+
+### Breaking Changes (P0)
+For each removed endpoint/schema:
+- [ ] Code deleted (not commented out)
+- [ ] No orphaned references in other files
+- [ ] Barrel exports updated
+- [ ] Related tests removed
+
+### New Endpoints (P1)
+For each new endpoint:
+- [ ] Resource method exists with correct HTTP verb
+- [ ] URL path matches spec exactly
+- [ ] Request/response types match spec schemas
+- [ ] Added to client (if top-level resource)
+
+### New Schemas (P2)
+For each new schema, verify the model file has:
+- [ ] All properties from spec
+- [ ] Correct types (see Type Mappings in implementation-patterns.md)
+- [ ] Required vs optional matches spec
+- [ ] `fromJson` handles all fields with correct casting
+- [ ] `toJson` includes all fields with null checks
+- [ ] `copyWith` uses sentinel pattern for all fields
+- [ ] `toString` includes all fields
+- [ ] Exported in barrel file (`lib/googleai_dart.dart`)
+- [ ] Unit test with round-trip serialization test
+
+### Modified Schemas (P4)
+For each schema with new/changed properties:
+- [ ] New properties added to class
+- [ ] `fromJson` updated
+- [ ] `toJson` updated
+- [ ] `copyWith` updated
+- [ ] `toString` updated
+- [ ] Tests updated for new fields
+
+---
+
+## Cross-Reference Verification
+
+### Sealed Classes
+Check these sealed classes handle all their variants:
+- [ ] `Part` - all part types in `fromJson` switch
+- [ ] Other sealed classes with `factory fromJson`
+
+### Nested References
+- [ ] All nested object types are imported
+- [ ] `List<T>` uses correct element type
+- [ ] Enum converters exist for all enum types
+
+### Parent Model Updates
+When a new type is added, check if it should be referenced by:
+- [ ] `Tool` (new tool types: fileSearch, mcpServers, googleMaps)
+- [ ] `ToolConfig` (config extensions)
+- [ ] `GenerationConfig` (new config fields)
+- [ ] `Candidate` (new response fields)
+- [ ] `Content`/`Part` (new content types)
+
+---
+
+## Common Gaps
+
+These are frequently missed - explicitly check:
+
+| Gap | Check | How to Verify |
+|-----|-------|---------------|
+| **Missing barrel exports** | Model files not exported in barrel file | Run `verify_exports.py` |
+| **Transitive dependencies** | Types used by exported classes not exported | Run `verify_exports.py --verbose` |
+| `Part.mediaResolution` | Part sealed class handles mediaResolution | Read `part.dart` |
+| `ImageConfig` | Schema exists and GenerationConfig references it | Grep for ImageConfig |
+| `GenerationConfig` fields | All new optional fields added | Compare against spec |
+| Enum values | New values added to existing enums | Compare against spec |
+| Platform code | IO and Web implementations both updated | Check `_io.dart`/`_web.dart` |
+
+---
+
+## Barrel File Completeness (PASS 2)
+
+**This is the most commonly missed check.** Run the verification script:
+
+```bash
+python3 .claude/skills/openapi-updater/scripts/verify_exports.py
+```
+
+The script will:
+1. Scan all `.dart` files in `lib/src/models/` subdirectories
+2. Check each is exported in `lib/googleai_dart.dart`
+3. Report unexported files and suggest fixes
+4. Check transitive dependencies (types used by exported classes)
+
+**If unexported files are found:**
+- Add export to `lib/googleai_dart.dart` if it's a public API type
+- If intentionally internal, document reason in code comment
+
+**Manual fallback** (if script unavailable):
+```bash
+for f in lib/src/models/*/*.dart; do
+  base=$(basename "$f")
+  if ! grep -q "$base" lib/googleai_dart.dart; then
+    echo "NOT EXPORTED: $f"
+  fi
+done
+```
+
+---
+
+## README Documentation (PASS 3)
+
+**Check that README.md accurately reflects the current API state.**
+
+### Run the README Validator
+
+```bash
+python3 .claude/skills/openapi-updater/scripts/verify_readme.py
+```
+
+The script validates:
+1. **Resources**: Documented resources match `lib/src/resources/`
+2. **Tool types**: All Tool properties are documented (function calling, code execution, etc.)
+3. **Stale references**: No references to removed APIs (ragStores, chunks, etc.)
+4. **Examples**: Referenced example files actually exist
+
+### If Issues Are Found
+
+**For stale references:**
+- Remove references to deleted APIs from API Coverage section
+- Update feature comparison tables
+- Remove non-existent example file references
+
+**For missing documentation:**
+- Add new resource sections to API Coverage
+- Document new tool types in Features section
+- Update example list if new examples added
+
+### Quick Manual Verification
+```bash
+# Check if new feature types are documented (backup check)
+grep -c "fileSearch\|googleMaps\|mcpServers\|FileSearchStore" README.md
+
+# Compare resource count in README vs actual API
+ls lib/src/resources/ | wc -l
+```
+
+### Common README Gaps
+
+| Gap | Section | How to Fix |
+|-----|---------|------------|
+| Stale API Coverage | "API Coverage" section | Update endpoint counts, remove deleted resources |
+| Missing new tools | "Features" | Add to Tool support list |
+| Missing resources | "API Coverage" | Add new resource subsections |
+| Outdated feature tables | "Quick Comparison" | Update capability matrix |
+| Non-existent examples | "Examples" | Remove or create missing examples |
+
+---
+
+## Quality Gates
+
+Run all commands - all must pass:
+
+```bash
+# Static analysis (zero issues - info, warning, or error)
+dart analyze --fatal-infos
+
+# Formatting check
+dart format --set-exit-if-changed .
+
+# Unit tests
+dart test test/unit/
+
+# Barrel file verification (CRITICAL - often missed!)
+python3 .claude/skills/openapi-updater/scripts/verify_exports.py
+```
+
+---
+
+## Review Output Template
+
+Document findings in this format:
+
+### Verified
+- [x] FileSearchStore model complete (`lib/src/models/files/file_search_store.dart`)
+- [x] GroundingMetadata has all fields (`lib/src/models/metadata/grounding_metadata.dart:42`)
+
+### Gaps Found
+- [ ] Part missing `mediaResolution` field (`lib/src/models/content/part.dart:11`)
+- [ ] ImageConfig schema not implemented
+
+### Recommendation
+[ ] Proceed to finalize
+[x] Fix gaps first
+
+---
+
+## Fix Loop Process
+
+If gaps were found:
+
+1. **Fix each gap** using patterns from `implementation-patterns.md`
+2. **Re-run quality gates**:
+   ```bash
+   dart analyze --fatal-infos
+   dart format --set-exit-if-changed .
+   dart test test/unit/
+   ```
+3. **Re-run this review** from Pre-Review step
+4. **Repeat** until all items verified
+
+### Common Fix Patterns
+
+| Gap Type | Fix |
+|----------|-----|
+| Missing property | Add field, update fromJson/toJson/copyWith/toString |
+| Missing export | Add to `lib/googleai_dart.dart` |
+| Sealed class variant | Add case to `fromJson` factory switch |
+| Missing test | Create using `assets/test_template.dart` |
+| Type mismatch | Check Type Mappings in implementation-patterns.md |

--- a/packages/googleai_dart/.claude/skills/openapi-updater/scripts/analyze_changes.py
+++ b/packages/googleai_dart/.claude/skills/openapi-updater/scripts/analyze_changes.py
@@ -535,6 +535,57 @@ def generate_plan(analysis: dict) -> str:
         "- [ ] Update CHANGELOG.md",
     ])
 
+    # Add Review Checklist section
+    lines.extend([
+        "",
+        "---",
+        "",
+        "## Review Checklist",
+        "",
+        "After implementation, verify each change. See `references/REVIEW_CHECKLIST.md` for full guide.",
+        "",
+    ])
+
+    # Generate specific checklist items from analysis
+    if analysis['schemas']['removed']:
+        lines.append("### Removed Schemas")
+        for sc in analysis['schemas']['removed']:
+            lines.append(f"- [ ] `{sc['name']}` - code deleted, exports updated, tests removed")
+        lines.append("")
+
+    if analysis['schemas']['added']:
+        lines.append("### New Schemas")
+        for sc in analysis['schemas']['added']:
+            file_path = schema_to_file_path(sc['name'])
+            props = ', '.join(list(sc['properties'].keys())[:5])
+            if len(sc['properties']) > 5:
+                props += f" (+{len(sc['properties'])-5} more)"
+            lines.append(f"- [ ] `{sc['name']}` → `{file_path}`")
+            if props:
+                lines.append(f"  - Properties: {props}")
+        lines.append("")
+
+    if analysis['schemas']['modified']:
+        lines.append("### Modified Schemas")
+        for mod in analysis['schemas']['modified']:
+            sc = mod['schema']
+            changes = [c.get('property', c.get('value', '')) for c in mod['changes']]
+            lines.append(f"- [ ] `{sc['name']}` - verify: {', '.join(changes)}")
+        lines.append("")
+
+    # Cross-reference reminders
+    lines.extend([
+        "### Cross-Reference Checks",
+        "- [ ] All new models exported in `lib/googleai_dart.dart`",
+        "- [ ] Sealed classes (Part, etc.) handle new variants",
+        "- [ ] Parent models reference new child types",
+        "",
+        "### Quality Gates",
+        "- [ ] `dart analyze --fatal-infos` - no issues",
+        "- [ ] `dart format --set-exit-if-changed .` - no changes",
+        "- [ ] `dart test test/unit/` - all pass",
+    ])
+
     return "\n".join(lines)
 
 

--- a/packages/googleai_dart/.claude/skills/openapi-updater/scripts/fetch_spec.py
+++ b/packages/googleai_dart/.claude/skills/openapi-updater/scripts/fetch_spec.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
 """
-Fetch the latest GoogleAI OpenAPI specification.
+Fetch the latest GoogleAI OpenAPI specifications.
+
+Supports multiple specs via registry (specs.json) and auto-discovery of new specs.
 
 Usage:
-    python3 fetch_spec.py [--output DIR]
+    python3 fetch_spec.py [--spec NAME] [--no-discover] [--output DIR]
+
+Examples:
+    python3 fetch_spec.py                    # Fetch all specs + discover new
+    python3 fetch_spec.py --spec main        # Fetch only main spec
+    python3 fetch_spec.py --spec interactions # Fetch only interactions spec
+    python3 fetch_spec.py --no-discover      # Skip discovery probing
 
 Environment:
-    GEMINI_API_KEY or GOOGLE_AI_API_KEY: API key for authentication (required)
+    GEMINI_API_KEY or GOOGLE_AI_API_KEY: API key for authenticated specs
 """
 
 import argparse
@@ -19,40 +27,50 @@ from urllib.request import urlopen, Request
 from urllib.error import URLError, HTTPError
 
 # Configuration
-SPEC_URL = "https://generativelanguage.googleapis.com/$discovery/OPENAPI3_0?version=v1beta"
-DEFAULT_OUTPUT_DIR = "/tmp/openapi-updater"
+SCRIPT_DIR = Path(__file__).parent
+REGISTRY_PATH = SCRIPT_DIR.parent / "specs.json"
+DEFAULT_OUTPUT_DIR = Path("/tmp/openapi-updater")
 
 
-def get_api_key() -> str:
-    """Get API key from environment."""
-    key = os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_AI_API_KEY')
-    if not key:
-        print("ERROR: GEMINI_API_KEY or GOOGLE_AI_API_KEY environment variable not set",
-              file=sys.stderr)
+def load_registry() -> dict:
+    """Load spec registry from specs.json."""
+    if not REGISTRY_PATH.exists():
+        print(f"ERROR: Registry not found: {REGISTRY_PATH}", file=sys.stderr)
         sys.exit(1)
-    return key
+
+    with open(REGISTRY_PATH) as f:
+        return json.load(f)
 
 
-def fetch_spec(api_key: str) -> dict:
-    """Fetch OpenAPI spec from Google AI."""
-    url = f"{SPEC_URL}&key={api_key}"
-    print(f"Fetching spec from {SPEC_URL.split('?')[0]}...")
+def get_api_key() -> str | None:
+    """Get API key from environment (optional for some specs)."""
+    return os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_AI_API_KEY')
+
+
+def fetch_url(url: str, api_key: str | None = None, requires_auth: bool = False) -> dict | None:
+    """Fetch JSON from URL with optional auth."""
+    if requires_auth:
+        if not api_key:
+            print(f"  ERROR: API key required but not set", file=sys.stderr)
+            return None
+        url = f"{url}&key={api_key}" if '?' in url else f"{url}?key={api_key}"
 
     try:
         req = Request(url, headers={'User-Agent': 'OpenAPI-Updater/1.0'})
         with urlopen(req, timeout=30) as response:
             data = response.read().decode('utf-8')
-            spec = json.loads(data)
-            return spec
+            return json.loads(data)
     except HTTPError as e:
-        print(f"ERROR: HTTP {e.code}: {e.reason}", file=sys.stderr)
-        sys.exit(2)
+        if e.code == 404:
+            return None  # Not found is expected for discovery
+        print(f"  ERROR: HTTP {e.code}: {e.reason}", file=sys.stderr)
+        return None
     except URLError as e:
-        print(f"ERROR: Network error: {e.reason}", file=sys.stderr)
-        sys.exit(2)
+        print(f"  ERROR: Network error: {e.reason}", file=sys.stderr)
+        return None
     except json.JSONDecodeError as e:
-        print(f"ERROR: Invalid JSON response: {e}", file=sys.stderr)
-        sys.exit(3)
+        print(f"  ERROR: Invalid JSON: {e}", file=sys.stderr)
+        return None
 
 
 def count_endpoints(spec: dict) -> int:
@@ -70,45 +88,141 @@ def count_schemas(spec: dict) -> int:
     return len(spec.get('components', {}).get('schemas', {}))
 
 
-def save_spec(spec: dict, output_dir: Path) -> Path:
+def save_spec(spec: dict, output_dir: Path, spec_name: str) -> Path:
     """Save spec to output directory."""
     output_dir.mkdir(parents=True, exist_ok=True)
-
-    filepath = output_dir / "latest.json"
+    filepath = output_dir / f"latest-{spec_name}.json"
     with open(filepath, 'w') as f:
         json.dump(spec, f, indent=2)
-
     return filepath
 
 
+def print_spec_info(spec: dict, filepath: Path):
+    """Print spec metadata."""
+    info = spec.get('info', {})
+    print(f"  Saved to: {filepath}")
+    print(f"  OpenAPI: {spec.get('openapi', 'unknown')}")
+    print(f"  Version: {info.get('version', 'unknown')}")
+    print(f"  Title: {info.get('title', 'unknown')}")
+    print(f"  Endpoints: {count_endpoints(spec)}")
+    print(f"  Schemas: {count_schemas(spec)}")
+
+
+def fetch_registered_specs(registry: dict, spec_filter: str | None, output_dir: Path, api_key: str | None) -> int:
+    """Fetch all registered specs (or a specific one)."""
+    specs = registry.get('specs', {})
+    fetched = 0
+
+    for name, config in specs.items():
+        if spec_filter and name != spec_filter:
+            continue
+
+        print(f"\n[{name}] {config.get('name', 'Unknown')}")
+        url = config['url']
+        requires_auth = config.get('requires_auth', False)
+        experimental = config.get('experimental', False)
+
+        if experimental:
+            print(f"  (experimental)")
+
+        print(f"  Fetching from {url.split('?')[0]}...")
+
+        spec = fetch_url(url, api_key, requires_auth)
+        if spec is None:
+            print(f"  FAILED to fetch spec")
+            continue
+
+        if 'openapi' not in spec:
+            print(f"  ERROR: Not a valid OpenAPI spec")
+            continue
+
+        filepath = save_spec(spec, output_dir, name)
+        print_spec_info(spec, filepath)
+        fetched += 1
+
+    return fetched
+
+
+def discover_new_specs(registry: dict) -> list[str]:
+    """Probe for new specs at discovery patterns."""
+    patterns = registry.get('discovery_patterns', [])
+    names = registry.get('discovery_names', [])
+    registered = set(registry.get('specs', {}).keys())
+
+    discovered = []
+
+    for pattern in patterns:
+        for name in names:
+            if name in registered:
+                continue  # Already registered
+
+            url = pattern.replace('{name}', name)
+            # Quick HEAD-like check using a GET with timeout
+            try:
+                req = Request(url, headers={'User-Agent': 'OpenAPI-Updater/1.0'})
+                with urlopen(req, timeout=5) as response:
+                    if response.status == 200:
+                        discovered.append((name, url))
+            except:
+                pass  # Not found or error, skip
+
+    return discovered
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Fetch GoogleAI OpenAPI spec")
-    parser.add_argument('--output', '-o', type=Path, default=Path(DEFAULT_OUTPUT_DIR),
+    parser = argparse.ArgumentParser(description="Fetch GoogleAI OpenAPI specs")
+    parser.add_argument('--spec', '-s', type=str, default=None,
+                        help="Fetch only this spec (default: all)")
+    parser.add_argument('--no-discover', action='store_true',
+                        help="Skip discovery probing for new specs")
+    parser.add_argument('--output', '-o', type=Path, default=DEFAULT_OUTPUT_DIR,
                         help=f"Output directory (default: {DEFAULT_OUTPUT_DIR})")
     args = parser.parse_args()
 
+    registry = load_registry()
     api_key = get_api_key()
-    spec = fetch_spec(api_key)
 
-    # Validate spec structure
-    if 'openapi' not in spec:
-        print("ERROR: Response is not a valid OpenAPI spec", file=sys.stderr)
-        sys.exit(3)
+    print(f"OpenAPI Spec Fetcher")
+    print(f"Registry: {REGISTRY_PATH}")
+    print(f"Output: {args.output}")
 
-    filepath = save_spec(spec, args.output)
+    # Check for API key if needed
+    if args.spec:
+        spec_config = registry.get('specs', {}).get(args.spec)
+        if not spec_config:
+            print(f"\nERROR: Unknown spec '{args.spec}'", file=sys.stderr)
+            print(f"Available specs: {', '.join(registry.get('specs', {}).keys())}")
+            sys.exit(1)
+        if spec_config.get('requires_auth') and not api_key:
+            print(f"\nERROR: GEMINI_API_KEY or GOOGLE_AI_API_KEY required for '{args.spec}'",
+                  file=sys.stderr)
+            sys.exit(1)
+    else:
+        # Check if any spec requires auth
+        for name, config in registry.get('specs', {}).items():
+            if config.get('requires_auth') and not api_key:
+                print(f"\nWARNING: API key not set - will skip '{name}' spec")
 
-    # Extract metadata
-    info = spec.get('info', {})
-    endpoint_count = count_endpoints(spec)
-    schema_count = count_schemas(spec)
+    # Fetch specs
+    fetched = fetch_registered_specs(registry, args.spec, args.output, api_key)
 
-    print(f"\nSpec saved to: {filepath}")
-    print(f"OpenAPI version: {spec.get('openapi', 'unknown')}")
-    print(f"API version: {info.get('version', 'unknown')}")
-    print(f"Title: {info.get('title', 'unknown')}")
-    print(f"Endpoints: {endpoint_count}")
-    print(f"Schemas: {schema_count}")
-    print(f"Fetched at: {datetime.now().isoformat()}")
+    # Auto-discover new specs
+    if not args.no_discover and not args.spec:
+        print(f"\n--- Discovery ---")
+        print(f"Probing for new specs...")
+        discovered = discover_new_specs(registry)
+
+        if discovered:
+            print(f"\n⚠️  NEW SPECS DISCOVERED:")
+            for name, url in discovered:
+                print(f"  - {name}: {url}")
+            print(f"\nTo add to registry, update: {REGISTRY_PATH}")
+        else:
+            print(f"No new specs found.")
+
+    print(f"\n--- Summary ---")
+    print(f"Fetched: {fetched} spec(s)")
+    print(f"Time: {datetime.now().isoformat()}")
 
 
 if __name__ == '__main__':

--- a/packages/googleai_dart/.claude/skills/openapi-updater/scripts/verify_exports.py
+++ b/packages/googleai_dart/.claude/skills/openapi-updater/scripts/verify_exports.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Verify all model files are exported in the barrel file.
+
+This script scans all .dart files in lib/src/models/ subdirectories and checks
+that each is exported in lib/googleai_dart.dart. It also checks for transitive
+dependencies (types used by exported classes that should also be exported).
+
+Usage:
+    python3 .claude/skills/openapi-updater/scripts/verify_exports.py
+
+Exit codes:
+    0 - All files are exported
+    1 - Unexported files found
+    2 - Error (wrong directory, missing files, etc.)
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def find_model_files(models_dir: Path) -> list[Path]:
+    """Find all .dart files in models subdirectories."""
+    files = []
+    for subdir in models_dir.iterdir():
+        if subdir.is_dir() and not subdir.name.startswith('.'):
+            for dart_file in subdir.glob('*.dart'):
+                # Skip internal utility files
+                if dart_file.name == 'copy_with_sentinel.dart':
+                    continue
+                files.append(dart_file)
+    return sorted(files)
+
+
+def get_barrel_exports(barrel_file: Path) -> set[str]:
+    """Extract exported filenames from barrel file."""
+    exports = set()
+    content = barrel_file.read_text()
+    # Match: export 'src/models/xxx/filename.dart';
+    pattern = r"export\s+'[^']*?([^/]+\.dart)'"
+    for match in re.finditer(pattern, content):
+        exports.add(match.group(1))
+    return exports
+
+
+def extract_types_from_file(file: Path) -> set[str]:
+    """Extract class, enum, and sealed class names from a Dart file."""
+    content = file.read_text()
+    pattern = r'(?:class|enum|sealed class)\s+(\w+)'
+    return set(re.findall(pattern, content))
+
+
+def find_type_usages(file: Path, type_names: set[str]) -> set[str]:
+    """Find which types from type_names are used in the file."""
+    content = file.read_text()
+    used = set()
+    for type_name in type_names:
+        # Look for type usage: as type annotation, in generics, etc.
+        # Pattern matches: TypeName, List<TypeName>, TypeName?, etc.
+        if re.search(rf'\b{type_name}\b', content):
+            used.add(type_name)
+    return used
+
+
+def check_transitive_dependencies(
+    unexported_files: list[Path],
+    exported_files: list[Path],
+    models_dir: Path,
+) -> dict[str, list[str]]:
+    """
+    Check if unexported types are used by exported types.
+
+    Returns a dict mapping unexported file names to list of exported files using them.
+    """
+    # Build map of type -> file for unexported files
+    unexported_types: dict[str, Path] = {}
+    for f in unexported_files:
+        for type_name in extract_types_from_file(f):
+            unexported_types[type_name] = f
+
+    # Check each exported file for usage of unexported types
+    dependencies: dict[str, list[str]] = {}
+
+    for exported_file in exported_files:
+        used_types = find_type_usages(exported_file, set(unexported_types.keys()))
+        for type_name in used_types:
+            unexported_file = unexported_types[type_name]
+            file_key = unexported_file.name
+            if file_key not in dependencies:
+                dependencies[file_key] = []
+            # Record which exported file uses this unexported type
+            dependencies[file_key].append(f"{type_name} (used by {exported_file.name})")
+
+    return dependencies
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Verify all model files are exported in barrel file.'
+    )
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Show detailed output including transitive dependency analysis'
+    )
+    parser.add_argument(
+        '--check-transitive',
+        action='store_true',
+        default=True,
+        help='Check for transitive dependencies (default: True)'
+    )
+    args = parser.parse_args()
+
+    models_dir = Path('lib/src/models')
+    barrel_file = Path('lib/googleai_dart.dart')
+
+    # Verify we're in the right directory
+    if not models_dir.exists():
+        print("Error: lib/src/models/ not found. Run from package root directory.")
+        sys.exit(2)
+
+    if not barrel_file.exists():
+        print("Error: lib/googleai_dart.dart not found. Run from package root directory.")
+        sys.exit(2)
+
+    print("Checking barrel file completeness...")
+    print()
+
+    # Find all model files and check exports
+    model_files = find_model_files(models_dir)
+    exports = get_barrel_exports(barrel_file)
+
+    unexported = []
+    exported_paths = []
+
+    for f in model_files:
+        if f.name not in exports:
+            unexported.append(f)
+        else:
+            exported_paths.append(f)
+
+    if args.verbose:
+        print(f"Found {len(model_files)} model files")
+        print(f"Found {len(exports)} exports in barrel file")
+        print()
+
+    if not unexported:
+        print("✓ All model files are exported.")
+        sys.exit(0)
+
+    # Report unexported files
+    print("UNEXPORTED FILES:")
+    for f in unexported:
+        relative_path = f.relative_to(Path.cwd())
+        print(f"  - {relative_path}")
+    print()
+
+    # Check transitive dependencies
+    if args.check_transitive and unexported:
+        dependencies = check_transitive_dependencies(
+            unexported, exported_paths, models_dir
+        )
+
+        if dependencies:
+            print("USED BY EXPORTED CLASSES (should be exported):")
+            for file_name, usages in sorted(dependencies.items()):
+                print(f"  - {file_name}:")
+                for usage in usages:
+                    print(f"      → {usage}")
+            print()
+
+    # Summary
+    print(f"Found {len(unexported)} unexported file(s).")
+    print()
+    print("To fix, add exports to lib/googleai_dart.dart:")
+    print()
+    for f in unexported:
+        relative_import = str(f.relative_to(Path('lib')))
+        print(f"export '{relative_import}';")
+
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/googleai_dart/.claude/skills/openapi-updater/scripts/verify_readme.py
+++ b/packages/googleai_dart/.claude/skills/openapi-updater/scripts/verify_readme.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+Verify README.md accuracy against actual API implementation.
+
+This script validates that the README documentation matches the actual
+implementation by checking:
+1. Resources documented match lib/src/resources/
+2. Tool types documented match Tool class properties
+3. No stale references to removed APIs
+4. Example files exist
+
+Usage:
+    python3 .claude/skills/openapi-updater/scripts/verify_readme.py
+
+Exit codes:
+    0 - All checks passed
+    1 - Validation issues found
+    2 - Error (wrong directory, missing files, etc.)
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+# Known removed APIs to check for stale references
+REMOVED_APIS = [
+    ('ragStores', 'RAG Stores API removed - use fileSearchStores instead'),
+    ('chunks.batchCreate', 'Chunk batch operations removed from API'),
+    ('chunks.batchUpdate', 'Chunk batch operations removed from API'),
+    ('chunks.batchDelete', 'Chunk batch operations removed from API'),
+    ('chunks(document).create', 'Chunk management removed from API'),
+    ('chunks(document).list', 'Chunk management removed from API'),
+    ('chunks(document).get', 'Chunk management removed from API'),
+    ('chunks(document).update', 'Chunk management removed from API'),
+    ('chunks(document).delete', 'Chunk management removed from API'),
+]
+
+# Tool properties that should be documented
+# Maps property name to (description, [search_terms])
+TOOL_PROPERTIES = {
+    'functionDeclarations': ('Function calling with custom functions',
+                             ['functiondeclarations', 'function calling', 'function declarations']),
+    'codeExecution': ('Code execution capability',
+                      ['codeexecution', 'code execution']),
+    'googleSearch': ('Google Search grounding',
+                     ['googlesearch', 'google search']),
+    'fileSearch': ('File search using Semantic Retrieval (FileSearchStores)',
+                   ['filesearch', 'file search']),
+    'mcpServers': ('MCP (Model Context Protocol) server integration',
+                   ['mcpservers', 'mcp server', 'model context protocol']),
+    'googleMaps': ('Google Maps geospatial context',
+                   ['googlemaps', 'google maps']),
+}
+
+# Resource name mappings (directory/file name -> expected client accessor)
+RESOURCE_MAPPINGS = {
+    'models_resource': 'models',
+    'tuned_models_resource': 'tunedModels',
+    'files': 'files',
+    'file_search_stores': 'fileSearchStores',
+    'cached_contents_resource': 'cachedContents',
+    'batches_resource': 'batches',
+    'corpora_resource': 'corpora',
+    'documents_resource': None,  # Nested under corpora, not standalone
+    'permissions_resource': None,  # Nested under other resources
+    'operations_resource': None,  # Universal, mentioned separately
+    'generated_files_resource': None,  # Nested under files
+    'base_resource': None,  # Base class, not a resource
+}
+
+
+def find_implemented_resources() -> set[str]:
+    """Find all resource directories/files and return expected client names."""
+    resources_dir = Path('lib/src/resources')
+    resources = set()
+
+    for item in resources_dir.iterdir():
+        if item.name.startswith('.'):
+            continue
+
+        if item.is_dir():
+            # Directory-based resources (e.g., file_search_stores, files)
+            name = item.name
+        elif item.is_file() and item.suffix == '.dart':
+            # File-based resources (e.g., models_resource.dart)
+            name = item.stem
+        else:
+            continue
+
+        # Skip backup files
+        if name.endswith('.bak'):
+            continue
+
+        # Map to expected client accessor
+        client_name = RESOURCE_MAPPINGS.get(name)
+        if client_name:  # Only include top-level resources
+            resources.add(client_name)
+
+    return resources
+
+
+def extract_documented_resources(readme: str) -> set[str]:
+    """Extract resource names from README API Coverage section."""
+    # Match: ### ResourceName Resource (`client.resourceName`)
+    pattern = r"### \w+(?:\s+\w+)* Resource \(`client\.(\w+)`\)"
+    return set(re.findall(pattern, readme))
+
+
+def find_tool_properties() -> dict[str, int]:
+    """Extract tool properties from Tool class with line numbers."""
+    tool_file = Path('lib/src/models/tools/tool.dart')
+    content = tool_file.read_text()
+    properties = {}
+
+    for i, line in enumerate(content.split('\n'), 1):
+        # Match: final Type? propertyName;
+        match = re.search(r'final\s+[\w<>?]+\s+(\w+);', line)
+        if match:
+            properties[match.group(1)] = i
+
+    return properties
+
+
+def check_tool_documentation(readme: str) -> list[tuple[str, str]]:
+    """Check if all tool properties are documented in README."""
+    missing = []
+    readme_lower = readme.lower()
+
+    for prop, (description, search_terms) in TOOL_PROPERTIES.items():
+        # Check if any of the search terms are found in README
+        found = any(term in readme_lower for term in search_terms)
+        if not found:
+            missing.append((prop, description))
+
+    return missing
+
+
+def check_stale_references(readme: str) -> list[tuple[int, str, str]]:
+    """Find references to removed APIs with line numbers."""
+    issues = []
+    lines = readme.split('\n')
+
+    for i, line in enumerate(lines, 1):
+        for api, reason in REMOVED_APIS:
+            if api in line:
+                issues.append((i, api, reason))
+
+    return issues
+
+
+def check_example_files(readme: str) -> list[str]:
+    """Check that referenced example files exist."""
+    example_dir = Path('example')
+
+    # Find all .dart file references in README
+    # Match patterns like: example/filename.dart, `filename.dart`, filename.dart
+    pattern = r'[`/]?(\w+(?:_\w+)*\.dart)[`]?'
+    referenced = set(re.findall(pattern, readme))
+
+    # Filter to likely example files (contain 'example' or common patterns)
+    example_patterns = ['_example.dart', 'example.dart']
+
+    missing = []
+    for filename in referenced:
+        # Only check files that look like examples
+        is_example = any(p in filename for p in example_patterns)
+        if is_example and not (example_dir / filename).exists():
+            missing.append(filename)
+
+    return missing
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Verify README accuracy against implementation'
+    )
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Show detailed output'
+    )
+    args = parser.parse_args()
+
+    # Validate directory
+    readme_path = Path('README.md')
+    if not readme_path.exists():
+        print("Error: README.md not found. Run from package root directory.")
+        sys.exit(2)
+
+    resources_dir = Path('lib/src/resources')
+    if not resources_dir.exists():
+        print("Error: lib/src/resources/ not found. Run from package root directory.")
+        sys.exit(2)
+
+    print("Checking README accuracy...")
+    print()
+
+    readme = readme_path.read_text()
+    total_issues = 0
+
+    # Check 1: Resource validation
+    impl_resources = find_implemented_resources()
+    doc_resources = extract_documented_resources(readme)
+
+    stale_resources = doc_resources - impl_resources
+    missing_resources = impl_resources - doc_resources
+
+    if args.verbose:
+        print(f"Implemented resources: {sorted(impl_resources)}")
+        print(f"Documented resources: {sorted(doc_resources)}")
+        print()
+
+    # Check 2: Tool properties
+    missing_tools = check_tool_documentation(readme)
+
+    # Check 3: Stale references
+    stale_refs = check_stale_references(readme)
+
+    # Check 4: Example files
+    missing_examples = check_example_files(readme)
+
+    # Report stale references
+    if stale_refs:
+        print("STALE REFERENCES (removed from API):")
+        for line_num, api, reason in stale_refs:
+            print(f"  - README.md:{line_num} - '{api}'")
+            print(f"      → {reason}")
+        print()
+        total_issues += len(stale_refs)
+
+    # Report stale resources
+    if stale_resources:
+        print("STALE RESOURCES (documented but not implemented):")
+        for res in sorted(stale_resources):
+            print(f"  - client.{res}")
+        print()
+        total_issues += len(stale_resources)
+
+    # Report missing resources
+    if missing_resources:
+        print("MISSING RESOURCES (implemented but not documented):")
+        for res in sorted(missing_resources):
+            print(f"  - client.{res} (lib/src/resources/)")
+        print()
+        total_issues += len(missing_resources)
+
+    # Report missing tool documentation
+    if missing_tools:
+        print("MISSING TOOL DOCUMENTATION:")
+        tool_props = find_tool_properties()
+        for prop, description in missing_tools:
+            line = tool_props.get(prop, '?')
+            print(f"  - Tool.{prop} (lib/src/models/tools/tool.dart:{line})")
+            print(f"      → {description}")
+        print()
+        total_issues += len(missing_tools)
+
+    # Report missing examples
+    if missing_examples:
+        print("MISSING EXAMPLE FILES:")
+        for example in sorted(missing_examples):
+            print(f"  - {example}")
+        print()
+        total_issues += len(missing_examples)
+
+    # Summary
+    if total_issues == 0:
+        print("✓ README is accurate and complete.")
+        sys.exit(0)
+    else:
+        print(f"Found {total_issues} issue(s).")
+        print()
+
+        # Provide actionable suggestions
+        if stale_refs or stale_resources:
+            print("SUGGESTED REMOVALS:")
+            if stale_resources:
+                for res in sorted(stale_resources):
+                    print(f"  - Remove '{res} Resource' section from API Coverage")
+            # Group stale refs by section
+            chunk_refs = [r for r in stale_refs if 'chunk' in r[1].lower()]
+            rag_refs = [r for r in stale_refs if 'rag' in r[1].lower()]
+            if chunk_refs:
+                lines = sorted(set(r[0] for r in chunk_refs))
+                print(f"  - Remove Chunk Management references (lines: {lines})")
+            if rag_refs:
+                lines = sorted(set(r[0] for r in rag_refs))
+                print(f"  - Remove RAG Stores references (lines: {lines})")
+            print()
+
+        if missing_resources or missing_tools:
+            print("SUGGESTED ADDITIONS:")
+            if missing_resources:
+                for res in sorted(missing_resources):
+                    print(f"  - Add '{res}' Resource section to API Coverage")
+            if missing_tools:
+                for prop, desc in missing_tools:
+                    print(f"  - Document Tool.{prop} in Function Calling section")
+            print()
+
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/googleai_dart/.claude/skills/openapi-updater/specs.json
+++ b/packages/googleai_dart/.claude/skills/openapi-updater/specs.json
@@ -1,0 +1,36 @@
+{
+  "specs": {
+    "main": {
+      "name": "Generative Language API",
+      "url": "https://generativelanguage.googleapis.com/$discovery/OPENAPI3_0?version=v1beta",
+      "local_file": "openapi.json",
+      "requires_auth": true,
+      "description": "Core Gemini API - generation, embeddings, files, models, etc."
+    },
+    "interactions": {
+      "name": "Interactions API",
+      "url": "https://ai.google.dev/static/api/interactions.openapi.json",
+      "local_file": "openapi-interactions.json",
+      "requires_auth": false,
+      "experimental": true,
+      "description": "Server-side state, agents, background execution"
+    }
+  },
+  "discovery_patterns": [
+    "https://ai.google.dev/static/api/{name}.openapi.json"
+  ],
+  "discovery_names": [
+    "interactions",
+    "live",
+    "live-api",
+    "bidi",
+    "music",
+    "live-music",
+    "agents",
+    "adk",
+    "imagen",
+    "veo",
+    "file-search",
+    "grounding"
+  ]
+}

--- a/packages/googleai_dart/openapi-interactions.json
+++ b/packages/googleai_dart/openapi-interactions.json
@@ -1,0 +1,2656 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Gemini API",
+    "description": "The Gemini Interactions API is an experimental API that allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
+    "version": "v1beta",
+    "x-google-revision": "0"
+  },
+  "servers": [{ "url": "https://generativelanguage.googleapis.com", "description": "Global Endpoint" }],
+  "paths": {
+    "/{api_version}/interactions": {
+      "parameters": [{ "$ref": "#/components/parameters/api_version" }],
+      "post": {
+        "operationId": "CreateInteraction",
+        "description": "Creates a new interaction.",
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "description": "The request body.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  { "$ref": "#/components/schemas/CreateModelInteractionParams" },
+                  { "$ref": "#/components/schemas/CreateAgentInteractionParams" }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Interaction" },
+                "examples": {
+                  "simple": {
+                    "summary": "Simple Request",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-2.5-flash",
+                      "object": "interaction",
+                      "outputs": [
+                        {
+                          "text": "Hello! I'm functioning perfectly and ready to assist you.\n\nHow are you doing today?",
+                          "type": "text"
+                        }
+                      ],
+                      "role": "model",
+                      "status": "completed",
+                      "updated": "2025-11-26T12:25:15Z",
+                      "usage": {
+                        "input_tokens_by_modality": [{ "modality": "text", "tokens": 7 }],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 7,
+                        "total_output_tokens": 20,
+                        "total_reasoning_tokens": 22,
+                        "total_tokens": 49,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "multi_turn": {
+                    "summary": "Multi-turn",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-2.5-flash",
+                      "status": "completed",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:22:47Z",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "role": "model",
+                      "outputs": [{ "type": "text", "text": "The capital of France is Paris." }],
+                      "usage": {
+                        "input_tokens_by_modality": [{ "modality": "text", "tokens": 50 }],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 50,
+                        "total_output_tokens": 10,
+                        "total_reasoning_tokens": 0,
+                        "total_tokens": 60,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "multimodal_image": {
+                    "summary": "Image Input",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-2.5-flash",
+                      "status": "completed",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:22:47Z",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "role": "model",
+                      "outputs": [
+                        {
+                          "type": "text",
+                          "text": "A white humanoid robot with glowing blue eyes stands holding a red skateboard."
+                        }
+                      ],
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          { "modality": "text", "tokens": 10 },
+                          { "modality": "image", "tokens": 258 }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 268,
+                        "total_output_tokens": 20,
+                        "total_reasoning_tokens": 0,
+                        "total_tokens": 288,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "function_calling": {
+                    "summary": "Function Calling",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-2.5-flash",
+                      "status": "requires_action",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:22:47Z",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "role": "model",
+                      "outputs": [
+                        {
+                          "type": "function_call",
+                          "function_call": {
+                            "name": "get_weather",
+                            "arguments": { "location": "Boston, MA" }
+                          }
+                        }
+                      ],
+                      "usage": {
+                        "input_tokens_by_modality": [{ "modality": "text", "tokens": 100 }],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 100,
+                        "total_output_tokens": 25,
+                        "total_reasoning_tokens": 0,
+                        "total_tokens": 125,
+                        "total_tool_use_tokens": 50
+                      }
+                    }
+                  },
+                  "deep_research": {
+                    "summary": "Deep Research",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "agent": "deep-research-pro-preview-12-2025",
+                      "status": "completed",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:22:47Z",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "role": "model",
+                      "outputs": [
+                        {
+                          "type": "text",
+                          "text": "Here is a comprehensive research report on the current state of cancer research..."
+                        }
+                      ],
+                      "usage": {
+                        "input_tokens_by_modality": [{ "modality": "text", "tokens": 20 }],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 20,
+                        "total_output_tokens": 1000,
+                        "total_reasoning_tokens": 500,
+                        "total_tokens": 1520,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error creating interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "$ref": "#/components/schemas/Error" } }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Creating an interaction",
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "simple",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"input\": \"Hello, how are you?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "simple",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    input=\"Hello, how are you?\",\n)\nprint(interaction.outputs[-1].text)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "simple",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    input: 'Hello, how are you?',\n});\nconsole.log(interaction.outputs[interaction.outputs.length - 1].text);\n"
+          },
+          {
+            "lang": "sh",
+            "label": "multi_turn",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"input\": [\n      {\n        \"role\": \"user\",\n        \"content\": \"Hello!\"\n      },\n      {\n        \"role\": \"model\",\n        \"content\": \"Hi there! How can I help you today?\"\n      },\n      {\n        \"role\": \"user\",\n        \"content\": \"What is the capital of France?\"\n      }\n    ]\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "multi_turn",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    input=[\n        { \"role\": \"user\", \"content\": \"Hello!\" },\n        { \"role\": \"model\", \"content\": \"Hi there! How can I help you today?\" },\n        { \"role\": \"user\", \"content\": \"What is the capital of France?\" }\n    ]\n)\nprint(response.outputs[-1].text)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "multi_turn",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    input: [\n        { role: 'user', content: 'Hello' },\n        { role: 'model', content: 'Hi there! How can I help you today?' },\n        { role: 'user', content: 'What is the capital of France?' }\n    ]\n});\nconsole.log(interaction.outputs[interaction.outputs.length - 1].text);\n"
+          },
+          {
+            "lang": "sh",
+            "label": "multimodal_image",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"input\": [\n      {\n        \"type\": \"text\",\n        \"text\": \"What is in this picture?\"\n      },\n      {\n        \"type\": \"image\",\n        \"data\": \"BASE64_ENCODED_IMAGE\",\n        \"mime_type\": \"image/png\"\n      }\n    ]\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "multimodal_image",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    input=[\n      { \"type\": \"text\", \"text\": \"What is in this picture?\" },\n      { \"type\": \"image\", \"data\": \"BASE64_ENCODED_IMAGE\", \"mime_type\": \"image/png\" }\n    ]\n)\nprint(response.outputs[-1].text)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "multimodal_image",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    input: [\n      { type: 'text', text: 'What is in this picture?' },\n      { type: 'image', data: 'BASE64_ENCODED_IMAGE', mime_type: 'image/png' }\n    ]\n});\nconsole.log(interaction.outputs[interaction.outputs.length - 1].text);\n"
+          },
+          {
+            "lang": "sh",
+            "label": "function_calling",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"tools\": [\n      {\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\",\n              \"description\": \"The city and state, e.g. San Francisco, CA\"\n            }\n          },\n          \"required\": [\n            \"location\"\n          ]\n        }\n      }\n    ],\n    \"input\": \"What is the weather like in Boston, MA?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "function_calling",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    tools=[{\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"location\": {\n                    \"type\": \"string\",\n                    \"description\": \"The city and state, e.g. San Francisco, CA\"\n                }\n            },\n            \"required\": [\"location\"]\n        }\n    }],\n    input=\"What is the weather like in Boston, MA?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "function_calling",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    tools: [{\n        type: 'function',\n        name: 'get_weather',\n        description: 'Get the current weather in a given location',\n        parameters: {\n            type: 'object',\n            properties: {\n                location: {\n                    type: 'string',\n                    description: 'The city and state, e.g. San Francisco, CA'\n                }\n            },\n            required: ['location']\n        }\n    }],\n    input: 'What is the weather like in Boston, MA?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          },
+          {
+            "lang": "sh",
+            "label": "deep_research",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"agent\": \"deep-research-pro-preview-12-2025\",\n    \"input\": \"Find a cure to cancer\",\n    \"background\": true\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "deep_research",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    agent=\"deep-research-pro-preview-12-2025\",\n    input=\"find a cure to cancer\",\n    background=True,\n)\nprint(interaction.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "deep_research",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    agent: 'deep-research-pro-preview-12-2025',\n    input: 'find a cure to cancer',\n    background: true,\n});\nconsole.log(interaction.status);\n"
+          }
+        ]
+      }
+    },
+    "/{api_version}/interactions/{id}": {
+      "get": {
+        "operationId": "getInteractionById",
+        "description": "Retrieves the full details of a single interaction based on its `Interaction.id`.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the interaction to retrieve.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "stream",
+            "in": "query",
+            "schema": { "type": "boolean", "default": false },
+            "description": "If set to true, the generated content will be streamed incrementally."
+          },
+          {
+            "name": "last_event_id",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Optional. If set, resumes the interaction stream from the next chunk after the event marked by the event id. Can only be used if `stream` is true."
+          },
+          { "$ref": "#/components/parameters/api_version" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful retrieval of the interaction.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Interaction" },
+                "examples": {
+                  "get": {
+                    "summary": "Get Interaction",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-2.5-flash",
+                      "status": "completed",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:25:15Z",
+                      "updated": "2025-11-26T12:25:15Z",
+                      "role": "model",
+                      "outputs": [
+                        {
+                          "type": "text",
+                          "text": "I'm doing great, thank you for asking! How can I help you today?"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error getting interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "$ref": "#/components/schemas/Error" } }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Retrieving an interaction",
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "get",
+            "source": "curl -X GET https://generativelanguage.googleapis.com/v1beta/interactions/v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "lang": "python",
+            "label": "get",
+            "source": "from google import genai\n\nclient = genai.Client()\n\ninteraction = client.interactions.get(id=\"v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg\")\nprint(interaction.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "get",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.get('v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg');\nconsole.log(interaction.status);\n"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteInteraction",
+        "description": "Deletes the interaction by id.",
+        "summary": "Deleting an interaction",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the interaction to delete.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          { "$ref": "#/components/parameters/api_version" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful deletion of the interaction.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" },
+                "examples": { "delete": { "summary": "Delete Interaction", "value": {} } }
+              }
+            }
+          },
+          "default": {
+            "description": "Error deleting interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "$ref": "#/components/schemas/Error" } }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "delete",
+            "source": "curl -X DELETE https://generativelanguage.googleapis.com/v1beta/interactions/v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "lang": "python",
+            "label": "delete",
+            "source": "from google import genai\n\nclient = genai.Client()\n\ninteraction = client.interactions.delete(id=\"v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg\")\nprint(interaction.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "delete",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.delete('v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg');\nconsole.log(interaction.status);\n"
+          }
+        ]
+      }
+    },
+    "/{api_version}/interactions/{id}/cancel": {
+      "post": {
+        "operationId": "cancelInteractionById",
+        "description": "Cancels an interaction by id. This only applies to background interactions that are still running.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the interaction to cancel.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          { "$ref": "#/components/parameters/api_version" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful cancellation of the interaction.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Interaction" },
+                "examples": {
+                  "cancel": {
+                    "summary": "Cancel Interaction",
+                    "value": {
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "agent": "deep-research-pro-preview-12-2025",
+                      "status": "cancelled",
+                      "object": "interaction",
+                      "created": "2025-11-26T12:25:15Z",
+                      "updated": "2025-11-26T12:25:15Z",
+                      "role": "model"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error cancelling interaction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "$ref": "#/components/schemas/Error" } }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Canceling an interaction",
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "cancel",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions/v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg/cancel \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "lang": "python",
+            "label": "cancel",
+            "source": "from google import genai\n\nclient = genai.Client()\n\ninteraction = client.interactions.cancel(id=\"v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg\")\nprint(interaction.status)\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "cancel",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.cancel('v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg');\nconsole.log(interaction.status);\n"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "api_version": {
+        "name": "api_version",
+        "description": "Which version of the API to use.",
+        "schema": { "type": "string" },
+        "in": "path"
+      }
+    },
+    "securitySchemes": {},
+    "schemas": {
+      "Content": {
+        "description": "The content of the response.",
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/TextContent" },
+          { "$ref": "#/components/schemas/ImageContent" },
+          { "$ref": "#/components/schemas/AudioContent" },
+          { "$ref": "#/components/schemas/DocumentContent" },
+          { "$ref": "#/components/schemas/VideoContent" },
+          { "$ref": "#/components/schemas/ThoughtContent" },
+          { "$ref": "#/components/schemas/FunctionCallContent" },
+          { "$ref": "#/components/schemas/FunctionResultContent" },
+          { "$ref": "#/components/schemas/CodeExecutionCallContent" },
+          { "$ref": "#/components/schemas/CodeExecutionResultContent" },
+          { "$ref": "#/components/schemas/UrlContextCallContent" },
+          { "$ref": "#/components/schemas/UrlContextResultContent" },
+          { "$ref": "#/components/schemas/GoogleSearchCallContent" },
+          { "$ref": "#/components/schemas/GoogleSearchResultContent" },
+          { "$ref": "#/components/schemas/McpServerToolCallContent" },
+          { "$ref": "#/components/schemas/McpServerToolResultContent" },
+          { "$ref": "#/components/schemas/FileSearchResultContent" }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "text": "#/components/schemas/TextContent",
+            "image": "#/components/schemas/ImageContent",
+            "audio": "#/components/schemas/AudioContent",
+            "document": "#/components/schemas/DocumentContent",
+            "video": "#/components/schemas/VideoContent",
+            "thought": "#/components/schemas/ThoughtContent",
+            "function_call": "#/components/schemas/FunctionCallContent",
+            "function_result": "#/components/schemas/FunctionResultContent",
+            "code_execution_call": "#/components/schemas/CodeExecutionCallContent",
+            "code_execution_result": "#/components/schemas/CodeExecutionResultContent",
+            "url_context_call": "#/components/schemas/UrlContextCallContent",
+            "url_context_result": "#/components/schemas/UrlContextResultContent",
+            "google_search_call": "#/components/schemas/GoogleSearchCallContent",
+            "google_search_result": "#/components/schemas/GoogleSearchResultContent",
+            "mcp_server_tool_call": "#/components/schemas/McpServerToolCallContent",
+            "mcp_server_tool_result": "#/components/schemas/McpServerToolResultContent",
+            "file_search_result": "#/components/schemas/FileSearchResultContent"
+          }
+        }
+      },
+      "TextContent": {
+        "description": "A text content block.",
+        "type": "object",
+        "properties": {
+          "text": { "description": "The text content.", "type": "string" },
+          "annotations": {
+            "description": "Citation information for model-generated content.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Annotation" }
+          },
+          "type": { "const": "text" }
+        },
+        "required": ["type"],
+        "examples": [
+          { "text": null, "summary": "Text", "value": { "type": "text", "text": "Hello, how are you?" } }
+        ]
+      },
+      "Annotation": {
+        "description": "Citation information for model-generated content.",
+        "type": "object",
+        "properties": {
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.\n\nIndex indicates the start of the segment, measured in bytes.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "source": {
+            "description": "Source attributed for a portion of the text. Could be a URL, title, or\nother identifier.",
+            "type": "string"
+          }
+        }
+      },
+      "ImageContent": {
+        "description": "An image content block.",
+        "type": "object",
+        "properties": {
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": { "$ref": "#/components/schemas/ImageMimeTypeOption" },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          },
+          "type": { "const": "image" }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "image": null,
+            "summary": "Image",
+            "value": { "type": "image", "data": "BASE64_ENCODED_IMAGE", "mime_type": "image/png" }
+          }
+        ]
+      },
+      "AudioContent": {
+        "description": "An audio content block.",
+        "type": "object",
+        "properties": {
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": { "$ref": "#/components/schemas/AudioMimeTypeOption" },
+          "type": { "const": "audio" }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "audio": null,
+            "summary": "Audio",
+            "value": { "type": "audio", "data": "BASE64_ENCODED_AUDIO", "mime_type": "audio/wav" }
+          }
+        ]
+      },
+      "DocumentContent": {
+        "description": "A document content block.",
+        "type": "object",
+        "properties": {
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": { "$ref": "#/components/schemas/DocumentMimeTypeOption" },
+          "type": { "const": "document" }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "document": null,
+            "summary": "Document",
+            "value": { "type": "document", "data": "BASE64_ENCODED_DOCUMENT", "mime_type": "application/pdf" }
+          }
+        ]
+      },
+      "VideoContent": {
+        "description": "A video content block.",
+        "type": "object",
+        "properties": {
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": { "$ref": "#/components/schemas/VideoMimeTypeOption" },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          },
+          "type": { "const": "video" }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "video": null,
+            "summary": "Video",
+            "value": { "type": "video", "uri": "https://www.youtube.com/watch?v=9hE5-98ZeCg" }
+          }
+        ]
+      },
+      "ThoughtContent": {
+        "description": "A thought content block.",
+        "type": "object",
+        "properties": {
+          "signature": {
+            "description": "Signature to match the backend source to be part of the generation.",
+            "type": "string",
+            "format": "byte"
+          },
+          "summary": {
+            "description": "A summary of the thought.",
+            "$ref": "#/components/schemas/ThoughtSummary"
+          },
+          "type": { "const": "thought" }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "thought": null,
+            "summary": "Thought",
+            "value": {
+              "type": "thought",
+              "summary": [
+                {
+                  "type": "text",
+                  "text": "The user is asking about the weather. I should use the get_weather tool."
+                }
+              ],
+              "signature": "CoMDAXLI2nynRYojJIy6B1Jh9os2crpWLfB0+19xcLsGG46bd8wjkF/6RNlRUdvHrXyjsHkG0BZFcuO/bPOyA6Xh5jANNgx82wPHjGExN8A4ZQn56FlMwyZoqFVQz0QyY1lfibFJ2zU3J87uw26OewzcuVX0KEcs+GIsZa3EA6WwqhbsOd3wtZB3Ua2Qf98VAWZTS5y/tWpql7jnU3/CU7pouxQr/Bwft3hwnJNesQ9/dDJTuaQ8Zprh9VRWf1aFFjpIueOjBRrlT3oW6/y/eRl/Gt9BQXCYTqg/38vHFUU4Wo/d9dUpvfCe/a3o97t2Jgxp34oFKcsVb4S5WJrykIkw+14DzVnTpCpbQNFckqvFLuqnJCkL0EQFtunBXI03FJpPu3T1XU6id8S7ojoJQZSauGUCgmaLqUGdMrd08oo81ecoJSLs51Re9N/lISGmjWFPGpqJLoGq6uo4FHz58hmeyXCgHG742BHz2P3MiH1CXHUT2J8mF6zLhf3SR9Qb3lkrobAh"
+            }
+          }
+        ]
+      },
+      "ThoughtSummary": {
+        "description": "A summary of the thought.",
+        "type": "array",
+        "items": {
+          "oneOf": [
+            { "$ref": "#/components/schemas/TextContent" },
+            { "$ref": "#/components/schemas/ImageContent" }
+          ],
+          "discriminator": {
+            "propertyName": "type",
+            "mapping": {
+              "text": "#/components/schemas/TextContent",
+              "image": "#/components/schemas/ImageContent"
+            }
+          }
+        }
+      },
+      "FunctionCallContent": {
+        "description": "A function tool call content block.",
+        "type": "object",
+        "properties": {
+          "name": { "description": "The name of the tool to call.", "type": "string" },
+          "arguments": {
+            "description": "The arguments to pass to the function.",
+            "type": "object",
+            "additionalProperties": { "description": "Properties of the object." }
+          },
+          "type": { "const": "function_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["name", "id", "arguments", "type"],
+        "examples": [
+          {
+            "function_call": null,
+            "summary": "Function Call",
+            "value": {
+              "type": "function_call",
+              "name": "get_weather",
+              "id": "gth23981",
+              "arguments": { "location": "Boston, MA" }
+            }
+          }
+        ]
+      },
+      "CodeExecutionCallContent": {
+        "description": "Code execution content.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "The arguments to pass to the code execution.",
+            "$ref": "#/components/schemas/CodeExecutionCallArguments"
+          },
+          "type": { "const": "code_execution_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "code_execution_call": null,
+            "summary": "Code Execution Call",
+            "value": {
+              "type": "code_execution_call",
+              "id": "call_123456",
+              "arguments": { "language": "python", "code": "print('hello world')" }
+            }
+          }
+        ]
+      },
+      "CodeExecutionCallArguments": {
+        "description": "The arguments to pass to the code execution.",
+        "type": "object",
+        "properties": {
+          "language": {
+            "description": "Programming language of the `code`.",
+            "type": "string",
+            "x-google-enum-descriptions": ["Python >= 3.10, with numpy and simpy available."],
+            "enum": ["python"]
+          },
+          "code": { "description": "The code to be executed.", "type": "string" }
+        }
+      },
+      "UrlContextCallContent": {
+        "description": "URL context content.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "The arguments to pass to the URL context.",
+            "$ref": "#/components/schemas/UrlContextCallArguments"
+          },
+          "type": { "const": "url_context_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "url_context_call": null,
+            "summary": "Url Context Call",
+            "value": {
+              "type": "url_context_call",
+              "id": "call_123456",
+              "arguments": { "urls": ["https://www.example.com"] }
+            }
+          }
+        ]
+      },
+      "UrlContextCallArguments": {
+        "description": "The arguments to pass to the URL context.",
+        "type": "object",
+        "properties": {
+          "urls": { "description": "The URLs to fetch.", "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "McpServerToolCallContent": {
+        "description": "MCPServer tool call content.",
+        "type": "object",
+        "properties": {
+          "name": { "description": "The name of the tool which was called.", "type": "string" },
+          "server_name": { "description": "The name of the used MCP server.", "type": "string" },
+          "arguments": {
+            "description": "The JSON object of arguments for the function.",
+            "type": "object",
+            "additionalProperties": { "description": "Properties of the object." }
+          },
+          "type": { "const": "mcp_server_tool_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["name", "server_name", "arguments", "id", "type"],
+        "examples": [
+          {
+            "mcp_server_tool_call": null,
+            "summary": "Mcp Server Tool Call",
+            "value": {
+              "type": "mcp_server_tool_call",
+              "id": "call_123456",
+              "name": "get_forecast",
+              "server_name": "weather_server",
+              "arguments": { "city": "London" }
+            }
+          }
+        ]
+      },
+      "GoogleSearchCallContent": {
+        "description": "Google Search content.",
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "The arguments to pass to Google Search.",
+            "$ref": "#/components/schemas/GoogleSearchCallArguments"
+          },
+          "type": { "const": "google_search_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "google_search_call": null,
+            "summary": "Google Search Call",
+            "value": {
+              "type": "google_search_call",
+              "id": "call_123456",
+              "arguments": { "queries": ["weather in Boston"] }
+            }
+          }
+        ]
+      },
+      "GoogleSearchCallArguments": {
+        "description": "The arguments to pass to Google Search.",
+        "type": "object",
+        "properties": {
+          "queries": {
+            "description": "Web search queries for the following-up web search.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "FunctionResultContent": {
+        "description": "A function tool result content block.",
+        "type": "object",
+        "properties": {
+          "name": { "description": "The name of the tool that was called.", "type": "string" },
+          "is_error": { "description": "Whether the tool call resulted in an error.", "type": "boolean" },
+          "type": { "const": "function_result" },
+          "result": {
+            "description": "The result of the tool call.",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/components/schemas/ImageContent" },
+                        { "type": "object" }
+                      ]
+                    }
+                  }
+                }
+              },
+              { "type": "object" },
+              { "type": "string" }
+            ]
+          },
+          "call_id": { "type": "string", "description": "ID to match the ID from the function call block." }
+        },
+        "required": ["call_id", "result", "type"],
+        "examples": [
+          {
+            "function_result": null,
+            "summary": "Function Result",
+            "value": {
+              "type": "function_result",
+              "name": "get_weather",
+              "call_id": "gth23981",
+              "result": { "weather": "sunny" }
+            }
+          }
+        ]
+      },
+      "CodeExecutionResultContent": {
+        "description": "Code execution result content.",
+        "type": "object",
+        "properties": {
+          "result": { "description": "The output of the code execution.", "type": "string" },
+          "is_error": {
+            "description": "Whether the code execution resulted in an error.",
+            "type": "boolean"
+          },
+          "signature": { "description": "A signature hash for backend validation.", "type": "string" },
+          "type": { "const": "code_execution_result" },
+          "call_id": {
+            "type": "string",
+            "description": "ID to match the ID from the code execution call block."
+          }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "code_execution_result": null,
+            "summary": "Code Execution Result",
+            "value": { "type": "code_execution_result", "call_id": "call_123456", "result": "hello world\n" }
+          }
+        ]
+      },
+      "UrlContextResultContent": {
+        "description": "URL context result content.",
+        "type": "object",
+        "properties": {
+          "signature": { "description": "The signature of the URL context result.", "type": "string" },
+          "result": {
+            "description": "The results of the URL context.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/UrlContextResult" }
+          },
+          "is_error": { "description": "Whether the URL context resulted in an error.", "type": "boolean" },
+          "type": { "const": "url_context_result" },
+          "call_id": {
+            "type": "string",
+            "description": "ID to match the ID from the url context call block."
+          }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "url_context_result": null,
+            "summary": "Url Context Result",
+            "value": {
+              "type": "url_context_result",
+              "call_id": "call_123456",
+              "result": [{ "url": "https://www.example.com", "status": "SUCCESS" }]
+            }
+          }
+        ]
+      },
+      "UrlContextResult": {
+        "description": "The result of the URL context.",
+        "type": "object",
+        "properties": {
+          "url": { "description": "The URL that was fetched.", "type": "string" },
+          "status": {
+            "description": "The status of the URL retrieval.",
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Url retrieval is successful.",
+              "Url retrieval is failed due to error.",
+              "Url retrieval is failed because the content is behind paywall.",
+              "Url retrieval is failed because the content is unsafe."
+            ],
+            "enum": ["success", "error", "paywall", "unsafe"]
+          }
+        }
+      },
+      "GoogleSearchResultContent": {
+        "description": "Google Search result content.",
+        "type": "object",
+        "properties": {
+          "signature": { "description": "The signature of the Google Search result.", "type": "string" },
+          "result": {
+            "description": "The results of the Google Search.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/GoogleSearchResult" }
+          },
+          "is_error": { "description": "Whether the Google Search resulted in an error.", "type": "boolean" },
+          "type": { "const": "google_search_result" },
+          "call_id": {
+            "type": "string",
+            "description": "ID to match the ID from the google search call block."
+          }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "google_search_result": null,
+            "summary": "Google Search Result",
+            "value": {
+              "type": "google_search_result",
+              "call_id": "call_123456",
+              "result": [
+                { "url": "https://www.google.com/search?q=weather+in+Boston", "title": "Weather in Boston" }
+              ]
+            }
+          }
+        ]
+      },
+      "GoogleSearchResult": {
+        "description": "The result of the Google Search.",
+        "type": "object",
+        "properties": {
+          "url": { "description": "URI reference of the search result.", "type": "string" },
+          "title": { "description": "Title of the search result.", "type": "string" },
+          "rendered_content": {
+            "description": "Web content snippet that can be embedded in a web page or an app webview.",
+            "type": "string"
+          }
+        }
+      },
+      "McpServerToolResultContent": {
+        "description": "MCPServer tool result content.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Name of the tool which is called for this specific tool call.",
+            "type": "string"
+          },
+          "server_name": { "description": "The name of the used MCP server.", "type": "string" },
+          "type": { "const": "mcp_server_tool_result" },
+          "result": {
+            "description": "The result of the tool call.",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/components/schemas/ImageContent" },
+                        { "type": "object" }
+                      ]
+                    }
+                  }
+                }
+              },
+              { "type": "object" },
+              { "type": "string" }
+            ]
+          },
+          "call_id": {
+            "type": "string",
+            "description": "ID to match the ID from the MCP server tool call block."
+          }
+        },
+        "required": ["call_id", "result", "type"],
+        "examples": [
+          {
+            "mcp_server_tool_result": null,
+            "summary": "Mcp Server Tool Result",
+            "value": {
+              "type": "mcp_server_tool_result",
+              "name": "get_forecast",
+              "server_name": "weather_server",
+              "call_id": "call_123456",
+              "result": "sunny"
+            }
+          }
+        ]
+      },
+      "FileSearchResultContent": {
+        "description": "File Search result content.",
+        "type": "object",
+        "properties": {
+          "result": {
+            "description": "The results of the File Search.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/FileSearchResult" }
+          },
+          "type": { "const": "file_search_result" }
+        },
+        "required": ["type"],
+        "examples": [
+          {
+            "file_search_result": null,
+            "summary": "File Search Result",
+            "value": {
+              "type": "file_search_result",
+              "result": [{ "text": "search result chunk", "file_search_store": "file_search_store" }]
+            }
+          }
+        ]
+      },
+      "FileSearchResult": {
+        "description": "The result of the File Search.",
+        "type": "object",
+        "properties": {
+          "title": { "description": "The title of the search result.", "type": "string" },
+          "text": { "description": "The text of the search result.", "type": "string" },
+          "file_search_store": { "description": "The name of the file search store.", "type": "string" }
+        }
+      },
+      "Turn": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "description": "The originator of this turn. Must be user for input or model for\nmodel output.",
+            "type": "string"
+          },
+          "content": {
+            "description": "The content of the turn.",
+            "oneOf": [
+              { "type": "string" },
+              { "type": "array", "items": { "$ref": "#/components/schemas/Content" } }
+            ]
+          }
+        },
+        "examples": [
+          {
+            "user_turn": null,
+            "summary": "User Turn",
+            "value": { "role": "user", "content": [{ "type": "text", "text": "user turn" }] }
+          },
+          {
+            "model_turn": null,
+            "summary": "Model Turn",
+            "value": { "role": "model", "content": [{ "type": "text", "text": "model turn" }] }
+          }
+        ]
+      },
+      "GenerationConfig": {
+        "description": "Configuration parameters for model interactions.",
+        "type": "object",
+        "properties": {
+          "temperature": {
+            "description": "Controls the randomness of the output.",
+            "type": "number",
+            "format": "float"
+          },
+          "top_p": {
+            "description": "The maximum cumulative probability of tokens to consider when sampling.",
+            "type": "number",
+            "format": "float"
+          },
+          "seed": {
+            "description": "Seed used in decoding for reproducibility.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "stop_sequences": {
+            "description": "A list of character sequences that will stop output interaction.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "tool_choice": {
+            "description": "The tool choice for the interaction.",
+            "$ref": "#/components/schemas/ToolChoice"
+          },
+          "thinking_level": {
+            "description": "The level of thought tokens that the model should generate.",
+            "$ref": "#/components/schemas/ThinkingLevel"
+          },
+          "thinking_summaries": {
+            "description": "Whether to include thought summaries in the response.",
+            "$ref": "#/components/schemas/ThinkingSummaries"
+          },
+          "max_output_tokens": {
+            "description": "The maximum number of tokens to include in the response.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "speech_config": {
+            "description": "Configuration for speech interaction.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/SpeechConfig" }
+          }
+        }
+      },
+      "ToolChoice": {
+        "description": "The configuration for tool choice.",
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/ToolChoiceType" },
+          { "$ref": "#/components/schemas/ToolChoiceConfig" }
+        ]
+      },
+      "AllowedTools": {
+        "description": "The configuration for allowed tools.",
+        "type": "object",
+        "properties": {
+          "mode": {
+            "description": "The mode of the tool choice.",
+            "$ref": "#/components/schemas/ToolChoiceType"
+          },
+          "tools": {
+            "description": "The names of the allowed tools.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "SpeechConfig": {
+        "description": "The configuration for speech interaction.",
+        "type": "object",
+        "properties": {
+          "voice": { "description": "The voice of the speaker.", "type": "string" },
+          "language": { "description": "The language of the speech.", "type": "string" },
+          "speaker": {
+            "description": "The speaker's name, it should match the speaker name given in the prompt.",
+            "type": "string"
+          }
+        }
+      },
+      "DynamicAgentConfig": {
+        "description": "Configuration for dynamic agents.",
+        "type": "object",
+        "properties": { "type": { "const": "dynamic" } },
+        "additionalProperties": { "description": "Additional properties for the dynamic agent." }
+      },
+      "DeepResearchAgentConfig": {
+        "description": "Configuration for the Deep Research agent.",
+        "type": "object",
+        "properties": {
+          "thinking_summaries": {
+            "description": "Whether to include thought summaries in the response.",
+            "$ref": "#/components/schemas/ThinkingSummaries"
+          },
+          "type": { "const": "deep-research" }
+        }
+      },
+      "Function": {
+        "description": "A tool that can be used by the model.",
+        "type": "object",
+        "properties": {
+          "name": { "description": "The name of the function.", "type": "string" },
+          "description": { "description": "A description of the function.", "type": "string" },
+          "parameters": { "description": "The JSON Schema for the function's parameters." },
+          "type": { "type": "string", "const": "function" }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "function_calling",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"tools\": [{\n      \"type\": \"function\",\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather in a given location\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\",\n            \"description\": \"The city and state, e.g. San Francisco, CA\"\n          }\n        },\n        \"required\": [\"location\"]\n      }\n    }],\n    \"input\": \"What is the weather like in Boston, MA?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "function_calling",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    tools=[{\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"location\": {\n                    \"type\": \"string\",\n                    \"description\": \"The city and state, e.g. San Francisco, CA\"\n                }\n            },\n            \"required\": [\"location\"]\n        }\n    }],\n    input=\"What is the weather like in Boston?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "function_calling",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    tools: [{\n        type: 'function',\n        name: 'get_weather',\n        description: 'Get the current weather in a given location',\n        parameters: {\n            type: 'object',\n            properties: {\n                location: {\n                    type: 'string',\n                    description: 'The city and state, e.g. San Francisco, CA'\n                }\n            },\n            required: ['location']\n        }\n    }],\n    input: 'What is the weather like in Boston?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "CodeExecution": {
+        "description": "A tool that can be used by the model to execute code.",
+        "type": "object",
+        "properties": { "type": { "type": "string", "const": "code_execution" } },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "code_execution",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"tools\": [{\n      \"type\": \"code_execution\"\n    }],\n    \"input\": \"Calculate the first 10 Fibonacci numbers\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "code_execution",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    tools=[{\"type\": \"code_execution\"}],\n    input=\"Calculate the first 10 Fibonacci numbers\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "code_execution",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    tools: [{ type: 'code_execution' }],\n    input: 'Calculate the first 10 Fibonacci numbers'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "UrlContext": {
+        "description": "A tool that can be used by the model to fetch URL context.",
+        "type": "object",
+        "properties": { "type": { "type": "string", "const": "url_context" } },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "url_context",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"tools\": [{\n      \"type\": \"url_context\"\n    }],\n    \"input\": \"Summarize https://www.example.com\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "url_context",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    tools=[{\"type\": \"url_context\"}],\n    input=\"Summarize https://www.example.com\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "url_context",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    tools: [{ type: 'url_context' }],\n    input: 'Summarize https://www.example.com'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "ComputerUse": {
+        "description": "A tool that can be used by the model to interact with the computer.",
+        "type": "object",
+        "properties": {
+          "environment": {
+            "description": "The environment being operated.",
+            "type": "string",
+            "x-google-enum-descriptions": ["Operates in a web browser."],
+            "enum": ["browser"]
+          },
+          "excludedPredefinedFunctions": {
+            "description": "The list of predefined functions that are excluded from the model call.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "type": { "type": "string", "const": "computer_use" }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "computer_use",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-computer-use-preview-10-2025\",\n    \"tools\": [{\n      \"type\": \"computer_use\",\n    }],\n    \"input\": \"Find a flight to Tokyo\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "computer_use",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-computer-use-preview-10-2025\",\n    tools=[{\"type\": \"computer_use\"}],\n    input=\"Find a flight to Tokyo\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "computer_use",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-computer-use-preview-10-2025',\n    tools: [{ type: 'computer_use'}],\n    input: 'Find a flight to Tokyo'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "McpServer": {
+        "description": "A MCPServer is a server that can be called by the model to perform actions.",
+        "type": "object",
+        "properties": {
+          "name": { "description": "The name of the MCPServer.", "type": "string" },
+          "url": {
+            "description": "The full URL for the MCPServer endpoint.\nExample: \"https://api.example.com/mcp\"",
+            "type": "string"
+          },
+          "headers": {
+            "description": "Optional: Fields for authentication headers, timeouts, etc., if needed.",
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          },
+          "allowed_tools": {
+            "description": "The allowed tools.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AllowedTools" }
+          },
+          "type": { "type": "string", "const": "mcp_server" }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "mcp_server",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"tools\": [{\n      \"type\": \"mcp_server\",\n      \"name\": \"weather_service\",\n      \"url\": \"https://gemini-api-demos.uc.r.appspot.com/mcp\"\n    }],\n    \"input\": \"Today is 12-05-2025, what is the temperature today in London?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "mcp_server",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    tools=[{\n        \"type\": \"mcp_server\",\n        \"name\": \"weather_service\",\n        \"url\": \"https://gemini-api-demos.uc.r.appspot.com/mcp\"\n    }],\n    input=\"Today is 12-05-2025, what is the temperature today in London?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "mcp_server",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    tools: [{\n        type: 'mcp_server',\n        name: 'weather_service',\n        url: 'https://gemini-api-demos.uc.r.appspot.com/mcp'\n    }],\n    input: 'Today is 12-05-2025, what is the temperature today in London?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "GoogleSearch": {
+        "description": "A tool that can be used by the model to search Google.",
+        "type": "object",
+        "properties": { "type": { "type": "string", "const": "google_search" } },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "google_search",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"tools\": [{\n      \"type\": \"google_search\"\n    }],\n    \"input\": \"Who is the current president of France?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "google_search",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    tools=[{\"type\": \"google_search\"}],\n    input=\"Who is the current president of France?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "google_search",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    tools: [{ type: 'google_search' }],\n    input: 'Who is the current president of France?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "FileSearch": {
+        "description": "A tool that can be used by the model to search files.",
+        "type": "object",
+        "properties": {
+          "file_search_store_names": {
+            "description": "The file search store names to search.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "top_k": {
+            "description": "The number of semantic retrieval chunks to retrieve.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "metadata_filter": {
+            "description": "Metadata filter to apply to the semantic retrieval documents and chunks.",
+            "type": "string"
+          },
+          "type": { "type": "string", "const": "file_search" }
+        },
+        "required": ["type"],
+        "x-codeSamples": [
+          {
+            "lang": "sh",
+            "label": "file_search",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-flash\",\n    \"tools\": [{\n      \"type\": \"file_search\",\n      \"file_search_store_names\": [\"fileSearchStores/m64d1sevsr4y-xfyawui3fxqg\"]\n    }],\n    \"input\": \"Who is the author of the book?\"\n  }'\n"
+          },
+          {
+            "lang": "python",
+            "label": "file_search",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-flash\",\n    tools=[{\n        \"type\": \"file_search\",\n        \"file_search_store_names\": [\"fileSearchStores/m64d1sevsr4y-xfyawui3fxqg\"]\n    }],\n    input=\"Who is the author of the book?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "lang": "javascript",
+            "label": "file_search",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-flash',\n    tools: [{\n        type: 'file_search',\n        file_search_store_names: ['fileSearchStores/m64d1sevsr4y-xfyawui3fxqg']\n    }],\n    input: 'Who is the author of the book?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "Usage": {
+        "description": "Statistics on the interaction request's token usage.",
+        "type": "object",
+        "properties": {
+          "total_input_tokens": {
+            "description": "Number of tokens in the prompt (context).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "input_tokens_by_modality": {
+            "description": "A breakdown of input token usage by modality.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ModalityTokens" }
+          },
+          "total_cached_tokens": {
+            "description": "Number of tokens in the cached part of the prompt (the cached content).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "cached_tokens_by_modality": {
+            "description": "A breakdown of cached token usage by modality.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ModalityTokens" }
+          },
+          "total_output_tokens": {
+            "description": "Total number of tokens across all the generated responses.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "output_tokens_by_modality": {
+            "description": "A breakdown of output token usage by modality.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ModalityTokens" }
+          },
+          "total_tool_use_tokens": {
+            "description": "Number of tokens present in tool-use prompt(s).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "tool_use_tokens_by_modality": {
+            "description": "A breakdown of tool-use token usage by modality.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ModalityTokens" }
+          },
+          "total_reasoning_tokens": {
+            "description": "Number of tokens of thoughts for thinking models.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_tokens": {
+            "description": "Total token count for the interaction request (prompt + responses + other\ninternal tokens).",
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ModalityTokens": {
+        "description": "The token count for a single response modality.",
+        "type": "object",
+        "properties": {
+          "modality": {
+            "description": "The modality associated with the token count.",
+            "$ref": "#/components/schemas/ResponseModality"
+          },
+          "tokens": {
+            "description": "Number of tokens for the modality.",
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "InteractionEvent": {
+        "type": "object",
+        "properties": {
+          "event_type": { "type": "string", "enum": ["interaction.start", "interaction.complete"] },
+          "interaction": { "$ref": "#/components/schemas/Interaction" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "examples": {
+          "interaction_start": {
+            "summary": "Interaction Start",
+            "value": {
+              "event_type": "interaction.start",
+              "interaction": {
+                "id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+                "model": "gemini-2.5-flash",
+                "object": "interaction",
+                "status": "in_progress"
+              }
+            }
+          },
+          "interaction_complete": {
+            "summary": "Interaction Complete",
+            "value": {
+              "event_type": "interaction.complete",
+              "interaction": {
+                "created": "2025-12-09T18:45:40Z",
+                "id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+                "model": "gemini-2.5-flash",
+                "object": "interaction",
+                "outputs": [
+                  {
+                    "signature": "CoMDAXLI2nynRYojJIy6B1Jh9os2crpWLfB0+19xcLsGG46bd8wjkF/6RNlRUdvHrXyjsHkG0BZFcuO/bPOyA6Xh5jANNgx82wPHjGExN8A4ZQn56FlMwyZoqFVQz0QyY1lfibFJ2zU3J87uw26OewzcuVX0KEcs+GIsZa3EA6WwqhbsOd3wtZB3Ua2Qf98VAWZTS5y/tWpql7jnU3/CU7pouxQr/Bwft3hwnJNesQ9/dDJTuaQ8Zprh9VRWf1aFFjpIueOjBRrlT3oW6/y/eRl/Gt9BQXCYTqg/38vHFUU4Wo/d9dUpvfCe/a3o97t2Jgxp34oFKcsVb4S5WJrykIkw+14DzVnTpCpbQNFckqvFLuqnJCkL0EQFtunBXI03FJpPu3T1XU6id8S7ojoJQZSauGUCgmaLqUGdMrd08oo81ecoJSLs51Re9N/lISGmjWFPGpqJLoGq6uo4FHz58hmeyXCgHG742BHz2P3MiH1CXHUT2J8mF6zLhf3SR9Qb3lkrobAh",
+                    "type": "thought"
+                  },
+                  {
+                    "text": "Elara’s life was a symphony of quiet moments. A librarian, she found solace in the hushed aisles, the scent of aged paper, and the predictable rhythm of her days. Her small apartment, meticulously ordered, reflected this internal calm, save",
+                    "type": "text"
+                  },
+                  {
+                    "text": " for one beloved anomaly: a chipped porcelain teacup, inherited from her grandmother, which held her morning Earl Grey.\n\nOne Tuesday, stirring her tea, Elara paused. At the bottom, nestled against the porcelain, was a star.",
+                    "type": "text"
+                  },
+                  {
+                    "text": " Not a star-shaped tea leaf, but a miniature, perfectly formed celestial body, radiating a faint, cool luminescence. Before she could gasp, it dissolved, leaving only the amber swirl of her brew. She dismissed it as a trick of",
+                    "type": "text"
+                  },
+                  {
+                    "text": " tired eyes.\n\nBut the next morning, a gossamer-thin feather, smaller than an eyelash and shimmering with iridescent hues, floated on the surface. It vanished the moment she tried to touch it. A week later, a single,",
+                    "type": "text"
+                  },
+                  {
+                    "text": " impossibly delicate bloom, like spun moonbeam, unfolded in her cup before fading into nothingness.\n\nThese weren't illusions. Each day, Elara’s chipped teacup offered a fleeting, exquisite secret. A tiny, perfect",
+                    "type": "text"
+                  },
+                  {
+                    "text": " crystal, a miniature spiral nebula, a fragment of rainbow caught in liquid form. They never lingered, never accumulated, simply *were* and then *weren't*, leaving behind a residue of quiet wonder.\n\nElara never spoke",
+                    "type": "text"
+                  },
+                  {
+                    "text": " of it. It was her private wellspring, a daily reminder that magic could exist in the smallest, most overlooked corners of the world. Her routine remained unchanged, her external life a picture of calm, but inside, a secret garden blo",
+                    "type": "text"
+                  },
+                  {
+                    "text": "omed. Each dawn brought not just tea, but the silent promise of extraordinary beauty, waiting patiently in a chipped teacup.",
+                    "type": "text"
+                  }
+                ],
+                "role": "model",
+                "status": "completed",
+                "updated": "2025-12-09T18:45:40Z",
+                "usage": {
+                  "input_tokens_by_modality": [{ "modality": "text", "tokens": 11 }],
+                  "total_cached_tokens": 0,
+                  "total_input_tokens": 11,
+                  "total_output_tokens": 364,
+                  "total_reasoning_tokens": 1120,
+                  "total_tokens": 1495,
+                  "total_tool_use_tokens": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      "InteractionStatusUpdate": {
+        "type": "object",
+        "properties": {
+          "interaction_id": { "type": "string" },
+          "status": {
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled."
+            ],
+            "enum": ["in_progress", "requires_action", "completed", "failed", "cancelled"]
+          },
+          "event_type": { "type": "string", "const": "interaction.status_update" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "examples": {
+          "interaction_status_update": {
+            "summary": "Interaction Status Update",
+            "value": {
+              "event_type": "interaction.status_update",
+              "interaction_id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+              "status": "in_progress"
+            }
+          }
+        }
+      },
+      "ContentStart": {
+        "type": "object",
+        "properties": {
+          "index": { "type": "integer", "format": "int32" },
+          "content": { "$ref": "#/components/schemas/Content" },
+          "event_type": { "type": "string", "const": "content.start" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "examples": {
+          "content_start": {
+            "summary": "Content Start",
+            "value": { "event_type": "content.start", "content": { "type": "text" }, "index": 1 }
+          }
+        }
+      },
+      "ContentDelta": {
+        "type": "object",
+        "properties": {
+          "index": { "type": "integer", "format": "int32" },
+          "event_type": { "type": "string", "const": "content.delta" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          },
+          "delta": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/TextDelta" },
+              { "$ref": "#/components/schemas/ImageDelta" },
+              { "$ref": "#/components/schemas/AudioDelta" },
+              { "$ref": "#/components/schemas/DocumentDelta" },
+              { "$ref": "#/components/schemas/VideoDelta" },
+              { "$ref": "#/components/schemas/ThoughtSummaryDelta" },
+              { "$ref": "#/components/schemas/ThoughtSignatureDelta" },
+              { "$ref": "#/components/schemas/FunctionCallDelta" },
+              { "$ref": "#/components/schemas/FunctionResultDelta" },
+              { "$ref": "#/components/schemas/CodeExecutionCallDelta" },
+              { "$ref": "#/components/schemas/CodeExecutionResultDelta" },
+              { "$ref": "#/components/schemas/UrlContextCallDelta" },
+              { "$ref": "#/components/schemas/UrlContextResultDelta" },
+              { "$ref": "#/components/schemas/GoogleSearchCallDelta" },
+              { "$ref": "#/components/schemas/GoogleSearchResultDelta" },
+              { "$ref": "#/components/schemas/McpServerToolCallDelta" },
+              { "$ref": "#/components/schemas/McpServerToolResultDelta" },
+              { "$ref": "#/components/schemas/FileSearchResultDelta" }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "text": "#/components/schemas/TextDelta",
+                "image": "#/components/schemas/ImageDelta",
+                "audio": "#/components/schemas/AudioDelta",
+                "document": "#/components/schemas/DocumentDelta",
+                "video": "#/components/schemas/VideoDelta",
+                "thought_summary": "#/components/schemas/ThoughtSummaryDelta",
+                "thought_signature": "#/components/schemas/ThoughtSignatureDelta",
+                "function_call": "#/components/schemas/FunctionCallDelta",
+                "function_result": "#/components/schemas/FunctionResultDelta",
+                "code_execution_call": "#/components/schemas/CodeExecutionCallDelta",
+                "code_execution_result": "#/components/schemas/CodeExecutionResultDelta",
+                "url_context_call": "#/components/schemas/UrlContextCallDelta",
+                "url_context_result": "#/components/schemas/UrlContextResultDelta",
+                "google_search_call": "#/components/schemas/GoogleSearchCallDelta",
+                "google_search_result": "#/components/schemas/GoogleSearchResultDelta",
+                "mcp_server_tool_call": "#/components/schemas/McpServerToolCallDelta",
+                "mcp_server_tool_result": "#/components/schemas/McpServerToolResultDelta",
+                "file_search_result": "#/components/schemas/FileSearchResultDelta"
+              }
+            }
+          }
+        },
+        "examples": {
+          "content_delta": {
+            "summary": "Content Delta",
+            "value": {
+              "event_type": "content.delta",
+              "delta": {
+                "type": "text",
+                "text": "Elara’s life was a symphony of quiet moments. A librarian, she found solace in the hushed aisles, the scent of aged paper, and the predictable rhythm of her days. Her small apartment, meticulously ordered, reflected this internal calm, save"
+              },
+              "index": 1
+            }
+          }
+        }
+      },
+      "TextDelta": {
+        "type": "object",
+        "properties": {
+          "text": { "type": "string" },
+          "annotations": {
+            "description": "Citation information for model-generated content.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Annotation" }
+          },
+          "type": { "const": "text" }
+        },
+        "required": ["type"]
+      },
+      "ImageDelta": {
+        "type": "object",
+        "properties": {
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": { "$ref": "#/components/schemas/ImageMimeTypeOption" },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          },
+          "type": { "const": "image" }
+        },
+        "required": ["type"]
+      },
+      "AudioDelta": {
+        "type": "object",
+        "properties": {
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": { "$ref": "#/components/schemas/AudioMimeTypeOption" },
+          "type": { "const": "audio" }
+        },
+        "required": ["type"]
+      },
+      "DocumentDelta": {
+        "type": "object",
+        "properties": {
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": { "$ref": "#/components/schemas/DocumentMimeTypeOption" },
+          "type": { "const": "document" }
+        },
+        "required": ["type"]
+      },
+      "VideoDelta": {
+        "type": "object",
+        "properties": {
+          "data": { "type": "string", "format": "byte" },
+          "uri": { "type": "string" },
+          "mime_type": { "$ref": "#/components/schemas/VideoMimeTypeOption" },
+          "resolution": {
+            "description": "The resolution of the media.",
+            "$ref": "#/components/schemas/MediaResolution"
+          },
+          "type": { "const": "video" }
+        },
+        "required": ["type"]
+      },
+      "ThoughtSummaryDelta": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "thought_summary" },
+          "content": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/TextContent" },
+              { "$ref": "#/components/schemas/ImageContent" }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "text": "#/components/schemas/TextContent",
+                "image": "#/components/schemas/ImageContent"
+              }
+            }
+          }
+        },
+        "required": ["type"]
+      },
+      "ThoughtSignatureDelta": {
+        "type": "object",
+        "properties": {
+          "signature": {
+            "description": "Signature to match the backend source to be part of the generation.",
+            "type": "string",
+            "format": "byte"
+          },
+          "type": { "const": "thought_signature" }
+        },
+        "required": ["type"]
+      },
+      "FunctionCallDelta": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "arguments": {
+            "type": "object",
+            "additionalProperties": { "description": "Properties of the object." }
+          },
+          "type": { "const": "function_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["type"]
+      },
+      "CodeExecutionCallDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": { "$ref": "#/components/schemas/CodeExecutionCallArguments" },
+          "type": { "const": "code_execution_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["type"]
+      },
+      "UrlContextCallDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": { "$ref": "#/components/schemas/UrlContextCallArguments" },
+          "type": { "const": "url_context_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["type"]
+      },
+      "GoogleSearchCallDelta": {
+        "type": "object",
+        "properties": {
+          "arguments": { "$ref": "#/components/schemas/GoogleSearchCallArguments" },
+          "type": { "const": "google_search_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["type"]
+      },
+      "McpServerToolCallDelta": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "server_name": { "type": "string" },
+          "arguments": {
+            "type": "object",
+            "additionalProperties": { "description": "Properties of the object." }
+          },
+          "type": { "const": "mcp_server_tool_call" },
+          "id": { "type": "string", "description": "A unique ID for this specific tool call." }
+        },
+        "required": ["type"]
+      },
+      "FunctionResultDelta": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "is_error": { "type": "boolean" },
+          "type": { "const": "function_result" },
+          "result": {
+            "description": "Tool call result delta.",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/components/schemas/ImageContent" },
+                        { "type": "object" }
+                      ]
+                    }
+                  }
+                }
+              },
+              { "type": "string" }
+            ]
+          },
+          "call_id": { "type": "string", "description": "ID to match the ID from the function call block." }
+        },
+        "required": ["type"]
+      },
+      "CodeExecutionResultDelta": {
+        "type": "object",
+        "properties": {
+          "result": { "type": "string" },
+          "is_error": { "type": "boolean" },
+          "signature": { "type": "string" },
+          "type": { "const": "code_execution_result" },
+          "call_id": { "type": "string", "description": "ID to match the ID from the function call block." }
+        },
+        "required": ["type"]
+      },
+      "UrlContextResultDelta": {
+        "type": "object",
+        "properties": {
+          "signature": { "type": "string" },
+          "result": { "type": "array", "items": { "$ref": "#/components/schemas/UrlContextResult" } },
+          "is_error": { "type": "boolean" },
+          "type": { "const": "url_context_result" },
+          "call_id": { "type": "string", "description": "ID to match the ID from the function call block." }
+        },
+        "required": ["type"]
+      },
+      "GoogleSearchResultDelta": {
+        "type": "object",
+        "properties": {
+          "signature": { "type": "string" },
+          "result": { "type": "array", "items": { "$ref": "#/components/schemas/GoogleSearchResult" } },
+          "is_error": { "type": "boolean" },
+          "type": { "const": "google_search_result" },
+          "call_id": { "type": "string", "description": "ID to match the ID from the function call block." }
+        },
+        "required": ["type"]
+      },
+      "McpServerToolResultDelta": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "server_name": { "type": "string" },
+          "type": { "const": "mcp_server_tool_result" },
+          "result": {
+            "description": "Tool call result delta.",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/components/schemas/ImageContent" },
+                        { "type": "object" }
+                      ]
+                    }
+                  }
+                }
+              },
+              { "type": "string" }
+            ]
+          },
+          "call_id": { "type": "string", "description": "ID to match the ID from the function call block." }
+        },
+        "required": ["type"]
+      },
+      "FileSearchResultDelta": {
+        "type": "object",
+        "properties": {
+          "result": { "type": "array", "items": { "$ref": "#/components/schemas/FileSearchResult" } },
+          "type": { "const": "file_search_result" }
+        },
+        "required": ["type"]
+      },
+      "ContentStop": {
+        "type": "object",
+        "properties": {
+          "index": { "type": "integer", "format": "int32" },
+          "event_type": { "type": "string", "const": "content.stop" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "examples": {
+          "content_stop": { "summary": "Content Stop", "value": { "event_type": "content.stop", "index": 1 } }
+        }
+      },
+      "ErrorEvent": {
+        "type": "object",
+        "properties": {
+          "event_type": { "type": "string", "const": "error" },
+          "error": { "$ref": "#/components/schemas/Error" },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from\nthis event.",
+            "type": "string"
+          }
+        },
+        "examples": {
+          "error_event": {
+            "summary": "Error Event",
+            "value": {
+              "event_type": "error",
+              "error": {
+                "message": "Failed to get completed interaction: Result not found.",
+                "code": "not_found"
+              }
+            }
+          }
+        }
+      },
+      "Error": {
+        "description": "Error message from an interaction.",
+        "type": "object",
+        "properties": {
+          "code": { "description": "A URI that identifies the error type.", "type": "string" },
+          "message": { "description": "A human-readable error message.", "type": "string" }
+        }
+      },
+      "MediaResolution": {
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Low resolution.",
+          "Medium resolution.",
+          "High resolution.",
+          "Ultra high resolution."
+        ],
+        "enum": ["low", "medium", "high", "ultra_high"]
+      },
+      "ToolChoiceType": {
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Auto tool choice.",
+          "Any tool choice.",
+          "No tool choice.",
+          "Validated tool choice."
+        ],
+        "enum": ["auto", "any", "none", "validated"]
+      },
+      "ThinkingLevel": {
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Little to no thinking.",
+          "Low thinking level.",
+          "Medium thinking level.",
+          "High thinking level."
+        ],
+        "enum": ["minimal", "low", "medium", "high"]
+      },
+      "ThinkingSummaries": {
+        "type": "string",
+        "x-google-enum-descriptions": ["Auto thinking summaries.", "No thinking summaries."],
+        "enum": ["auto", "none"]
+      },
+      "ResponseModality": {
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Indicates the model should return text.",
+          "Indicates the model should return images.",
+          "Indicates the model should return audio."
+        ],
+        "enum": ["text", "image", "audio"]
+      },
+      "Interaction": {
+        "description": "The Interaction resource.",
+        "properties": {
+          "model": {
+            "$ref": "#/components/schemas/ModelOption",
+            "description": "The name of the `Model` used for generating the interaction."
+          },
+          "agent": {
+            "$ref": "#/components/schemas/AgentOption",
+            "description": "The name of the `Agent` used for generating the interaction."
+          },
+          "id": {
+            "description": "Output only. A unique identifier for the interaction completion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Output only. The status of the interaction.",
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled."
+            ],
+            "enum": ["in_progress", "requires_action", "completed", "failed", "cancelled"]
+          },
+          "created": {
+            "description": "Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated": {
+            "description": "Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "role": {
+            "description": "Output only. The role of the interaction.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "outputs": {
+            "description": "Output only. Responses from the model.",
+            "readOnly": true,
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Content" }
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string",
+            "writeOnly": true
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Tool" },
+            "writeOnly": true
+          },
+          "background": {
+            "description": "Whether to run the model interaction in the background.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "object": {
+            "description": "Output only. The object type of the interaction. Always set to `interaction`.",
+            "readOnly": true,
+            "type": "string",
+            "const": "interaction",
+            "x-stainless-naming": {
+              "java": {
+                "type_name": "object_type",
+                "method_argument": "object_type",
+                "argument_name": "object_type",
+                "property_name": "object_type"
+              }
+            }
+          },
+          "usage": {
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/Usage"
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ResponseModality" },
+            "writeOnly": true
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with\nthe JSON schema specified in this field.",
+            "writeOnly": true
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string",
+            "writeOnly": true
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "input": {
+            "description": "The inputs for the interaction.",
+            "oneOf": [
+              { "type": "string" },
+              {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/Content" },
+                "title": "ContentList"
+              },
+              { "type": "array", "items": { "$ref": "#/components/schemas/Turn" }, "title": "TurnsList" },
+              { "$ref": "#/components/schemas/Content" }
+            ],
+            "writeOnly": true
+          },
+          "generation_config": {
+            "description": "Input only. Configuration parameters for the model interaction.",
+            "writeOnly": true,
+            "$ref": "#/components/schemas/GenerationConfig"
+          },
+          "agent_config": {
+            "description": "Configuration for the agent.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/DynamicAgentConfig" },
+              { "$ref": "#/components/schemas/DeepResearchAgentConfig" }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "dynamic": "#/components/schemas/DynamicAgentConfig",
+                "deep_research": "#/components/schemas/DeepResearchAgentConfig"
+              }
+            },
+            "writeOnly": true
+          }
+        },
+        "required": ["id", "status"],
+        "example": {
+          "created": "2025-12-04T15:01:45Z",
+          "id": "v1_ChdXS0l4YWZXTk9xbk0xZThQczhEcmlROBIXV0tJeGFmV05PcW5NMWU4UHM4RHJpUTg",
+          "model": "gemini-2.5-flash",
+          "object": "interaction",
+          "outputs": [
+            {
+              "text": "Hello! I'm doing well, functioning as expected. Thank you for asking! How are you doing today?",
+              "type": "text"
+            }
+          ],
+          "role": "model",
+          "status": "completed",
+          "updated": "2025-12-04T15:01:45Z",
+          "usage": {
+            "input_tokens_by_modality": [{ "modality": "text", "tokens": 7 }],
+            "total_cached_tokens": 0,
+            "total_input_tokens": 7,
+            "total_output_tokens": 23,
+            "total_reasoning_tokens": 49,
+            "total_tokens": 79,
+            "total_tool_use_tokens": 0
+          }
+        }
+      },
+      "CreateModelInteractionParams": {
+        "description": "Parameters for creating model interactions",
+        "properties": {
+          "model": {
+            "$ref": "#/components/schemas/ModelOption",
+            "description": "The name of the `Model` used for generating the interaction."
+          },
+          "stream": {
+            "description": "Input only. Whether the interaction will be streamed.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "store": {
+            "description": "Input only. Whether to store the response and request for later retrieval.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Output only. A unique identifier for the interaction completion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Output only. The status of the interaction.",
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Default value. This value is unused.",
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled."
+            ],
+            "enum": ["UNSPECIFIED", "IN_PROGRESS", "REQUIRES_ACTION", "COMPLETED", "FAILED", "CANCELLED"]
+          },
+          "created": {
+            "description": "Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated": {
+            "description": "Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "role": {
+            "description": "Output only. The role of the interaction.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "outputs": {
+            "description": "Output only. Responses from the model.",
+            "readOnly": true,
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Content" }
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string",
+            "writeOnly": true
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Tool" },
+            "writeOnly": true
+          },
+          "background": {
+            "description": "Whether to run the model interaction in the background.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "usage": {
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/Usage"
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ResponseModality" },
+            "writeOnly": true
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with\nthe JSON schema specified in this field.",
+            "writeOnly": true
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string",
+            "writeOnly": true
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "input": {
+            "description": "The inputs for the interaction.",
+            "oneOf": [
+              { "type": "string" },
+              {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/Content" },
+                "title": "ContentList"
+              },
+              { "type": "array", "items": { "$ref": "#/components/schemas/Turn" }, "title": "TurnsList" },
+              { "$ref": "#/components/schemas/Content" }
+            ],
+            "writeOnly": true
+          },
+          "generation_config": {
+            "description": "Input only. Configuration parameters for the model interaction.",
+            "writeOnly": true,
+            "$ref": "#/components/schemas/GenerationConfig"
+          }
+        },
+        "required": ["model", "input"]
+      },
+      "CreateAgentInteractionParams": {
+        "description": "Parameters for creating agent interactions",
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/AgentOption",
+            "description": "The name of the `Agent` used for generating the interaction."
+          },
+          "stream": {
+            "description": "Input only. Whether the interaction will be streamed.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "store": {
+            "description": "Input only. Whether to store the response and request for later retrieval.",
+            "writeOnly": true,
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Output only. A unique identifier for the interaction completion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Output only. The status of the interaction.",
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Default value. This value is unused.",
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled."
+            ],
+            "enum": ["UNSPECIFIED", "IN_PROGRESS", "REQUIRES_ACTION", "COMPLETED", "FAILED", "CANCELLED"]
+          },
+          "created": {
+            "description": "Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated": {
+            "description": "Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "role": {
+            "description": "Output only. The role of the interaction.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "outputs": {
+            "description": "Output only. Responses from the model.",
+            "readOnly": true,
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Content" }
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string",
+            "writeOnly": true
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Tool" },
+            "writeOnly": true
+          },
+          "background": {
+            "description": "Whether to run the model interaction in the background.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "usage": {
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "readOnly": true,
+            "$ref": "#/components/schemas/Usage"
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ResponseModality" },
+            "writeOnly": true
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with\nthe JSON schema specified in this field.",
+            "writeOnly": true
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string",
+            "writeOnly": true
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "input": {
+            "description": "The inputs for the interaction.",
+            "oneOf": [
+              { "type": "string" },
+              {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/Content" },
+                "title": "ContentList"
+              },
+              { "type": "array", "items": { "$ref": "#/components/schemas/Turn" }, "title": "TurnsList" },
+              { "$ref": "#/components/schemas/Content" }
+            ],
+            "writeOnly": true
+          },
+          "agent_config": {
+            "description": "Configuration for the agent.",
+            "oneOf": [
+              { "$ref": "#/components/schemas/DynamicAgentConfig" },
+              { "$ref": "#/components/schemas/DeepResearchAgentConfig" }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "dynamic": "#/components/schemas/DynamicAgentConfig",
+                "deep_research": "#/components/schemas/DeepResearchAgentConfig"
+              }
+            },
+            "writeOnly": true
+          }
+        },
+        "required": ["agent", "input"]
+      },
+      "InteractionSseEvent": {
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/InteractionEvent" },
+          { "$ref": "#/components/schemas/InteractionStatusUpdate" },
+          { "$ref": "#/components/schemas/ContentStart" },
+          { "$ref": "#/components/schemas/ContentDelta" },
+          { "$ref": "#/components/schemas/ContentStop" },
+          { "$ref": "#/components/schemas/ErrorEvent" }
+        ],
+        "discriminator": {
+          "propertyName": "event_type",
+          "mapping": {
+            "interaction.start": "#/components/schemas/InteractionEvent",
+            "interaction.status_update": "#/components/schemas/InteractionStatusUpdate",
+            "interaction.complete": "#/components/schemas/InteractionEvent",
+            "content.start": "#/components/schemas/ContentStart",
+            "content.delta": "#/components/schemas/ContentDelta",
+            "content.stop": "#/components/schemas/ContentStop",
+            "error": "#/components/schemas/ErrorEvent"
+          }
+        }
+      },
+      "ToolChoiceConfig": {
+        "type": "object",
+        "properties": { "allowed_tools": { "$ref": "#/components/schemas/AllowedTools" } }
+      },
+      "Tool": {
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/components/schemas/Function" },
+          { "$ref": "#/components/schemas/GoogleSearch" },
+          { "$ref": "#/components/schemas/CodeExecution" },
+          { "$ref": "#/components/schemas/UrlContext" },
+          { "$ref": "#/components/schemas/ComputerUse" },
+          { "$ref": "#/components/schemas/McpServer" },
+          { "$ref": "#/components/schemas/FileSearch" }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "function": "#/components/schemas/Function",
+            "google_search": "#/components/schemas/GoogleSearch",
+            "code_execution": "#/components/schemas/CodeExecution",
+            "url_context": "#/components/schemas/UrlContext",
+            "computer_use": "#/components/schemas/ComputerUse",
+            "mcp_server": "#/components/schemas/McpServer",
+            "file_search": "#/components/schemas/FileSearch"
+          }
+        }
+      },
+      "ModelOption": {
+        "title": "Model",
+        "description": "The model that will complete your prompt.\\n\\nSee [models](https://ai.google.dev/gemini-api/docs/models) for additional details.",
+        "anyOf": [
+          { "type": "string" },
+          {
+            "description": "Our state-of-the-art multipurpose model, which excels at coding and complex reasoning tasks.",
+            "const": "gemini-2.5-pro",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our first hybrid reasoning model which supports a 1M token context window and has thinking budgets.",
+            "const": "gemini-2.5-flash",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "The latest model based on the 2.5 Flash model. 2.5 Flash Preview is best for large scale processing, low-latency, high volume tasks that require thinking, and agentic use cases.",
+            "const": "gemini-2.5-flash-preview-09-2025",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our smallest and most cost effective model, built for at scale usage.",
+            "const": "gemini-2.5-flash-lite",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "The latest model based on Gemini 2.5 Flash lite optimized for cost-efficiency, high throughput and high quality.",
+            "const": "gemini-2.5-flash-lite-preview-09-2025",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our native audio models optimized for higher quality audio outputs with better pacing, voice naturalness, verbosity, and mood.",
+            "const": "gemini-2.5-flash-preview-native-audio-dialog",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our native image generation model, optimized for speed, flexibility, and contextual understanding. Text input and output is priced the same as 2.5 Flash.",
+            "const": "gemini-2.5-flash-image-preview",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our 2.5 Pro text-to-speech audio model optimized for powerful, low-latency speech generation for more natural outputs and easier to steer prompts.",
+            "const": "gemini-2.5-pro-preview-tts",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our most intelligent model with SOTA reasoning and multimodal understanding, and powerful agentic and vibe coding capabilities.",
+            "const": "gemini-3-pro-preview",
+            "x-stainless-nominal": false
+          },
+          {
+            "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+            "const": "gemini-3-flash-preview",
+            "x-stainless-nominal": false
+          }
+        ]
+      },
+      "AgentOption": {
+        "title": "Agent",
+        "description": "The agent to interact with.",
+        "anyOf": [
+          { "type": "string" },
+          {
+            "description": "Gemini Deep Research Agent",
+            "const": "deep-research-pro-preview-12-2025",
+            "x-stainless-nominal": false
+          }
+        ]
+      },
+      "ImageMimeTypeOption": {
+        "title": "ImageMimeType",
+        "description": "The mime type of the image.",
+        "anyOf": [
+          { "type": "string" },
+          { "const": "image/png", "x-stainless-nominal": false },
+          { "const": "image/jpeg", "x-stainless-nominal": false },
+          { "const": "image/webp", "x-stainless-nominal": false },
+          { "const": "image/heic", "x-stainless-nominal": false },
+          { "const": "image/heif", "x-stainless-nominal": false }
+        ]
+      },
+      "AudioMimeTypeOption": {
+        "title": "AudioMimeType",
+        "description": "The mime type of the audio.",
+        "anyOf": [
+          { "type": "string" },
+          { "const": "audio/wav", "x-stainless-nominal": false },
+          { "const": "audio/mp3", "x-stainless-nominal": false },
+          { "const": "audio/aiff", "x-stainless-nominal": false },
+          { "const": "audio/aac", "x-stainless-nominal": false },
+          { "const": "audio/ogg", "x-stainless-nominal": false },
+          { "const": "audio/flac", "x-stainless-nominal": false }
+        ]
+      },
+      "VideoMimeTypeOption": {
+        "title": "VideoMimeType",
+        "description": "The mime type of the video.",
+        "anyOf": [
+          { "type": "string" },
+          { "const": "video/mp4", "x-stainless-nominal": false },
+          { "const": "video/mpeg", "x-stainless-nominal": false },
+          { "const": "video/mov", "x-stainless-nominal": false },
+          { "const": "video/avi", "x-stainless-nominal": false },
+          { "const": "video/x-flv", "x-stainless-nominal": false },
+          { "const": "video/mpg", "x-stainless-nominal": false },
+          { "const": "video/webm", "x-stainless-nominal": false },
+          { "const": "video/wmv", "x-stainless-nominal": false },
+          { "const": "video/3gpp", "x-stainless-nominal": false }
+        ]
+      },
+      "DocumentMimeTypeOption": {
+        "title": "DocumentMimeType",
+        "description": "The mime type of the document.",
+        "anyOf": [{ "type": "string" }, { "const": "application/pdf", "x-stainless-nominal": false }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Enhance the openapi-updater skill with multi-spec support and validation tooling:

- Add `specs.json` registry for managing multiple OpenAPI specs (main + interactions)
- Update `fetch_spec.py` with multi-spec fetching and auto-discovery
- Add `REVIEW_CHECKLIST.md` for implementation review process
- Add `verify_exports.py` and `verify_readme.py` validation scripts
- Persist `openapi-interactions.json` for change detection
- Update `SKILL.md` with comprehensive workflow documentation

## Spec Registry

| Spec | Description | Auth Required |
|------|-------------|---------------|
| `main` | Core Gemini API (generation, embeddings, files, models) | Yes |
| `interactions` | Experimental Interactions API (server-side state, agents) | No |

## Workflow

```bash
# Fetch all specs + auto-discover new ones
python3 .claude/skills/openapi-updater/scripts/fetch_spec.py

# Fetch specific spec only
python3 .claude/skills/openapi-updater/scripts/fetch_spec.py --spec main
python3 .claude/skills/openapi-updater/scripts/fetch_spec.py --spec interactions
```

## Test plan

- [x] `dart analyze --fatal-infos` passes
- [x] `dart format --set-exit-if-changed .` passes
- [x] `dart test test/unit/` passes
- [x] Fetch script successfully fetches both specs
- [x] Auto-discovery works (probes for new specs on each fetch)