### PR TITLE
feat(mistralai_dart): Align embeddings API with latest Mistral spec

### DIFF
--- a/packages/langchain_mistralai/lib/src/embeddings/mistralai_embeddings.dart
+++ b/packages/langchain_mistralai/lib/src/embeddings/mistralai_embeddings.dart
@@ -91,6 +91,7 @@ class MistralAIEmbeddings extends Embeddings {
     final Map<String, dynamic>? queryParams,
     final http.Client? client,
     this.model = 'mistral-embed',
+    this.dimensions,
     this.batchSize = 512,
   }) : _client = MistralAIClient(
          apiKey: apiKey,
@@ -105,6 +106,10 @@ class MistralAIEmbeddings extends Embeddings {
 
   /// The embeddings model to use.
   final String model;
+
+  /// The number of dimensions for output embeddings.
+  /// Only supported by certain models (e.g., codestral-embed-2505).
+  final int? dimensions;
 
   /// The maximum number of documents to embed in a single request.
   int batchSize;
@@ -123,6 +128,7 @@ class MistralAIEmbeddings extends Embeddings {
             input: batch
                 .map((final doc) => doc.pageContent)
                 .toList(growable: false),
+            outputDimension: dimensions,
           ),
         );
         return data.data.map((final d) => d.embedding);
@@ -138,6 +144,7 @@ class MistralAIEmbeddings extends Embeddings {
       request: EmbeddingRequest(
         model: EmbeddingModel.modelId(model),
         input: [query],
+        outputDimension: dimensions,
       ),
     );
     return data.data.firstOrNull?.embedding ?? [];

--- a/packages/mistralai_dart/lib/src/generated/schema/embedding_request.dart
+++ b/packages/mistralai_dart/lib/src/generated/schema/embedding_request.dart
@@ -21,10 +21,26 @@ abstract class EmbeddingRequest with _$EmbeddingRequest {
     /// The list of strings to embed.
     required List<String> input,
 
+    /// The number of dimensions the resulting output embeddings should have.
+    /// Only supported by certain models (e.g., codestral-embed-2505).
+    @JsonKey(name: 'output_dimension', includeIfNull: false)
+    int? outputDimension,
+
+    /// The data type of the output embeddings.
+    @JsonKey(
+      name: 'output_dtype',
+      includeIfNull: false,
+      unknownEnumValue: JsonKey.nullForUndefinedEnumValue,
+    )
+    EmbeddingOutputDtype? outputDtype,
+
     /// The format of the output data.
-    @JsonKey(name: 'encoding_format')
-    @Default(EmbeddingEncodingFormat.float)
-    EmbeddingEncodingFormat encodingFormat,
+    @JsonKey(
+      name: 'encoding_format',
+      includeIfNull: false,
+      unknownEnumValue: JsonKey.nullForUndefinedEnumValue,
+    )
+    EmbeddingEncodingFormat? encodingFormat,
   }) = _EmbeddingRequest;
 
   /// Object construction from a JSON representation
@@ -35,6 +51,8 @@ abstract class EmbeddingRequest with _$EmbeddingRequest {
   static const List<String> propertyNames = [
     'model',
     'input',
+    'output_dimension',
+    'output_dtype',
     'encoding_format',
   ];
 
@@ -45,7 +63,13 @@ abstract class EmbeddingRequest with _$EmbeddingRequest {
 
   /// Map representation of object (not serialized)
   Map<String, dynamic> toMap() {
-    return {'model': model, 'input': input, 'encoding_format': encodingFormat};
+    return {
+      'model': model,
+      'input': input,
+      'output_dimension': outputDimension,
+      'output_dtype': outputDtype,
+      'encoding_format': encodingFormat,
+    };
   }
 }
 
@@ -57,6 +81,8 @@ abstract class EmbeddingRequest with _$EmbeddingRequest {
 enum EmbeddingModels {
   @JsonValue('mistral-embed')
   mistralEmbed,
+  @JsonValue('codestral-embed-2505')
+  codestralEmbed2505,
 }
 
 // ==========================================
@@ -110,6 +136,24 @@ class _EmbeddingModelConverter
 }
 
 // ==========================================
+// ENUM: EmbeddingOutputDtype
+// ==========================================
+
+/// The data type of the output embeddings.
+enum EmbeddingOutputDtype {
+  @JsonValue('float')
+  float,
+  @JsonValue('int8')
+  int8,
+  @JsonValue('uint8')
+  uint8,
+  @JsonValue('binary')
+  binary,
+  @JsonValue('ubinary')
+  ubinary,
+}
+
+// ==========================================
 // ENUM: EmbeddingEncodingFormat
 // ==========================================
 
@@ -117,4 +161,6 @@ class _EmbeddingModelConverter
 enum EmbeddingEncodingFormat {
   @JsonValue('float')
   float,
+  @JsonValue('base64')
+  base64,
 }

--- a/packages/mistralai_dart/lib/src/generated/schema/embedding_response.dart
+++ b/packages/mistralai_dart/lib/src/generated/schema/embedding_response.dart
@@ -27,6 +27,9 @@ abstract class EmbeddingResponse with _$EmbeddingResponse {
     /// The model used for this embedding.
     required String model,
 
+    /// Unix timestamp when the response was created.
+    @JsonKey(includeIfNull: false) int? created,
+
     /// The usage statistics for this embedding.
     required EmbeddingUsage usage,
   }) = _EmbeddingResponse;
@@ -41,6 +44,7 @@ abstract class EmbeddingResponse with _$EmbeddingResponse {
     'object',
     'data',
     'model',
+    'created',
     'usage',
   ];
 
@@ -56,6 +60,7 @@ abstract class EmbeddingResponse with _$EmbeddingResponse {
       'object': object,
       'data': data,
       'model': model,
+      'created': created,
       'usage': usage,
     };
   }
@@ -75,8 +80,15 @@ abstract class EmbeddingUsage with _$EmbeddingUsage {
     /// The number of tokens in the prompt.
     @JsonKey(name: 'prompt_tokens') required int promptTokens,
 
-    /// The total number of tokens generated.
+    /// The number of completion tokens (typically 0 for embeddings).
+    @JsonKey(name: 'completion_tokens') required int completionTokens,
+
+    /// The total number of tokens.
     @JsonKey(name: 'total_tokens') required int totalTokens,
+
+    /// Duration of audio input in seconds (if applicable).
+    @JsonKey(name: 'prompt_audio_seconds', includeIfNull: false)
+    int? promptAudioSeconds,
   }) = _EmbeddingUsage;
 
   /// Object construction from a JSON representation
