### PR TITLE
feat(langchain_mistralai): Add tool/function calling support

### DIFF
--- a/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/chat_mistralai.dart
@@ -3,7 +3,7 @@ import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_tiktoken/langchain_tiktoken.dart';
-import 'package:mistralai_dart/mistralai_dart.dart';
+import 'package:mistralai_dart/mistralai_dart.dart' as mistral;
 
 import 'mappers.dart';
 import 'types.dart';
@@ -158,7 +158,7 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
     final http.Client? client,
     super.defaultOptions = const ChatMistralAIOptions(model: defaultModel),
     this.encoding = 'cl100k_base',
-  }) : _client = MistralAIClient(
+  }) : _client = mistral.MistralAIClient(
          apiKey: apiKey,
          baseUrl: baseUrl,
          headers: headers,
@@ -167,7 +167,7 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
        );
 
   /// A client for interacting with Mistral AI API.
-  final MistralAIClient _client;
+  final mistral.MistralAIClient _client;
 
   /// The encoding to use by tiktoken when [tokenize] is called.
   ///
@@ -211,13 +211,16 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
   }
 
   /// Creates a [GenerateCompletionRequest] from the given input.
-  ChatCompletionRequest _generateCompletionRequest(
+  mistral.ChatCompletionRequest _generateCompletionRequest(
     final List<ChatMessage> messages, {
     final bool stream = false,
     final ChatMistralAIOptions? options,
   }) {
-    return ChatCompletionRequest(
-      model: ChatCompletionModel.modelId(
+    final tools = options?.tools ?? defaultOptions.tools;
+    final toolChoice = options?.toolChoice ?? defaultOptions.toolChoice;
+
+    return mistral.ChatCompletionRequest(
+      model: mistral.ChatCompletionModel.modelId(
         options?.model ?? defaultOptions.model ?? defaultModel,
       ),
       messages: messages.toChatCompletionMessages(),
@@ -226,6 +229,8 @@ class ChatMistralAI extends BaseChatModel<ChatMistralAIOptions> {
       maxTokens: options?.maxTokens ?? defaultOptions.maxTokens,
       safePrompt: options?.safePrompt ?? defaultOptions.safePrompt,
       randomSeed: options?.randomSeed ?? defaultOptions.randomSeed,
+      tools: tools?.toMistralTools(),
+      toolChoice: toolChoice?.toMistralToolChoice(),
       stream: stream,
     );
   }

--- a/packages/langchain_mistralai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/mappers.dart
@@ -1,43 +1,114 @@
 // ignore_for_file: public_member_api_docs
+import 'dart:convert';
+
 import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/language_models.dart';
-import 'package:mistralai_dart/mistralai_dart.dart';
+import 'package:langchain_core/tools.dart';
+import 'package:mistralai_dart/mistralai_dart.dart' as mistral;
 
 extension ChatMessageListMapper on List<ChatMessage> {
-  List<ChatCompletionMessage> toChatCompletionMessages() {
+  List<mistral.ChatCompletionMessage> toChatCompletionMessages() {
     return map(_mapMessage).toList(growable: false);
   }
 
-  ChatCompletionMessage _mapMessage(final ChatMessage msg) {
+  mistral.ChatCompletionMessage _mapMessage(final ChatMessage msg) {
     return switch (msg) {
-      final SystemChatMessage systemChatMessage => ChatCompletionMessage(
-        role: ChatCompletionMessageRole.system,
-        content: systemChatMessage.content,
+      final SystemChatMessage msg => mistral.ChatCompletionMessage(
+        role: mistral.ChatCompletionMessageRole.system,
+        content: msg.content,
       ),
-      final HumanChatMessage humanChatMessage => ChatCompletionMessage(
-        role: ChatCompletionMessageRole.user,
-        content: humanChatMessage.contentAsString,
+      final HumanChatMessage msg => mistral.ChatCompletionMessage(
+        role: mistral.ChatCompletionMessageRole.user,
+        content: msg.contentAsString,
       ),
-      final AIChatMessage aiChatMessage => ChatCompletionMessage(
-        role: ChatCompletionMessageRole.assistant,
-        content: aiChatMessage.content,
+      final AIChatMessage msg => mistral.ChatCompletionMessage(
+        role: mistral.ChatCompletionMessageRole.assistant,
+        content: msg.content,
+        toolCalls: msg.toolCalls.isNotEmpty
+            ? msg.toolCalls.map(_mapToolCall).toList(growable: false)
+            : null,
       ),
-      ToolChatMessage() => throw UnsupportedError(
-        'Mistral AI does not support tool calls',
+      final ToolChatMessage msg => mistral.ChatCompletionMessage(
+        role: mistral.ChatCompletionMessageRole.tool,
+        content: msg.content,
+        toolCallId: msg.toolCallId,
+        name: null,
       ),
       CustomChatMessage() => throw UnsupportedError(
         'Mistral AI does not support custom messages',
       ),
     };
   }
+
+  mistral.ToolCall _mapToolCall(final AIChatMessageToolCall toolCall) {
+    return mistral.ToolCall(
+      id: toolCall.id,
+      type: mistral.ToolType.function,
+      function: mistral.FunctionCall(
+        name: toolCall.name,
+        arguments: json.encode(toolCall.arguments),
+      ),
+    );
+  }
 }
 
-extension ChatResultMapper on ChatCompletionResponse {
+extension ChatToolListMapper on List<ToolSpec> {
+  List<mistral.Tool> toMistralTools() {
+    return map(_mapTool).toList(growable: false);
+  }
+
+  mistral.Tool _mapTool(final ToolSpec tool) {
+    return mistral.Tool(
+      type: mistral.ToolType.function,
+      function: mistral.FunctionDefinition(
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.inputJsonSchema,
+      ),
+    );
+  }
+}
+
+extension ChatToolChoiceMapper on ChatToolChoice {
+  mistral.ChatCompletionToolChoice toMistralToolChoice() {
+    return switch (this) {
+      ChatToolChoiceNone() =>
+        const mistral.ChatCompletionToolChoice.enumeration(
+          mistral.ChatCompletionToolChoiceOption.none,
+        ),
+      ChatToolChoiceAuto() =>
+        const mistral.ChatCompletionToolChoice.enumeration(
+          mistral.ChatCompletionToolChoiceOption.auto,
+        ),
+      ChatToolChoiceRequired() =>
+        const mistral.ChatCompletionToolChoice.enumeration(
+          mistral.ChatCompletionToolChoiceOption.any,
+        ),
+      final ChatToolChoiceForced t =>
+        mistral.ChatCompletionToolChoice.toolChoiceTool(
+          mistral.ToolChoiceTool(
+            type: mistral.ToolType.function,
+            function: mistral.ToolChoiceToolFunction(name: t.name),
+          ),
+        ),
+    };
+  }
+}
+
+extension ChatResultMapper on mistral.ChatCompletionResponse {
   ChatResult toChatResult({final bool streaming = false}) {
     final choice = choices.first;
+    final message = choice.message;
     return ChatResult(
       id: id,
-      output: AIChatMessage(content: choice.message?.content ?? ''),
+      output: AIChatMessage(
+        content: message.content ?? '',
+        toolCalls:
+            message.toolCalls
+                ?.map(_mapResponseToolCall)
+                .toList(growable: false) ??
+            const [],
+      ),
       finishReason: _mapFinishReason(choice.finishReason),
       metadata: {'model': model, 'created': created},
       usage: _mapUsage(usage),
@@ -45,7 +116,22 @@ extension ChatResultMapper on ChatCompletionResponse {
     );
   }
 
-  LanguageModelUsage _mapUsage(final ChatCompletionUsage usage) {
+  AIChatMessageToolCall _mapResponseToolCall(final mistral.ToolCall toolCall) {
+    var args = <String, dynamic>{};
+    try {
+      args = toolCall.function.arguments.isEmpty
+          ? {}
+          : json.decode(toolCall.function.arguments);
+    } catch (_) {}
+    return AIChatMessageToolCall(
+      id: toolCall.id,
+      name: toolCall.function.name,
+      argumentsRaw: toolCall.function.arguments,
+      arguments: args,
+    );
+  }
+
+  LanguageModelUsage _mapUsage(final mistral.ChatCompletionUsage usage) {
     return LanguageModelUsage(
       promptTokens: usage.promptTokens,
       responseTokens: usage.completionTokens,
@@ -54,27 +140,57 @@ extension ChatResultMapper on ChatCompletionResponse {
   }
 }
 
-/// Mapper for [ChatCompletionStreamResponse].
+/// Mapper for [mistral.ChatCompletionStreamResponse].
 extension CreateChatCompletionStreamResponseMapper
-    on ChatCompletionStreamResponse {
-  /// Converts a [ChatCompletionStreamResponse] to a [ChatResult].
+    on mistral.ChatCompletionStreamResponse {
+  /// Converts a [mistral.ChatCompletionStreamResponse] to a [ChatResult].
   ChatResult toChatResult() {
     final choice = choices.first;
+    final delta = choice.delta;
     return ChatResult(
       id: id,
-      output: AIChatMessage(content: choice.delta.content ?? ''),
+      output: AIChatMessage(
+        content: delta.content ?? '',
+        toolCalls:
+            delta.toolCalls?.map(_mapStreamToolCall).toList(growable: false) ??
+            const [],
+      ),
       finishReason: _mapFinishReason(choice.finishReason),
       metadata: {'model': model, 'created': created},
-      usage: const LanguageModelUsage(),
+      usage: _mapStreamUsage(usage),
       streaming: true,
+    );
+  }
+
+  AIChatMessageToolCall _mapStreamToolCall(final mistral.ToolCall toolCall) {
+    var args = <String, dynamic>{};
+    try {
+      args = json.decode(toolCall.function.arguments);
+    } catch (_) {}
+    return AIChatMessageToolCall(
+      id: toolCall.id,
+      name: toolCall.function.name,
+      argumentsRaw: toolCall.function.arguments,
+      arguments: args,
+    );
+  }
+
+  LanguageModelUsage _mapStreamUsage(final mistral.ChatCompletionUsage? usage) {
+    return LanguageModelUsage(
+      promptTokens: usage?.promptTokens,
+      responseTokens: usage?.completionTokens,
+      totalTokens: usage?.totalTokens,
     );
   }
 }
 
-FinishReason _mapFinishReason(final ChatCompletionFinishReason? reason) =>
-    switch (reason) {
-      ChatCompletionFinishReason.stop => FinishReason.stop,
-      ChatCompletionFinishReason.length => FinishReason.length,
-      ChatCompletionFinishReason.modelLength => FinishReason.length,
-      null => FinishReason.unspecified,
-    };
+FinishReason _mapFinishReason(
+  final mistral.ChatCompletionFinishReason? reason,
+) => switch (reason) {
+  mistral.ChatCompletionFinishReason.stop => FinishReason.stop,
+  mistral.ChatCompletionFinishReason.length => FinishReason.length,
+  mistral.ChatCompletionFinishReason.modelLength => FinishReason.length,
+  mistral.ChatCompletionFinishReason.error => FinishReason.unspecified,
+  mistral.ChatCompletionFinishReason.toolCalls => FinishReason.toolCalls,
+  null => FinishReason.unspecified,
+};

--- a/packages/langchain_mistralai/lib/src/chat_models/types.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/types.dart
@@ -17,6 +17,8 @@ class ChatMistralAIOptions extends ChatModelOptions {
     this.maxTokens,
     this.safePrompt,
     this.randomSeed,
+    super.tools,
+    super.toolChoice,
     super.concurrencyLimit,
   });
 
@@ -66,6 +68,8 @@ class ChatMistralAIOptions extends ChatModelOptions {
       maxTokens: maxTokens ?? this.maxTokens,
       safePrompt: safePrompt ?? this.safePrompt,
       randomSeed: randomSeed ?? this.randomSeed,
+      tools: tools ?? this.tools,
+      toolChoice: toolChoice ?? this.toolChoice,
       concurrencyLimit: concurrencyLimit ?? this.concurrencyLimit,
     );
   }
@@ -79,6 +83,8 @@ class ChatMistralAIOptions extends ChatModelOptions {
       maxTokens: other?.maxTokens,
       safePrompt: other?.safePrompt,
       randomSeed: other?.randomSeed,
+      tools: other?.tools,
+      toolChoice: other?.toolChoice,
       concurrencyLimit: other?.concurrencyLimit,
     );
   }
@@ -91,6 +97,8 @@ class ChatMistralAIOptions extends ChatModelOptions {
         maxTokens == other.maxTokens &&
         safePrompt == other.safePrompt &&
         randomSeed == other.randomSeed &&
+        tools == other.tools &&
+        toolChoice == other.toolChoice &&
         concurrencyLimit == other.concurrencyLimit;
   }
 
@@ -102,6 +110,8 @@ class ChatMistralAIOptions extends ChatModelOptions {
         maxTokens.hashCode ^
         safePrompt.hashCode ^
         randomSeed.hashCode ^
+        tools.hashCode ^
+        toolChoice.hashCode ^
         concurrencyLimit.hashCode;
   }
 }


### PR DESCRIPTION
## Summary

This PR adds tool/function calling support to the `langchain_mistralai` package, leveraging the new schemas from `mistralai_dart` (#887).

Closes #653 (in conjunction with #887)

## Changes

### ChatMistralAIOptions
- Enable `tools` and `toolChoice` parameters (inherited from base ChatModelOptions)
- Both parameters are properly passed to the API request

### Mappers
- Add `ChatToolListMapper` extension for converting LangChain tools to Mistral format
- Add `ChatToolChoiceMapper` extension for converting tool choice options:
  - `ChatToolChoiceNone` → `none`
  - `ChatToolChoiceAuto` → `auto`
  - `ChatToolChoiceRequired` → `any`
  - `ChatToolChoiceForced` → specific tool
- Handle `ToolChatMessage` mapping with `tool_call_id`
- Map `AIChatMessage.toolCalls` to Mistral `ToolCall` format
- Map response `tool_calls` back to `AIChatMessageToolCall`
- Handle `tool_calls` finish reason → `FinishReason.toolCalls`
- Add streaming support for tool calls in delta responses

### Import Handling
- Use `as mistral` prefix for `mistralai_dart` imports to avoid naming conflicts with `langchain_core`'s `Tool` class

## Usage Example

```dart
final chatModel = ChatMistralAI(
  apiKey: 'your-api-key',
  defaultOptions: ChatMistralAIOptions(
    model: 'mistral-large-latest',
    tools: [
      ToolSpec(
        name: 'get_weather',
        description: 'Get weather for a location',
        inputJsonSchema: {
          'type': 'object',
          'properties': {
            'location': {'type': 'string'},
          },
          'required': ['location'],
        },
      ),
    ],
    toolChoice: ChatToolChoiceAuto(),
  ),
);

final result = await chatModel.invoke(
  PromptValue.chat([ChatMessage.humanText('What is the weather in Paris?')]),
);

// Access tool calls from the response
for (final toolCall in result.output.toolCalls) {
  print('Tool: ${toolCall.name}, Args: ${toolCall.arguments}');
}
```

## Test plan
- [x] Formatter passes
- [x] Analyzer passes
- [x] Depends on #887