@@ -84,7 +96,12 @@ abstract class EmbeddingUsage with _$EmbeddingUsage {
       _$EmbeddingUsageFromJson(json);
 
   /// List of all property names of schema
-  static const List<String> propertyNames = ['prompt_tokens', 'total_tokens'];
+  static const List<String> propertyNames = [
+    'prompt_tokens',
+    'completion_tokens',
+    'total_tokens',
+    'prompt_audio_seconds',
+  ];
 
   /// Perform validations on the schema property values
   String? validateSchema() {
@@ -93,6 +110,11 @@ abstract class EmbeddingUsage with _$EmbeddingUsage {
 
   /// Map representation of object (not serialized)
   Map<String, dynamic> toMap() {
-    return {'prompt_tokens': promptTokens, 'total_tokens': totalTokens};
+    return {
+      'prompt_tokens': promptTokens,
+      'completion_tokens': completionTokens,
+      'total_tokens': totalTokens,
+      'prompt_audio_seconds': promptAudioSeconds,
+    };
   }
 }

--- a/packages/mistralai_dart/lib/src/generated/schema/schema.freezed.dart
+++ b/packages/mistralai_dart/lib/src/generated/schema/schema.freezed.dart
@@ -2729,8 +2729,11 @@ mixin _$EmbeddingRequest {
 
 /// ID of the model to use. You can use the [List Available Models](https://docs.mistral.ai/api#operation/listModels) API to see all of your available models, or see our [Model overview](https://docs.mistral.ai/models) for model descriptions.
 @_EmbeddingModelConverter() EmbeddingModel get model;/// The list of strings to embed.
- List<String> get input;/// The format of the output data.
-@JsonKey(name: 'encoding_format') EmbeddingEncodingFormat get encodingFormat;
+ List<String> get input;/// The number of dimensions the resulting output embeddings should have.
+/// Only supported by certain models (e.g., codestral-embed-2505).
+@JsonKey(name: 'output_dimension', includeIfNull: false) int? get outputDimension;/// The data type of the output embeddings.
+@JsonKey(name: 'output_dtype', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) EmbeddingOutputDtype? get outputDtype;/// The format of the output data.
+@JsonKey(name: 'encoding_format', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) EmbeddingEncodingFormat? get encodingFormat;
 /// Create a copy of EmbeddingRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2743,16 +2746,16 @@ $EmbeddingRequestCopyWith<EmbeddingRequest> get copyWith => _$EmbeddingRequestCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingRequest&&(identical(other.model, model) || other.model == model)&&const DeepCollectionEquality().equals(other.input, input)&&(identical(other.encodingFormat, encodingFormat) || other.encodingFormat == encodingFormat));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingRequest&&(identical(other.model, model) || other.model == model)&&const DeepCollectionEquality().equals(other.input, input)&&(identical(other.outputDimension, outputDimension) || other.outputDimension == outputDimension)&&(identical(other.outputDtype, outputDtype) || other.outputDtype == outputDtype)&&(identical(other.encodingFormat, encodingFormat) || other.encodingFormat == encodingFormat));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,model,const DeepCollectionEquality().hash(input),encodingFormat);
+int get hashCode => Object.hash(runtimeType,model,const DeepCollectionEquality().hash(input),outputDimension,outputDtype,encodingFormat);
 
 @override
 String toString() {
-  return 'EmbeddingRequest(model: $model, input: $input, encodingFormat: $encodingFormat)';
+  return 'EmbeddingRequest(model: $model, input: $input, outputDimension: $outputDimension, outputDtype: $outputDtype, encodingFormat: $encodingFormat)';
 }
 
 
@@ -2763,7 +2766,7 @@ abstract mixin class $EmbeddingRequestCopyWith<$Res>  {
   factory $EmbeddingRequestCopyWith(EmbeddingRequest value, $Res Function(EmbeddingRequest) _then) = _$EmbeddingRequestCopyWithImpl;
 @useResult
 $Res call({
-@_EmbeddingModelConverter() EmbeddingModel model, List<String> input,@JsonKey(name: 'encoding_format') EmbeddingEncodingFormat encodingFormat
+@_EmbeddingModelConverter() EmbeddingModel model, List<String> input,@JsonKey(name: 'output_dimension', includeIfNull: false) int? outputDimension,@JsonKey(name: 'output_dtype', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) EmbeddingOutputDtype? outputDtype,@JsonKey(name: 'encoding_format', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) EmbeddingEncodingFormat? encodingFormat
 });
 
 
@@ -2780,12 +2783,14 @@ class _$EmbeddingRequestCopyWithImpl<$Res>
 
 /// Create a copy of EmbeddingRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? model = null,Object? input = null,Object? encodingFormat = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? model = null,Object? input = null,Object? outputDimension = freezed,Object? outputDtype = freezed,Object? encodingFormat = freezed,}) {
   return _then(_self.copyWith(
 model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as EmbeddingModel,input: null == input ? _self.input : input // ignore: cast_nullable_to_non_nullable
-as List<String>,encodingFormat: null == encodingFormat ? _self.encodingFormat : encodingFormat // ignore: cast_nullable_to_non_nullable
-as EmbeddingEncodingFormat,
+as List<String>,outputDimension: freezed == outputDimension ? _self.outputDimension : outputDimension // ignore: cast_nullable_to_non_nullable
+as int?,outputDtype: freezed == outputDtype ? _self.outputDtype : outputDtype // ignore: cast_nullable_to_non_nullable
+as EmbeddingOutputDtype?,encodingFormat: freezed == encodingFormat ? _self.encodingFormat : encodingFormat // ignore: cast_nullable_to_non_nullable
+as EmbeddingEncodingFormat?,
   ));
 }
 /// Create a copy of EmbeddingRequest
@@ -2879,10 +2884,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@_EmbeddingModelConverter()  EmbeddingModel model,  List<String> input, @JsonKey(name: 'encoding_format')  EmbeddingEncodingFormat encodingFormat)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@_EmbeddingModelConverter()  EmbeddingModel model,  List<String> input, @JsonKey(name: 'output_dimension', includeIfNull: false)  int? outputDimension, @JsonKey(name: 'output_dtype', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue)  EmbeddingOutputDtype? outputDtype, @JsonKey(name: 'encoding_format', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue)  EmbeddingEncodingFormat? encodingFormat)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EmbeddingRequest() when $default != null:
-return $default(_that.model,_that.input,_that.encodingFormat);case _:
+return $default(_that.model,_that.input,_that.outputDimension,_that.outputDtype,_that.encodingFormat);case _:
   return orElse();
 
 }
@@ -2900,10 +2905,10 @@ return $default(_that.model,_that.input,_that.encodingFormat);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@_EmbeddingModelConverter()  EmbeddingModel model,  List<String> input, @JsonKey(name: 'encoding_format')  EmbeddingEncodingFormat encodingFormat)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@_EmbeddingModelConverter()  EmbeddingModel model,  List<String> input, @JsonKey(name: 'output_dimension', includeIfNull: false)  int? outputDimension, @JsonKey(name: 'output_dtype', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue)  EmbeddingOutputDtype? outputDtype, @JsonKey(name: 'encoding_format', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue)  EmbeddingEncodingFormat? encodingFormat)  $default,) {final _that = this;
 switch (_that) {
 case _EmbeddingRequest():
-return $default(_that.model,_that.input,_that.encodingFormat);case _:
+return $default(_that.model,_that.input,_that.outputDimension,_that.outputDtype,_that.encodingFormat);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -2920,10 +2925,10 @@ return $default(_that.model,_that.input,_that.encodingFormat);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@_EmbeddingModelConverter()  EmbeddingModel model,  List<String> input, @JsonKey(name: 'encoding_format')  EmbeddingEncodingFormat encodingFormat)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@_EmbeddingModelConverter()  EmbeddingModel model,  List<String> input, @JsonKey(name: 'output_dimension', includeIfNull: false)  int? outputDimension, @JsonKey(name: 'output_dtype', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue)  EmbeddingOutputDtype? outputDtype, @JsonKey(name: 'encoding_format', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue)  EmbeddingEncodingFormat? encodingFormat)?  $default,) {final _that = this;
 switch (_that) {
 case _EmbeddingRequest() when $default != null:
-return $default(_that.model,_that.input,_that.encodingFormat);case _:
+return $default(_that.model,_that.input,_that.outputDimension,_that.outputDtype,_that.encodingFormat);case _:
   return null;
 
 }
@@ -2935,7 +2940,7 @@ return $default(_that.model,_that.input,_that.encodingFormat);case _:
 @JsonSerializable()
 
 class _EmbeddingRequest extends EmbeddingRequest {
-  const _EmbeddingRequest({@_EmbeddingModelConverter() required this.model, required final  List<String> input, @JsonKey(name: 'encoding_format') this.encodingFormat = EmbeddingEncodingFormat.float}): _input = input,super._();
+  const _EmbeddingRequest({@_EmbeddingModelConverter() required this.model, required final  List<String> input, @JsonKey(name: 'output_dimension', includeIfNull: false) this.outputDimension, @JsonKey(name: 'output_dtype', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) this.outputDtype, @JsonKey(name: 'encoding_format', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) this.encodingFormat}): _input = input,super._();
   factory _EmbeddingRequest.fromJson(Map<String, dynamic> json) => _$EmbeddingRequestFromJson(json);
 
 /// ID of the model to use. You can use the [List Available Models](https://docs.mistral.ai/api#operation/listModels) API to see all of your available models, or see our [Model overview](https://docs.mistral.ai/models) for model descriptions.
@@ -2949,8 +2954,13 @@ class _EmbeddingRequest extends EmbeddingRequest {
   return EqualUnmodifiableListView(_input);
 }
 
+/// The number of dimensions the resulting output embeddings should have.
+/// Only supported by certain models (e.g., codestral-embed-2505).
+@override@JsonKey(name: 'output_dimension', includeIfNull: false) final  int? outputDimension;
+/// The data type of the output embeddings.
+@override@JsonKey(name: 'output_dtype', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) final  EmbeddingOutputDtype? outputDtype;
 /// The format of the output data.
-@override@JsonKey(name: 'encoding_format') final  EmbeddingEncodingFormat encodingFormat;
+@override@JsonKey(name: 'encoding_format', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) final  EmbeddingEncodingFormat? encodingFormat;
 
 /// Create a copy of EmbeddingRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -2965,16 +2975,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbeddingRequest&&(identical(other.model, model) || other.model == model)&&const DeepCollectionEquality().equals(other._input, _input)&&(identical(other.encodingFormat, encodingFormat) || other.encodingFormat == encodingFormat));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbeddingRequest&&(identical(other.model, model) || other.model == model)&&const DeepCollectionEquality().equals(other._input, _input)&&(identical(other.outputDimension, outputDimension) || other.outputDimension == outputDimension)&&(identical(other.outputDtype, outputDtype) || other.outputDtype == outputDtype)&&(identical(other.encodingFormat, encodingFormat) || other.encodingFormat == encodingFormat));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,model,const DeepCollectionEquality().hash(_input),encodingFormat);
+int get hashCode => Object.hash(runtimeType,model,const DeepCollectionEquality().hash(_input),outputDimension,outputDtype,encodingFormat);
 
 @override
 String toString() {
-  return 'EmbeddingRequest(model: $model, input: $input, encodingFormat: $encodingFormat)';
+  return 'EmbeddingRequest(model: $model, input: $input, outputDimension: $outputDimension, outputDtype: $outputDtype, encodingFormat: $encodingFormat)';
 }
 
 
@@ -2985,7 +2995,7 @@ abstract mixin class _$EmbeddingRequestCopyWith<$Res> implements $EmbeddingReque
   factory _$EmbeddingRequestCopyWith(_EmbeddingRequest value, $Res Function(_EmbeddingRequest) _then) = __$EmbeddingRequestCopyWithImpl;
 @override @useResult
 $Res call({
-@_EmbeddingModelConverter() EmbeddingModel model, List<String> input,@JsonKey(name: 'encoding_format') EmbeddingEncodingFormat encodingFormat
+@_EmbeddingModelConverter() EmbeddingModel model, List<String> input,@JsonKey(name: 'output_dimension', includeIfNull: false) int? outputDimension,@JsonKey(name: 'output_dtype', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) EmbeddingOutputDtype? outputDtype,@JsonKey(name: 'encoding_format', includeIfNull: false, unknownEnumValue: JsonKey.nullForUndefinedEnumValue) EmbeddingEncodingFormat? encodingFormat
 });
 
 
@@ -3002,12 +3012,14 @@ class __$EmbeddingRequestCopyWithImpl<$Res>
 
 /// Create a copy of EmbeddingRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? model = null,Object? input = null,Object? encodingFormat = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? model = null,Object? input = null,Object? outputDimension = freezed,Object? outputDtype = freezed,Object? encodingFormat = freezed,}) {
   return _then(_EmbeddingRequest(
 model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as EmbeddingModel,input: null == input ? _self._input : input // ignore: cast_nullable_to_non_nullable
-as List<String>,encodingFormat: null == encodingFormat ? _self.encodingFormat : encodingFormat // ignore: cast_nullable_to_non_nullable
-as EmbeddingEncodingFormat,
+as List<String>,outputDimension: freezed == outputDimension ? _self.outputDimension : outputDimension // ignore: cast_nullable_to_non_nullable
+as int?,outputDtype: freezed == outputDtype ? _self.outputDtype : outputDtype // ignore: cast_nullable_to_non_nullable
+as EmbeddingOutputDtype?,encodingFormat: freezed == encodingFormat ? _self.encodingFormat : encodingFormat // ignore: cast_nullable_to_non_nullable
+as EmbeddingEncodingFormat?,
   ));
 }
 
@@ -3363,7 +3375,8 @@ mixin _$EmbeddingResponse {
  String get id;/// The object type, which is always `list`.
  String get object;/// The list of embeddings.
  List<Embedding> get data;/// The model used for this embedding.
- String get model;/// The usage statistics for this embedding.
+ String get model;/// Unix timestamp when the response was created.
+@JsonKey(includeIfNull: false) int? get created;/// The usage statistics for this embedding.
  EmbeddingUsage get usage;
 /// Create a copy of EmbeddingResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -3377,16 +3390,16 @@ $EmbeddingResponseCopyWith<EmbeddingResponse> get copyWith => _$EmbeddingRespons
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.object, object) || other.object == object)&&const DeepCollectionEquality().equals(other.data, data)&&(identical(other.model, model) || other.model == model)&&(identical(other.usage, usage) || other.usage == usage));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.object, object) || other.object == object)&&const DeepCollectionEquality().equals(other.data, data)&&(identical(other.model, model) || other.model == model)&&(identical(other.created, created) || other.created == created)&&(identical(other.usage, usage) || other.usage == usage));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,object,const DeepCollectionEquality().hash(data),model,usage);
+int get hashCode => Object.hash(runtimeType,id,object,const DeepCollectionEquality().hash(data),model,created,usage);
 
 @override
 String toString() {
-  return 'EmbeddingResponse(id: $id, object: $object, data: $data, model: $model, usage: $usage)';
+  return 'EmbeddingResponse(id: $id, object: $object, data: $data, model: $model, created: $created, usage: $usage)';
 }
 
 
@@ -3397,7 +3410,7 @@ abstract mixin class $EmbeddingResponseCopyWith<$Res>  {
   factory $EmbeddingResponseCopyWith(EmbeddingResponse value, $Res Function(EmbeddingResponse) _then) = _$EmbeddingResponseCopyWithImpl;
 @useResult
 $Res call({
- String id, String object, List<Embedding> data, String model, EmbeddingUsage usage
+ String id, String object, List<Embedding> data, String model,@JsonKey(includeIfNull: false) int? created, EmbeddingUsage usage
 });
 
 
@@ -3414,13 +3427,14 @@ class _$EmbeddingResponseCopyWithImpl<$Res>
 
 /// Create a copy of EmbeddingResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? object = null,Object? data = null,Object? model = null,Object? usage = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? object = null,Object? data = null,Object? model = null,Object? created = freezed,Object? usage = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,object: null == object ? _self.object : object // ignore: cast_nullable_to_non_nullable
 as String,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
 as List<Embedding>,model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
-as String,usage: null == usage ? _self.usage : usage // ignore: cast_nullable_to_non_nullable
+as String,created: freezed == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
+as int?,usage: null == usage ? _self.usage : usage // ignore: cast_nullable_to_non_nullable
 as EmbeddingUsage,
   ));
 }
@@ -3515,10 +3529,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String object,  List<Embedding> data,  String model,  EmbeddingUsage usage)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String object,  List<Embedding> data,  String model, @JsonKey(includeIfNull: false)  int? created,  EmbeddingUsage usage)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EmbeddingResponse() when $default != null:
-return $default(_that.id,_that.object,_that.data,_that.model,_that.usage);case _:
+return $default(_that.id,_that.object,_that.data,_that.model,_that.created,_that.usage);case _:
   return orElse();
 
 }
@@ -3536,10 +3550,10 @@ return $default(_that.id,_that.object,_that.data,_that.model,_that.usage);case _
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String object,  List<Embedding> data,  String model,  EmbeddingUsage usage)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String object,  List<Embedding> data,  String model, @JsonKey(includeIfNull: false)  int? created,  EmbeddingUsage usage)  $default,) {final _that = this;
 switch (_that) {
 case _EmbeddingResponse():
-return $default(_that.id,_that.object,_that.data,_that.model,_that.usage);case _:
+return $default(_that.id,_that.object,_that.data,_that.model,_that.created,_that.usage);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -3556,10 +3570,10 @@ return $default(_that.id,_that.object,_that.data,_that.model,_that.usage);case _
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String object,  List<Embedding> data,  String model,  EmbeddingUsage usage)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String object,  List<Embedding> data,  String model, @JsonKey(includeIfNull: false)  int? created,  EmbeddingUsage usage)?  $default,) {final _that = this;
 switch (_that) {
 case _EmbeddingResponse() when $default != null:
-return $default(_that.id,_that.object,_that.data,_that.model,_that.usage);case _:
+return $default(_that.id,_that.object,_that.data,_that.model,_that.created,_that.usage);case _:
   return null;
 
 }
@@ -3571,7 +3585,7 @@ return $default(_that.id,_that.object,_that.data,_that.model,_that.usage);case _
 @JsonSerializable()
 
 class _EmbeddingResponse extends EmbeddingResponse {
-  const _EmbeddingResponse({required this.id, required this.object, required final  List<Embedding> data, required this.model, required this.usage}): _data = data,super._();
+  const _EmbeddingResponse({required this.id, required this.object, required final  List<Embedding> data, required this.model, @JsonKey(includeIfNull: false) this.created, required this.usage}): _data = data,super._();
   factory _EmbeddingResponse.fromJson(Map<String, dynamic> json) => _$EmbeddingResponseFromJson(json);
 
 /// The unique identifier for this embedding response.
@@ -3589,6 +3603,8 @@ class _EmbeddingResponse extends EmbeddingResponse {
 
 /// The model used for this embedding.
 @override final  String model;
+/// Unix timestamp when the response was created.
+@override@JsonKey(includeIfNull: false) final  int? created;
 /// The usage statistics for this embedding.
 @override final  EmbeddingUsage usage;
 
@@ -3605,16 +3621,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbeddingResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.object, object) || other.object == object)&&const DeepCollectionEquality().equals(other._data, _data)&&(identical(other.model, model) || other.model == model)&&(identical(other.usage, usage) || other.usage == usage));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbeddingResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.object, object) || other.object == object)&&const DeepCollectionEquality().equals(other._data, _data)&&(identical(other.model, model) || other.model == model)&&(identical(other.created, created) || other.created == created)&&(identical(other.usage, usage) || other.usage == usage));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,object,const DeepCollectionEquality().hash(_data),model,usage);
+int get hashCode => Object.hash(runtimeType,id,object,const DeepCollectionEquality().hash(_data),model,created,usage);
 
 @override
 String toString() {
-  return 'EmbeddingResponse(id: $id, object: $object, data: $data, model: $model, usage: $usage)';
+  return 'EmbeddingResponse(id: $id, object: $object, data: $data, model: $model, created: $created, usage: $usage)';
 }
 
 
@@ -3625,7 +3641,7 @@ abstract mixin class _$EmbeddingResponseCopyWith<$Res> implements $EmbeddingResp
   factory _$EmbeddingResponseCopyWith(_EmbeddingResponse value, $Res Function(_EmbeddingResponse) _then) = __$EmbeddingResponseCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String object, List<Embedding> data, String model, EmbeddingUsage usage
+ String id, String object, List<Embedding> data, String model,@JsonKey(includeIfNull: false) int? created, EmbeddingUsage usage
 });
 
 
@@ -3642,13 +3658,14 @@ class __$EmbeddingResponseCopyWithImpl<$Res>
 
 /// Create a copy of EmbeddingResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? object = null,Object? data = null,Object? model = null,Object? usage = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? object = null,Object? data = null,Object? model = null,Object? created = freezed,Object? usage = null,}) {
   return _then(_EmbeddingResponse(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,object: null == object ? _self.object : object // ignore: cast_nullable_to_non_nullable
 as String,data: null == data ? _self._data : data // ignore: cast_nullable_to_non_nullable
 as List<Embedding>,model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
-as String,usage: null == usage ? _self.usage : usage // ignore: cast_nullable_to_non_nullable
+as String,created: freezed == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
+as int?,usage: null == usage ? _self.usage : usage // ignore: cast_nullable_to_non_nullable
 as EmbeddingUsage,
   ));
 }
@@ -3670,8 +3687,10 @@ $EmbeddingUsageCopyWith<$Res> get usage {
 mixin _$EmbeddingUsage {
 
 /// The number of tokens in the prompt.
-@JsonKey(name: 'prompt_tokens') int get promptTokens;/// The total number of tokens generated.
-@JsonKey(name: 'total_tokens') int get totalTokens;
+@JsonKey(name: 'prompt_tokens') int get promptTokens;/// The number of completion tokens (typically 0 for embeddings).
+@JsonKey(name: 'completion_tokens') int get completionTokens;/// The total number of tokens.
+@JsonKey(name: 'total_tokens') int get totalTokens;/// Duration of audio input in seconds (if applicable).
+@JsonKey(name: 'prompt_audio_seconds', includeIfNull: false) int? get promptAudioSeconds;
 /// Create a copy of EmbeddingUsage
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3684,16 +3703,16 @@ $EmbeddingUsageCopyWith<EmbeddingUsage> get copyWith => _$EmbeddingUsageCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingUsage&&(identical(other.promptTokens, promptTokens) || other.promptTokens == promptTokens)&&(identical(other.totalTokens, totalTokens) || other.totalTokens == totalTokens));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingUsage&&(identical(other.promptTokens, promptTokens) || other.promptTokens == promptTokens)&&(identical(other.completionTokens, completionTokens) || other.completionTokens == completionTokens)&&(identical(other.totalTokens, totalTokens) || other.totalTokens == totalTokens)&&(identical(other.promptAudioSeconds, promptAudioSeconds) || other.promptAudioSeconds == promptAudioSeconds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,promptTokens,totalTokens);
+int get hashCode => Object.hash(runtimeType,promptTokens,completionTokens,totalTokens,promptAudioSeconds);
 
 @override
 String toString() {
-  return 'EmbeddingUsage(promptTokens: $promptTokens, totalTokens: $totalTokens)';
+  return 'EmbeddingUsage(promptTokens: $promptTokens, completionTokens: $completionTokens, totalTokens: $totalTokens, promptAudioSeconds: $promptAudioSeconds)';
 }
 
 
@@ -3704,7 +3723,7 @@ abstract mixin class $EmbeddingUsageCopyWith<$Res>  {
   factory $EmbeddingUsageCopyWith(EmbeddingUsage value, $Res Function(EmbeddingUsage) _then) = _$EmbeddingUsageCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'prompt_tokens') int promptTokens,@JsonKey(name: 'total_tokens') int totalTokens
+@JsonKey(name: 'prompt_tokens') int promptTokens,@JsonKey(name: 'completion_tokens') int completionTokens,@JsonKey(name: 'total_tokens') int totalTokens,@JsonKey(name: 'prompt_audio_seconds', includeIfNull: false) int? promptAudioSeconds
 });
 
 
@@ -3721,11 +3740,13 @@ class _$EmbeddingUsageCopyWithImpl<$Res>
 
 /// Create a copy of EmbeddingUsage
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? promptTokens = null,Object? totalTokens = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? promptTokens = null,Object? completionTokens = null,Object? totalTokens = null,Object? promptAudioSeconds = freezed,}) {
   return _then(_self.copyWith(
 promptTokens: null == promptTokens ? _self.promptTokens : promptTokens // ignore: cast_nullable_to_non_nullable
+as int,completionTokens: null == completionTokens ? _self.completionTokens : completionTokens // ignore: cast_nullable_to_non_nullable
 as int,totalTokens: null == totalTokens ? _self.totalTokens : totalTokens // ignore: cast_nullable_to_non_nullable
-as int,
+as int,promptAudioSeconds: freezed == promptAudioSeconds ? _self.promptAudioSeconds : promptAudioSeconds // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -3810,10 +3831,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'prompt_tokens')  int promptTokens, @JsonKey(name: 'total_tokens')  int totalTokens)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'prompt_tokens')  int promptTokens, @JsonKey(name: 'completion_tokens')  int completionTokens, @JsonKey(name: 'total_tokens')  int totalTokens, @JsonKey(name: 'prompt_audio_seconds', includeIfNull: false)  int? promptAudioSeconds)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EmbeddingUsage() when $default != null:
-return $default(_that.promptTokens,_that.totalTokens);case _:
+return $default(_that.promptTokens,_that.completionTokens,_that.totalTokens,_that.promptAudioSeconds);case _:
   return orElse();
 
 }
@@ -3831,10 +3852,10 @@ return $default(_that.promptTokens,_that.totalTokens);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'prompt_tokens')  int promptTokens, @JsonKey(name: 'total_tokens')  int totalTokens)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'prompt_tokens')  int promptTokens, @JsonKey(name: 'completion_tokens')  int completionTokens, @JsonKey(name: 'total_tokens')  int totalTokens, @JsonKey(name: 'prompt_audio_seconds', includeIfNull: false)  int? promptAudioSeconds)  $default,) {final _that = this;
 switch (_that) {
 case _EmbeddingUsage():
-return $default(_that.promptTokens,_that.totalTokens);case _:
+return $default(_that.promptTokens,_that.completionTokens,_that.totalTokens,_that.promptAudioSeconds);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -3851,10 +3872,10 @@ return $default(_that.promptTokens,_that.totalTokens);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'prompt_tokens')  int promptTokens, @JsonKey(name: 'total_tokens')  int totalTokens)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'prompt_tokens')  int promptTokens, @JsonKey(name: 'completion_tokens')  int completionTokens, @JsonKey(name: 'total_tokens')  int totalTokens, @JsonKey(name: 'prompt_audio_seconds', includeIfNull: false)  int? promptAudioSeconds)?  $default,) {final _that = this;
 switch (_that) {
 case _EmbeddingUsage() when $default != null:
-return $default(_that.promptTokens,_that.totalTokens);case _:
+return $default(_that.promptTokens,_that.completionTokens,_that.totalTokens,_that.promptAudioSeconds);case _:
   return null;
 
 }
@@ -3866,13 +3887,17 @@ return $default(_that.promptTokens,_that.totalTokens);case _:
 @JsonSerializable()
 
 class _EmbeddingUsage extends EmbeddingUsage {
-  const _EmbeddingUsage({@JsonKey(name: 'prompt_tokens') required this.promptTokens, @JsonKey(name: 'total_tokens') required this.totalTokens}): super._();
+  const _EmbeddingUsage({@JsonKey(name: 'prompt_tokens') required this.promptTokens, @JsonKey(name: 'completion_tokens') required this.completionTokens, @JsonKey(name: 'total_tokens') required this.totalTokens, @JsonKey(name: 'prompt_audio_seconds', includeIfNull: false) this.promptAudioSeconds}): super._();
   factory _EmbeddingUsage.fromJson(Map<String, dynamic> json) => _$EmbeddingUsageFromJson(json);
 
 /// The number of tokens in the prompt.
 @override@JsonKey(name: 'prompt_tokens') final  int promptTokens;
-/// The total number of tokens generated.
+/// The number of completion tokens (typically 0 for embeddings).
+@override@JsonKey(name: 'completion_tokens') final  int completionTokens;
+/// The total number of tokens.
 @override@JsonKey(name: 'total_tokens') final  int totalTokens;
+/// Duration of audio input in seconds (if applicable).
+@override@JsonKey(name: 'prompt_audio_seconds', includeIfNull: false) final  int? promptAudioSeconds;
 
 /// Create a copy of EmbeddingUsage
 /// with the given fields replaced by the non-null parameter values.
@@ -3887,16 +3912,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbeddingUsage&&(identical(other.promptTokens, promptTokens) || other.promptTokens == promptTokens)&&(identical(other.totalTokens, totalTokens) || other.totalTokens == totalTokens));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EmbeddingUsage&&(identical(other.promptTokens, promptTokens) || other.promptTokens == promptTokens)&&(identical(other.completionTokens, completionTokens) || other.completionTokens == completionTokens)&&(identical(other.totalTokens, totalTokens) || other.totalTokens == totalTokens)&&(identical(other.promptAudioSeconds, promptAudioSeconds) || other.promptAudioSeconds == promptAudioSeconds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,promptTokens,totalTokens);
+int get hashCode => Object.hash(runtimeType,promptTokens,completionTokens,totalTokens,promptAudioSeconds);
 
 @override
 String toString() {
-  return 'EmbeddingUsage(promptTokens: $promptTokens, totalTokens: $totalTokens)';
+  return 'EmbeddingUsage(promptTokens: $promptTokens, completionTokens: $completionTokens, totalTokens: $totalTokens, promptAudioSeconds: $promptAudioSeconds)';
 }
 
 
@@ -3907,7 +3932,7 @@ abstract mixin class _$EmbeddingUsageCopyWith<$Res> implements $EmbeddingUsageCo
   factory _$EmbeddingUsageCopyWith(_EmbeddingUsage value, $Res Function(_EmbeddingUsage) _then) = __$EmbeddingUsageCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'prompt_tokens') int promptTokens,@JsonKey(name: 'total_tokens') int totalTokens
+@JsonKey(name: 'prompt_tokens') int promptTokens,@JsonKey(name: 'completion_tokens') int completionTokens,@JsonKey(name: 'total_tokens') int totalTokens,@JsonKey(name: 'prompt_audio_seconds', includeIfNull: false) int? promptAudioSeconds
 });
 
 
@@ -3924,11 +3949,13 @@ class __$EmbeddingUsageCopyWithImpl<$Res>
 
 /// Create a copy of EmbeddingUsage
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? promptTokens = null,Object? totalTokens = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? promptTokens = null,Object? completionTokens = null,Object? totalTokens = null,Object? promptAudioSeconds = freezed,}) {
   return _then(_EmbeddingUsage(
 promptTokens: null == promptTokens ? _self.promptTokens : promptTokens // ignore: cast_nullable_to_non_nullable
+as int,completionTokens: null == completionTokens ? _self.completionTokens : completionTokens // ignore: cast_nullable_to_non_nullable
 as int,totalTokens: null == totalTokens ? _self.totalTokens : totalTokens // ignore: cast_nullable_to_non_nullable
-as int,
+as int,promptAudioSeconds: freezed == promptAudioSeconds ? _self.promptAudioSeconds : promptAudioSeconds // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/packages/mistralai_dart/lib/src/generated/schema/schema.g.dart
+++ b/packages/mistralai_dart/lib/src/generated/schema/schema.g.dart
@@ -233,12 +233,17 @@ _EmbeddingRequest _$EmbeddingRequestFromJson(Map<String, dynamic> json) =>
     _EmbeddingRequest(
       model: const _EmbeddingModelConverter().fromJson(json['model']),
       input: (json['input'] as List<dynamic>).map((e) => e as String).toList(),
-      encodingFormat:
-          $enumDecodeNullable(
-            _$EmbeddingEncodingFormatEnumMap,
-            json['encoding_format'],
-          ) ??
-          EmbeddingEncodingFormat.float,
+      outputDimension: (json['output_dimension'] as num?)?.toInt(),
+      outputDtype: $enumDecodeNullable(
+        _$EmbeddingOutputDtypeEnumMap,
+        json['output_dtype'],
+        unknownValue: JsonKey.nullForUndefinedEnumValue,
+      ),
+      encodingFormat: $enumDecodeNullable(
+        _$EmbeddingEncodingFormatEnumMap,
+        json['encoding_format'],
+        unknownValue: JsonKey.nullForUndefinedEnumValue,
+      ),
     );
 
 Map<String, dynamic> _$EmbeddingRequestToJson(
@@ -246,11 +251,22 @@ Map<String, dynamic> _$EmbeddingRequestToJson(
 ) => <String, dynamic>{
   'model': const _EmbeddingModelConverter().toJson(instance.model),
   'input': instance.input,
-  'encoding_format': _$EmbeddingEncodingFormatEnumMap[instance.encodingFormat]!,
+  'output_dimension': ?instance.outputDimension,
+  'output_dtype': ?_$EmbeddingOutputDtypeEnumMap[instance.outputDtype],
+  'encoding_format': ?_$EmbeddingEncodingFormatEnumMap[instance.encodingFormat],
+};
+
+const _$EmbeddingOutputDtypeEnumMap = {
+  EmbeddingOutputDtype.float: 'float',
+  EmbeddingOutputDtype.int8: 'int8',
+  EmbeddingOutputDtype.uint8: 'uint8',
+  EmbeddingOutputDtype.binary: 'binary',
+  EmbeddingOutputDtype.ubinary: 'ubinary',
 };
 
 const _$EmbeddingEncodingFormatEnumMap = {
   EmbeddingEncodingFormat.float: 'float',
+  EmbeddingEncodingFormat.base64: 'base64',
 };
 
 EmbeddingModelEnumeration _$EmbeddingModelEnumerationFromJson(
@@ -269,6 +285,7 @@ Map<String, dynamic> _$EmbeddingModelEnumerationToJson(
 
 const _$EmbeddingModelsEnumMap = {
   EmbeddingModels.mistralEmbed: 'mistral-embed',
+  EmbeddingModels.codestralEmbed2505: 'codestral-embed-2505',
 };
 
 EmbeddingModelString _$EmbeddingModelStringFromJson(
@@ -290,6 +307,7 @@ _EmbeddingResponse _$EmbeddingResponseFromJson(Map<String, dynamic> json) =>
           .map((e) => Embedding.fromJson(e as Map<String, dynamic>))
           .toList(),
       model: json['model'] as String,
+      created: (json['created'] as num?)?.toInt(),
       usage: EmbeddingUsage.fromJson(json['usage'] as Map<String, dynamic>),
     );
 
@@ -299,19 +317,24 @@ Map<String, dynamic> _$EmbeddingResponseToJson(_EmbeddingResponse instance) =>
       'object': instance.object,
       'data': instance.data.map((e) => e.toJson()).toList(),
       'model': instance.model,
+      'created': ?instance.created,
       'usage': instance.usage.toJson(),
     };
 
 _EmbeddingUsage _$EmbeddingUsageFromJson(Map<String, dynamic> json) =>
     _EmbeddingUsage(
       promptTokens: (json['prompt_tokens'] as num).toInt(),
+      completionTokens: (json['completion_tokens'] as num).toInt(),
       totalTokens: (json['total_tokens'] as num).toInt(),
+      promptAudioSeconds: (json['prompt_audio_seconds'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$EmbeddingUsageToJson(_EmbeddingUsage instance) =>
     <String, dynamic>{
       'prompt_tokens': instance.promptTokens,
+      'completion_tokens': instance.completionTokens,
       'total_tokens': instance.totalTokens,
+      'prompt_audio_seconds': ?instance.promptAudioSeconds,
     };
 
 _Embedding _$EmbeddingFromJson(Map<String, dynamic> json) => _Embedding(

--- a/packages/mistralai_dart/oas/main.dart
+++ b/packages/mistralai_dart/oas/main.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:openapi_spec/openapi_spec.dart';
 
 /// Generates Mistral AI API client Dart code from the OpenAPI spec.
-/// https://docs.mistral.ai/api
+/// https://docs.mistral.ai/openapi.yaml
 void main() async {
   final spec = OpenApi.fromFile(source: 'oas/mistral_openapi_curated.yaml');
 

--- a/packages/mistralai_dart/oas/mistral_openapi_curated.yaml
+++ b/packages/mistralai_dart/oas/mistral_openapi_curated.yaml
@@ -346,6 +346,7 @@ components:
                 Available embedding models. Mind that the list may not be exhaustive nor up-to-date.
               enum:
                 - mistral-embed
+                - codestral-embed-2505
         input:
           type: array
           items:
@@ -355,13 +356,31 @@ components:
             - world
           description: |
             The list of strings to embed.
+        output_dimension:
+          type: integer
+          nullable: true
+          description: |
+            The number of dimensions the resulting output embeddings should have.
+            Only supported by certain models (e.g., codestral-embed-2505).
+        output_dtype:
+          type: string
+          title: EmbeddingOutputDtype
+          enum:
+            - float
+            - int8
+            - uint8
+            - binary
+            - ubinary
+          nullable: true
+          description: |
+            The data type of the output embeddings.
         encoding_format:
           type: string
           title: EmbeddingEncodingFormat
           enum:
             - float
-          default: float
-          example: float
+            - base64
+          nullable: true
           description: |
             The format of the output data.
       required:
@@ -387,6 +406,10 @@ components:
         model:
           type: string
           description: The model used for this embedding.
+        created:
+          type: integer
+          nullable: true
+          description: Unix timestamp when the response was created.
         usage:
           type: object
           title: EmbeddingUsage
@@ -396,12 +419,21 @@ components:
               type: integer
               description: The number of tokens in the prompt.
               example: 9
+            completion_tokens:
+              type: integer
+              description: The number of completion tokens (typically 0 for embeddings).
+              example: 0
             total_tokens:
               type: integer
-              description: The total number of tokens generated.
+              description: The total number of tokens.
               example: 9
+            prompt_audio_seconds:
+              type: integer
+              nullable: true
+              description: Duration of audio input in seconds (if applicable).
           required:
             - prompt_tokens
+            - completion_tokens
             - total_tokens
       required:
         - id

--- a/packages/mistralai_dart/test/embeddings_test.dart
+++ b/packages/mistralai_dart/test/embeddings_test.dart
@@ -1,0 +1,230 @@
+// ignore_for_file: avoid_redundant_argument_values
+import 'package:mistralai_dart/mistralai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EmbeddingRequest tests', () {
+    test('serializes with all optional fields', () {
+      const request = EmbeddingRequest(
+        model: EmbeddingModel.model(EmbeddingModels.mistralEmbed),
+        input: ['Hello', 'World'],
+        outputDimension: 256,
+        outputDtype: EmbeddingOutputDtype.float,
+        encodingFormat: EmbeddingEncodingFormat.float,
+      );
+
+      final json = request.toJson();
+
+      expect(json['model'], 'mistral-embed');
+      expect(json['input'], ['Hello', 'World']);
+      expect(json['output_dimension'], 256);
+      expect(json['output_dtype'], 'float');
+      expect(json['encoding_format'], 'float');
+    });
+
+    test('serializes with only required fields', () {
+      const request = EmbeddingRequest(
+        model: EmbeddingModel.modelId('codestral-embed-2505'),
+        input: ['Test'],
+      );
+
+      final json = request.toJson();
+
+      expect(json['model'], 'codestral-embed-2505');
+      expect(json['input'], ['Test']);
+      expect(json.containsKey('output_dimension'), isFalse);
+      expect(json.containsKey('output_dtype'), isFalse);
+      expect(json.containsKey('encoding_format'), isFalse);
+    });
+
+    test('serializes with base64 encoding format', () {
+      const request = EmbeddingRequest(
+        model: EmbeddingModel.model(EmbeddingModels.codestralEmbed2505),
+        input: ['Test'],
+        encodingFormat: EmbeddingEncodingFormat.base64,
+      );
+
+      final json = request.toJson();
+
+      expect(json['model'], 'codestral-embed-2505');
+      expect(json['encoding_format'], 'base64');
+    });
+
+    test('deserializes with all fields', () {
+      final json = {
+        'model': 'mistral-embed',
+        'input': ['Hello'],
+        'output_dimension': 512,
+        'output_dtype': 'int8',
+        'encoding_format': 'base64',
+      };
+
+      final request = EmbeddingRequest.fromJson(json);
+
+      expect(request.outputDimension, 512);
+      expect(request.outputDtype, EmbeddingOutputDtype.int8);
+      expect(request.encodingFormat, EmbeddingEncodingFormat.base64);
+    });
+
+    test('deserializes with only required fields', () {
+      final json = {
+        'model': 'mistral-embed',
+        'input': ['Hello'],
+      };
+
+      final request = EmbeddingRequest.fromJson(json);
+
+      expect(request.outputDimension, isNull);
+      expect(request.outputDtype, isNull);
+      expect(request.encodingFormat, isNull);
+    });
+  });
+
+  group('EmbeddingOutputDtype enum tests', () {
+    test('has all expected values', () {
+      expect(EmbeddingOutputDtype.values, hasLength(5));
+      expect(
+        EmbeddingOutputDtype.values,
+        containsAll([
+          EmbeddingOutputDtype.float,
+          EmbeddingOutputDtype.int8,
+          EmbeddingOutputDtype.uint8,
+          EmbeddingOutputDtype.binary,
+          EmbeddingOutputDtype.ubinary,
+        ]),
+      );
+    });
+  });
+
+  group('EmbeddingEncodingFormat enum tests', () {
+    test('has all expected values', () {
+      expect(EmbeddingEncodingFormat.values, hasLength(2));
+      expect(
+        EmbeddingEncodingFormat.values,
+        containsAll([
+          EmbeddingEncodingFormat.float,
+          EmbeddingEncodingFormat.base64,
+        ]),
+      );
+    });
+  });
+
+  group('EmbeddingModels enum tests', () {
+    test('has all expected values', () {
+      expect(EmbeddingModels.values, hasLength(2));
+      expect(
+        EmbeddingModels.values,
+        containsAll([
+          EmbeddingModels.mistralEmbed,
+          EmbeddingModels.codestralEmbed2505,
+        ]),
+      );
+    });
+  });
+
+  group('EmbeddingResponse tests', () {
+    test('deserializes with created field', () {
+      final json = {
+        'id': 'embd-123',
+        'object': 'list',
+        'data': [
+          {
+            'object': 'embedding',
+            'embedding': [0.1, 0.2],
+            'index': 0,
+          },
+        ],
+        'model': 'mistral-embed',
+        'created': 1702256327,
+        'usage': {
+          'prompt_tokens': 5,
+          'completion_tokens': 0,
+          'total_tokens': 5,
+        },
+      };
+
+      final response = EmbeddingResponse.fromJson(json);
+
+      expect(response.id, 'embd-123');
+      expect(response.created, 1702256327);
+      expect(response.usage.promptTokens, 5);
+      expect(response.usage.completionTokens, 0);
+    });
+
+    test('deserializes without created field', () {
+      final json = {
+        'id': 'embd-123',
+        'object': 'list',
+        'data': <Map<String, dynamic>>[],
+        'model': 'mistral-embed',
+        'usage': {
+          'prompt_tokens': 5,
+          'completion_tokens': 0,
+          'total_tokens': 5,
+        },
+      };
+
+      final response = EmbeddingResponse.fromJson(json);
+
+      expect(response.created, isNull);
+    });
+  });
+
+  group('EmbeddingUsage tests', () {
+    test('deserializes with all fields', () {
+      final json = {
+        'prompt_tokens': 10,
+        'completion_tokens': 0,
+        'total_tokens': 10,
+        'prompt_audio_seconds': 30,
+      };
+
+      final usage = EmbeddingUsage.fromJson(json);
+
+      expect(usage.promptTokens, 10);
+      expect(usage.completionTokens, 0);
+      expect(usage.totalTokens, 10);
+      expect(usage.promptAudioSeconds, 30);
+    });
+
+    test('deserializes without prompt_audio_seconds', () {
+      final json = {
+        'prompt_tokens': 10,
+        'completion_tokens': 0,
+        'total_tokens': 10,
+      };
+
+      final usage = EmbeddingUsage.fromJson(json);
+
+      expect(usage.promptAudioSeconds, isNull);
+    });
+
+    test('serializes with all fields', () {
+      const usage = EmbeddingUsage(
+        promptTokens: 10,
+        completionTokens: 0,
+        totalTokens: 10,
+        promptAudioSeconds: 30,
+      );
+
+      final json = usage.toJson();
+
+      expect(json['prompt_tokens'], 10);
+      expect(json['completion_tokens'], 0);
+      expect(json['total_tokens'], 10);
+      expect(json['prompt_audio_seconds'], 30);
+    });
+
+    test('serializes without prompt_audio_seconds when null', () {
+      const usage = EmbeddingUsage(
+        promptTokens: 10,
+        completionTokens: 0,
+        totalTokens: 10,
+      );
+
+      final json = usage.toJson();
+
+      expect(json.containsKey('prompt_audio_seconds'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Aligns the mistralai_dart embeddings API with the latest Mistral API spec and exposes the `dimensions` parameter in langchain_mistralai.

Fixes #820

## Changes

### EmbeddingRequest
- Add `output_dimension` for custom embedding dimensions
- Add `output_dtype` enum (float, int8, uint8, binary, ubinary)
- Add `base64` to `encoding_format` enum
- Add `codestral-embed-2505` to `EmbeddingModels` enum

### EmbeddingResponse
- Add `created` field (Unix timestamp)

### EmbeddingUsage
- Add `completion_tokens` (required, typically 0 for embeddings)
- Add `prompt_audio_seconds` (optional, for audio inputs)

### langchain_mistralai
- Expose `dimensions` parameter in `MistralAIEmbeddings`

## Test plan
- [x] Unit tests added for new embedding fields
- [x] Formatter passes
- [x] Analyzer passes
- [ ] CI passes