### PR TITLE
feat(googleai_dart): Add Interactions API core models

### DIFF
--- a/packages/googleai_dart/lib/src/models/interactions/agent_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/agent_config.dart
@@ -1,0 +1,102 @@
+import '../copy_with_sentinel.dart';
+import 'thinking_summaries.dart';
+
+/// Base class for agent configurations.
+sealed class AgentConfig {
+  /// The type of agent configuration.
+  String get type;
+
+  const AgentConfig();
+
+  /// Creates an [AgentConfig] from JSON.
+  factory AgentConfig.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'dynamic' => DynamicAgentConfig.fromJson(json),
+      'deep-research' => DeepResearchAgentConfig.fromJson(json),
+      _ => DynamicAgentConfig.fromJson(json),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Configuration for dynamic agents.
+class DynamicAgentConfig extends AgentConfig {
+  @override
+  String get type => 'dynamic';
+
+  /// Additional properties for the dynamic agent.
+  final Map<String, dynamic>? additionalProperties;
+
+  /// Creates a [DynamicAgentConfig] instance.
+  const DynamicAgentConfig({this.additionalProperties});
+
+  /// Creates a [DynamicAgentConfig] from JSON.
+  factory DynamicAgentConfig.fromJson(Map<String, dynamic> json) {
+    final props = Map<String, dynamic>.from(json)..remove('type');
+    return DynamicAgentConfig(
+      additionalProperties: props.isNotEmpty ? props : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (additionalProperties != null) ...additionalProperties!,
+  };
+
+  /// Creates a copy with replaced values.
+  DynamicAgentConfig copyWith({
+    Object? additionalProperties = unsetCopyWithValue,
+  }) {
+    return DynamicAgentConfig(
+      additionalProperties: additionalProperties == unsetCopyWithValue
+          ? this.additionalProperties
+          : additionalProperties as Map<String, dynamic>?,
+    );
+  }
+}
+
+/// Configuration for the Deep Research agent.
+class DeepResearchAgentConfig extends AgentConfig {
+  @override
+  String get type => 'deep-research';
+
+  /// Whether to include thought summaries in the response.
+  final InteractionThinkingSummaries? thinkingSummaries;
+
+  /// Creates a [DeepResearchAgentConfig] instance.
+  const DeepResearchAgentConfig({this.thinkingSummaries});
+
+  /// Creates a [DeepResearchAgentConfig] from JSON.
+  factory DeepResearchAgentConfig.fromJson(Map<String, dynamic> json) =>
+      DeepResearchAgentConfig(
+        thinkingSummaries: json['thinking_summaries'] != null
+            ? interactionThinkingSummariesFromString(
+                json['thinking_summaries'] as String?,
+              )
+            : null,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (thinkingSummaries != null)
+      'thinking_summaries': interactionThinkingSummariesToString(
+        thinkingSummaries!,
+      ),
+  };
+
+  /// Creates a copy with replaced values.
+  DeepResearchAgentConfig copyWith({
+    Object? thinkingSummaries = unsetCopyWithValue,
+  }) {
+    return DeepResearchAgentConfig(
+      thinkingSummaries: thinkingSummaries == unsetCopyWithValue
+          ? this.thinkingSummaries
+          : thinkingSummaries as InteractionThinkingSummaries?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/allowed_tools.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/allowed_tools.dart
@@ -1,0 +1,41 @@
+import '../copy_with_sentinel.dart';
+import 'tool_choice_type.dart';
+
+/// Configuration for allowed tools.
+class AllowedTools {
+  /// The mode of the tool choice.
+  final InteractionToolChoiceType? mode;
+
+  /// The names of the allowed tools.
+  final List<String>? tools;
+
+  /// Creates an [AllowedTools] instance.
+  const AllowedTools({this.mode, this.tools});
+
+  /// Creates an [AllowedTools] from JSON.
+  factory AllowedTools.fromJson(Map<String, dynamic> json) => AllowedTools(
+    mode: json['mode'] != null
+        ? interactionToolChoiceTypeFromString(json['mode'] as String?)
+        : null,
+    tools: (json['tools'] as List<dynamic>?)?.cast<String>(),
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (mode != null) 'mode': interactionToolChoiceTypeToString(mode!),
+    if (tools != null) 'tools': tools,
+  };
+
+  /// Creates a copy with replaced values.
+  AllowedTools copyWith({
+    Object? mode = unsetCopyWithValue,
+    Object? tools = unsetCopyWithValue,
+  }) {
+    return AllowedTools(
+      mode: mode == unsetCopyWithValue
+          ? this.mode
+          : mode as InteractionToolChoiceType?,
+      tools: tools == unsetCopyWithValue ? this.tools : tools as List<String>?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/generation_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/generation_config.dart
@@ -1,0 +1,132 @@
+import '../copy_with_sentinel.dart';
+import 'speech_config.dart';
+import 'thinking_level.dart';
+import 'thinking_summaries.dart';
+import 'tool_choice.dart';
+
+/// Configuration parameters for model interactions.
+class InteractionGenerationConfig {
+  /// Controls the randomness of the output.
+  final double? temperature;
+
+  /// The maximum cumulative probability of tokens to consider when sampling.
+  final double? topP;
+
+  /// Seed used in decoding for reproducibility.
+  final int? seed;
+
+  /// A list of character sequences that will stop output interaction.
+  final List<String>? stopSequences;
+
+  /// The tool choice for the interaction.
+  final InteractionToolChoice? toolChoice;
+
+  /// The level of thought tokens that the model should generate.
+  final InteractionThinkingLevel? thinkingLevel;
+
+  /// Whether to include thought summaries in the response.
+  final InteractionThinkingSummaries? thinkingSummaries;
+
+  /// The maximum number of tokens to include in the response.
+  final int? maxOutputTokens;
+
+  /// Configuration for speech interaction.
+  final List<InteractionSpeechConfig>? speechConfig;
+
+  /// Creates an [InteractionGenerationConfig] instance.
+  const InteractionGenerationConfig({
+    this.temperature,
+    this.topP,
+    this.seed,
+    this.stopSequences,
+    this.toolChoice,
+    this.thinkingLevel,
+    this.thinkingSummaries,
+    this.maxOutputTokens,
+    this.speechConfig,
+  });
+
+  /// Creates an [InteractionGenerationConfig] from JSON.
+  factory InteractionGenerationConfig.fromJson(
+    Map<String, dynamic> json,
+  ) => InteractionGenerationConfig(
+    temperature: (json['temperature'] as num?)?.toDouble(),
+    topP: (json['top_p'] as num?)?.toDouble(),
+    seed: json['seed'] as int?,
+    stopSequences: (json['stop_sequences'] as List<dynamic>?)?.cast<String>(),
+    toolChoice: json['tool_choice'] != null
+        ? InteractionToolChoice.fromJson(json['tool_choice'])
+        : null,
+    thinkingLevel: json['thinking_level'] != null
+        ? interactionThinkingLevelFromString(json['thinking_level'] as String?)
+        : null,
+    thinkingSummaries: json['thinking_summaries'] != null
+        ? interactionThinkingSummariesFromString(
+            json['thinking_summaries'] as String?,
+          )
+        : null,
+    maxOutputTokens: json['max_output_tokens'] as int?,
+    speechConfig: (json['speech_config'] as List<dynamic>?)
+        ?.map(
+          (e) => InteractionSpeechConfig.fromJson(e as Map<String, dynamic>),
+        )
+        .toList(),
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (temperature != null) 'temperature': temperature,
+    if (topP != null) 'top_p': topP,
+    if (seed != null) 'seed': seed,
+    if (stopSequences != null) 'stop_sequences': stopSequences,
+    if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
+    if (thinkingLevel != null)
+      'thinking_level': interactionThinkingLevelToString(thinkingLevel!),
+    if (thinkingSummaries != null)
+      'thinking_summaries': interactionThinkingSummariesToString(
+        thinkingSummaries!,
+      ),
+    if (maxOutputTokens != null) 'max_output_tokens': maxOutputTokens,
+    if (speechConfig != null)
+      'speech_config': speechConfig!.map((e) => e.toJson()).toList(),
+  };
+
+  /// Creates a copy with replaced values.
+  InteractionGenerationConfig copyWith({
+    Object? temperature = unsetCopyWithValue,
+    Object? topP = unsetCopyWithValue,
+    Object? seed = unsetCopyWithValue,
+    Object? stopSequences = unsetCopyWithValue,
+    Object? toolChoice = unsetCopyWithValue,
+    Object? thinkingLevel = unsetCopyWithValue,
+    Object? thinkingSummaries = unsetCopyWithValue,
+    Object? maxOutputTokens = unsetCopyWithValue,
+    Object? speechConfig = unsetCopyWithValue,
+  }) {
+    return InteractionGenerationConfig(
+      temperature: temperature == unsetCopyWithValue
+          ? this.temperature
+          : temperature as double?,
+      topP: topP == unsetCopyWithValue ? this.topP : topP as double?,
+      seed: seed == unsetCopyWithValue ? this.seed : seed as int?,
+      stopSequences: stopSequences == unsetCopyWithValue
+          ? this.stopSequences
+          : stopSequences as List<String>?,
+      toolChoice: toolChoice == unsetCopyWithValue
+          ? this.toolChoice
+          : toolChoice as InteractionToolChoice?,
+      thinkingLevel: thinkingLevel == unsetCopyWithValue
+          ? this.thinkingLevel
+          : thinkingLevel as InteractionThinkingLevel?,
+      thinkingSummaries: thinkingSummaries == unsetCopyWithValue
+          ? this.thinkingSummaries
+          : thinkingSummaries as InteractionThinkingSummaries?,
+      maxOutputTokens: maxOutputTokens == unsetCopyWithValue
+          ? this.maxOutputTokens
+          : maxOutputTokens as int?,
+      speechConfig: speechConfig == unsetCopyWithValue
+          ? this.speechConfig
+          : speechConfig as List<InteractionSpeechConfig>?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/interaction.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/interaction.dart
@@ -1,0 +1,271 @@
+import '../copy_with_sentinel.dart';
+import 'agent_config.dart';
+import 'generation_config.dart';
+import 'interaction_status.dart';
+import 'response_modality.dart';
+import 'usage.dart';
+
+/// The Interaction resource.
+///
+/// Represents a single interaction with the Gemini API using server-side
+/// state management.
+class Interaction {
+  /// A unique identifier for the interaction.
+  final String id;
+
+  /// The status of the interaction.
+  final InteractionStatus status;
+
+  /// The name of the model used for generating the interaction.
+  final String? model;
+
+  /// The name of the agent used for generating the interaction.
+  final String? agent;
+
+  /// The time at which the interaction was created (ISO 8601 format).
+  final DateTime? created;
+
+  /// The time at which the interaction was last updated (ISO 8601 format).
+  final DateTime? updated;
+
+  /// The role of the interaction response.
+  final String? role;
+
+  /// Output only. Responses from the model.
+  final List<dynamic>? outputs;
+
+  /// Statistics on the interaction request's token usage.
+  final InteractionUsage? usage;
+
+  /// The object type of the interaction. Always 'interaction'.
+  final String object;
+
+  /// The ID of the previous interaction, if any.
+  final String? previousInteractionId;
+
+  /// Creates an [Interaction] instance.
+  const Interaction({
+    required this.id,
+    required this.status,
+    this.model,
+    this.agent,
+    this.created,
+    this.updated,
+    this.role,
+    this.outputs,
+    this.usage,
+    this.object = 'interaction',
+    this.previousInteractionId,
+  });
+
+  /// Creates an [Interaction] from JSON.
+  factory Interaction.fromJson(Map<String, dynamic> json) => Interaction(
+    id: json['id'] as String,
+    status: interactionStatusFromString(json['status'] as String?),
+    model: json['model'] as String?,
+    agent: json['agent'] as String?,
+    created: json['created'] != null
+        ? DateTime.parse(json['created'] as String)
+        : null,
+    updated: json['updated'] != null
+        ? DateTime.parse(json['updated'] as String)
+        : null,
+    role: json['role'] as String?,
+    outputs: json['outputs'] as List<dynamic>?,
+    usage: json['usage'] != null
+        ? InteractionUsage.fromJson(json['usage'] as Map<String, dynamic>)
+        : null,
+    object: json['object'] as String? ?? 'interaction',
+    previousInteractionId: json['previous_interaction_id'] as String?,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'status': interactionStatusToString(status),
+    if (model != null) 'model': model,
+    if (agent != null) 'agent': agent,
+    if (created != null) 'created': created!.toIso8601String(),
+    if (updated != null) 'updated': updated!.toIso8601String(),
+    if (role != null) 'role': role,
+    if (outputs != null) 'outputs': outputs,
+    if (usage != null) 'usage': usage!.toJson(),
+    'object': object,
+    if (previousInteractionId != null)
+      'previous_interaction_id': previousInteractionId,
+  };
+
+  /// Creates a copy with replaced values.
+  Interaction copyWith({
+    Object? id = unsetCopyWithValue,
+    Object? status = unsetCopyWithValue,
+    Object? model = unsetCopyWithValue,
+    Object? agent = unsetCopyWithValue,
+    Object? created = unsetCopyWithValue,
+    Object? updated = unsetCopyWithValue,
+    Object? role = unsetCopyWithValue,
+    Object? outputs = unsetCopyWithValue,
+    Object? usage = unsetCopyWithValue,
+    Object? object = unsetCopyWithValue,
+    Object? previousInteractionId = unsetCopyWithValue,
+  }) {
+    return Interaction(
+      id: id == unsetCopyWithValue ? this.id : id! as String,
+      status: status == unsetCopyWithValue
+          ? this.status
+          : status! as InteractionStatus,
+      model: model == unsetCopyWithValue ? this.model : model as String?,
+      agent: agent == unsetCopyWithValue ? this.agent : agent as String?,
+      created: created == unsetCopyWithValue
+          ? this.created
+          : created as DateTime?,
+      updated: updated == unsetCopyWithValue
+          ? this.updated
+          : updated as DateTime?,
+      role: role == unsetCopyWithValue ? this.role : role as String?,
+      outputs: outputs == unsetCopyWithValue
+          ? this.outputs
+          : outputs as List<dynamic>?,
+      usage: usage == unsetCopyWithValue
+          ? this.usage
+          : usage as InteractionUsage?,
+      object: object == unsetCopyWithValue ? this.object : object! as String,
+      previousInteractionId: previousInteractionId == unsetCopyWithValue
+          ? this.previousInteractionId
+          : previousInteractionId as String?,
+    );
+  }
+}
+
+/// Parameters for creating an interaction with a model.
+class CreateModelInteractionParams {
+  /// The name of the model to use.
+  final String model;
+
+  /// The input for the interaction.
+  ///
+  /// Can be a [String] for simple text, a [List<dynamic>] for multimodal
+  /// content, or a [List<Turn>] for multi-turn conversations.
+  final Object? input;
+
+  /// System instruction for the interaction.
+  final String? systemInstruction;
+
+  /// A list of tool declarations the model may call during interaction.
+  final List<dynamic>? tools;
+
+  /// Configuration parameters for the model interaction.
+  final InteractionGenerationConfig? generationConfig;
+
+  /// The requested modalities of the response.
+  final List<InteractionResponseModality>? responseModalities;
+
+  /// The mime type of the response.
+  final String? responseMimeType;
+
+  /// The ID of a previous interaction to continue from.
+  final String? previousInteractionId;
+
+  /// Whether to run the model interaction in the background.
+  final bool? background;
+
+  /// Creates a [CreateModelInteractionParams] instance.
+  const CreateModelInteractionParams({
+    required this.model,
+    this.input,
+    this.systemInstruction,
+    this.tools,
+    this.generationConfig,
+    this.responseModalities,
+    this.responseMimeType,
+    this.previousInteractionId,
+    this.background,
+  });
+
+  /// Creates from JSON.
+  factory CreateModelInteractionParams.fromJson(Map<String, dynamic> json) =>
+      CreateModelInteractionParams(
+        model: json['model'] as String,
+        input: json['input'],
+        systemInstruction: json['system_instruction'] as String?,
+        tools: json['tools'] as List<dynamic>?,
+        generationConfig: json['generation_config'] != null
+            ? InteractionGenerationConfig.fromJson(
+                json['generation_config'] as Map<String, dynamic>,
+              )
+            : null,
+        responseModalities: (json['response_modalities'] as List<dynamic>?)
+            ?.map((e) => interactionResponseModalityFromString(e as String))
+            .toList(),
+        responseMimeType: json['response_mime_type'] as String?,
+        previousInteractionId: json['previous_interaction_id'] as String?,
+        background: json['background'] as bool?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'model': model,
+    if (input != null) 'input': input,
+    if (systemInstruction != null) 'system_instruction': systemInstruction,
+    if (tools != null) 'tools': tools,
+    if (generationConfig != null)
+      'generation_config': generationConfig!.toJson(),
+    if (responseModalities != null)
+      'response_modalities': responseModalities!
+          .map(interactionResponseModalityToString)
+          .toList(),
+    if (responseMimeType != null) 'response_mime_type': responseMimeType,
+    if (previousInteractionId != null)
+      'previous_interaction_id': previousInteractionId,
+    if (background != null) 'background': background,
+  };
+}
+
+/// Parameters for creating an interaction with an agent.
+class CreateAgentInteractionParams {
+  /// The name of the agent to use.
+  final String agent;
+
+  /// The input for the interaction.
+  final Object? input;
+
+  /// Configuration for the agent.
+  final AgentConfig? agentConfig;
+
+  /// The ID of a previous interaction to continue from.
+  final String? previousInteractionId;
+
+  /// Whether to run the agent interaction in the background.
+  final bool? background;
+
+  /// Creates a [CreateAgentInteractionParams] instance.
+  const CreateAgentInteractionParams({
+    required this.agent,
+    this.input,
+    this.agentConfig,
+    this.previousInteractionId,
+    this.background,
+  });
+
+  /// Creates from JSON.
+  factory CreateAgentInteractionParams.fromJson(Map<String, dynamic> json) =>
+      CreateAgentInteractionParams(
+        agent: json['agent'] as String,
+        input: json['input'],
+        agentConfig: json['agent_config'] != null
+            ? AgentConfig.fromJson(json['agent_config'] as Map<String, dynamic>)
+            : null,
+        previousInteractionId: json['previous_interaction_id'] as String?,
+        background: json['background'] as bool?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'agent': agent,
+    if (input != null) 'input': input,
+    if (agentConfig != null) 'agent_config': agentConfig!.toJson(),
+    if (previousInteractionId != null)
+      'previous_interaction_id': previousInteractionId,
+    if (background != null) 'background': background,
+  };
+}

--- a/packages/googleai_dart/lib/src/models/interactions/interaction_status.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/interaction_status.dart
@@ -1,0 +1,40 @@
+/// The status of an interaction.
+enum InteractionStatus {
+  /// The interaction is in progress.
+  inProgress,
+
+  /// The interaction requires action from the user.
+  requiresAction,
+
+  /// The interaction has completed successfully.
+  completed,
+
+  /// The interaction has failed.
+  failed,
+
+  /// The interaction was cancelled.
+  cancelled,
+}
+
+/// Converts a string to [InteractionStatus].
+InteractionStatus interactionStatusFromString(String? value) {
+  return switch (value) {
+    'in_progress' => InteractionStatus.inProgress,
+    'requires_action' => InteractionStatus.requiresAction,
+    'completed' => InteractionStatus.completed,
+    'failed' => InteractionStatus.failed,
+    'cancelled' => InteractionStatus.cancelled,
+    _ => InteractionStatus.inProgress,
+  };
+}
+
+/// Converts [InteractionStatus] to a string.
+String interactionStatusToString(InteractionStatus status) {
+  return switch (status) {
+    InteractionStatus.inProgress => 'in_progress',
+    InteractionStatus.requiresAction => 'requires_action',
+    InteractionStatus.completed => 'completed',
+    InteractionStatus.failed => 'failed',
+    InteractionStatus.cancelled => 'cancelled',
+  };
+}

--- a/packages/googleai_dart/lib/src/models/interactions/interactions.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/interactions.dart
@@ -1,0 +1,14 @@
+export 'agent_config.dart';
+export 'allowed_tools.dart';
+export 'generation_config.dart';
+export 'interaction.dart';
+export 'interaction_status.dart';
+export 'modality_tokens.dart';
+export 'response_modality.dart';
+export 'speech_config.dart';
+export 'thinking_level.dart';
+export 'thinking_summaries.dart';
+export 'tool_choice.dart';
+export 'tool_choice_type.dart';
+export 'turn.dart';
+export 'usage.dart';

--- a/packages/googleai_dart/lib/src/models/interactions/modality_tokens.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/modality_tokens.dart
@@ -1,0 +1,42 @@
+import '../copy_with_sentinel.dart';
+import 'response_modality.dart';
+
+/// Token count for a single response modality.
+class ModalityTokens {
+  /// The modality associated with the token count.
+  final InteractionResponseModality? modality;
+
+  /// Number of tokens for the modality.
+  final int? tokens;
+
+  /// Creates a [ModalityTokens] instance.
+  const ModalityTokens({this.modality, this.tokens});
+
+  /// Creates a [ModalityTokens] from JSON.
+  factory ModalityTokens.fromJson(Map<String, dynamic> json) => ModalityTokens(
+    modality: json['modality'] != null
+        ? interactionResponseModalityFromString(json['modality'] as String?)
+        : null,
+    tokens: json['tokens'] as int?,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (modality != null)
+      'modality': interactionResponseModalityToString(modality!),
+    if (tokens != null) 'tokens': tokens,
+  };
+
+  /// Creates a copy with replaced values.
+  ModalityTokens copyWith({
+    Object? modality = unsetCopyWithValue,
+    Object? tokens = unsetCopyWithValue,
+  }) {
+    return ModalityTokens(
+      modality: modality == unsetCopyWithValue
+          ? this.modality
+          : modality as InteractionResponseModality?,
+      tokens: tokens == unsetCopyWithValue ? this.tokens : tokens as int?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/response_modality.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/response_modality.dart
@@ -1,0 +1,34 @@
+/// The modality of a response.
+enum InteractionResponseModality {
+  /// Text response modality.
+  text,
+
+  /// Image response modality.
+  image,
+
+  /// Audio response modality.
+  audio,
+}
+
+/// Converts a string to [InteractionResponseModality].
+InteractionResponseModality interactionResponseModalityFromString(
+  String? value,
+) {
+  return switch (value) {
+    'text' => InteractionResponseModality.text,
+    'image' => InteractionResponseModality.image,
+    'audio' => InteractionResponseModality.audio,
+    _ => InteractionResponseModality.text,
+  };
+}
+
+/// Converts [InteractionResponseModality] to a string.
+String interactionResponseModalityToString(
+  InteractionResponseModality modality,
+) {
+  return switch (modality) {
+    InteractionResponseModality.text => 'text',
+    InteractionResponseModality.image => 'image',
+    InteractionResponseModality.audio => 'audio',
+  };
+}

--- a/packages/googleai_dart/lib/src/models/interactions/speech_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/speech_config.dart
@@ -1,0 +1,48 @@
+import '../copy_with_sentinel.dart';
+
+/// Configuration for speech interaction.
+class InteractionSpeechConfig {
+  /// The voice of the speaker.
+  final String? voice;
+
+  /// The language of the speech.
+  final String? language;
+
+  /// The speaker's name (should match the speaker name in the prompt).
+  final String? speaker;
+
+  /// Creates an [InteractionSpeechConfig] instance.
+  const InteractionSpeechConfig({this.voice, this.language, this.speaker});
+
+  /// Creates an [InteractionSpeechConfig] from JSON.
+  factory InteractionSpeechConfig.fromJson(Map<String, dynamic> json) =>
+      InteractionSpeechConfig(
+        voice: json['voice'] as String?,
+        language: json['language'] as String?,
+        speaker: json['speaker'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (voice != null) 'voice': voice,
+    if (language != null) 'language': language,
+    if (speaker != null) 'speaker': speaker,
+  };
+
+  /// Creates a copy with replaced values.
+  InteractionSpeechConfig copyWith({
+    Object? voice = unsetCopyWithValue,
+    Object? language = unsetCopyWithValue,
+    Object? speaker = unsetCopyWithValue,
+  }) {
+    return InteractionSpeechConfig(
+      voice: voice == unsetCopyWithValue ? this.voice : voice as String?,
+      language: language == unsetCopyWithValue
+          ? this.language
+          : language as String?,
+      speaker: speaker == unsetCopyWithValue
+          ? this.speaker
+          : speaker as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/thinking_level.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/thinking_level.dart
@@ -1,0 +1,35 @@
+/// Controls the level of thought tokens the model should generate.
+enum InteractionThinkingLevel {
+  /// Little to no thinking.
+  minimal,
+
+  /// Low thinking level.
+  low,
+
+  /// Medium thinking level.
+  medium,
+
+  /// High thinking level.
+  high,
+}
+
+/// Converts a string to [InteractionThinkingLevel].
+InteractionThinkingLevel interactionThinkingLevelFromString(String? value) {
+  return switch (value) {
+    'minimal' => InteractionThinkingLevel.minimal,
+    'low' => InteractionThinkingLevel.low,
+    'medium' => InteractionThinkingLevel.medium,
+    'high' => InteractionThinkingLevel.high,
+    _ => InteractionThinkingLevel.medium,
+  };
+}
+
+/// Converts [InteractionThinkingLevel] to a string.
+String interactionThinkingLevelToString(InteractionThinkingLevel level) {
+  return switch (level) {
+    InteractionThinkingLevel.minimal => 'minimal',
+    InteractionThinkingLevel.low => 'low',
+    InteractionThinkingLevel.medium => 'medium',
+    InteractionThinkingLevel.high => 'high',
+  };
+}

--- a/packages/googleai_dart/lib/src/models/interactions/thinking_summaries.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/thinking_summaries.dart
@@ -1,0 +1,29 @@
+/// Controls whether to include thought summaries in the response.
+enum InteractionThinkingSummaries {
+  /// Automatically include thought summaries.
+  auto,
+
+  /// Do not include thought summaries.
+  none,
+}
+
+/// Converts a string to [InteractionThinkingSummaries].
+InteractionThinkingSummaries interactionThinkingSummariesFromString(
+  String? value,
+) {
+  return switch (value) {
+    'auto' => InteractionThinkingSummaries.auto,
+    'none' => InteractionThinkingSummaries.none,
+    _ => InteractionThinkingSummaries.auto,
+  };
+}
+
+/// Converts [InteractionThinkingSummaries] to a string.
+String interactionThinkingSummariesToString(
+  InteractionThinkingSummaries summaries,
+) {
+  return switch (summaries) {
+    InteractionThinkingSummaries.auto => 'auto',
+    InteractionThinkingSummaries.none => 'none',
+  };
+}

--- a/packages/googleai_dart/lib/src/models/interactions/tool_choice.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/tool_choice.dart
@@ -1,0 +1,67 @@
+import '../copy_with_sentinel.dart';
+import 'allowed_tools.dart';
+import 'tool_choice_type.dart';
+
+/// Configuration for tool choice.
+///
+/// Can be either a simple [InteractionToolChoiceType] or a more detailed
+/// [AllowedTools] configuration.
+class InteractionToolChoice {
+  /// Simple tool choice type (auto, any, none, validated).
+  final InteractionToolChoiceType? type;
+
+  /// Detailed configuration for allowed tools.
+  final AllowedTools? allowedTools;
+
+  /// Creates an [InteractionToolChoice] with a type.
+  const InteractionToolChoice.type(this.type) : allowedTools = null;
+
+  /// Creates an [InteractionToolChoice] with allowed tools config.
+  const InteractionToolChoice.config(this.allowedTools) : type = null;
+
+  /// Creates an [InteractionToolChoice] from JSON.
+  factory InteractionToolChoice.fromJson(dynamic json) {
+    if (json is String) {
+      return InteractionToolChoice.type(
+        interactionToolChoiceTypeFromString(json),
+      );
+    } else if (json is Map<String, dynamic>) {
+      if (json.containsKey('allowed_tools')) {
+        return InteractionToolChoice.config(
+          AllowedTools.fromJson(json['allowed_tools'] as Map<String, dynamic>),
+        );
+      }
+    }
+    return const InteractionToolChoice.type(InteractionToolChoiceType.auto);
+  }
+
+  /// Converts to JSON.
+  dynamic toJson() {
+    if (type != null) {
+      return interactionToolChoiceTypeToString(type!);
+    } else if (allowedTools != null) {
+      return {'allowed_tools': allowedTools!.toJson()};
+    }
+    return null;
+  }
+
+  /// Creates a copy with replaced values.
+  InteractionToolChoice copyWith({
+    Object? type = unsetCopyWithValue,
+    Object? allowedTools = unsetCopyWithValue,
+  }) {
+    final newType = type == unsetCopyWithValue
+        ? this.type
+        : type as InteractionToolChoiceType?;
+    final newAllowedTools = allowedTools == unsetCopyWithValue
+        ? this.allowedTools
+        : allowedTools as AllowedTools?;
+
+    if (newType != null) {
+      return InteractionToolChoice.type(newType);
+    } else if (newAllowedTools != null) {
+      return InteractionToolChoice.config(newAllowedTools);
+    }
+    return const InteractionToolChoice.type(InteractionToolChoiceType.auto);
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/tool_choice_type.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/tool_choice_type.dart
@@ -1,0 +1,35 @@
+/// The type of tool choice.
+enum InteractionToolChoiceType {
+  /// The model automatically decides whether to use tools.
+  auto,
+
+  /// The model must use at least one tool.
+  any,
+
+  /// The model must not use any tools.
+  none,
+
+  /// Use only validated tools.
+  validated,
+}
+
+/// Converts a string to [InteractionToolChoiceType].
+InteractionToolChoiceType interactionToolChoiceTypeFromString(String? value) {
+  return switch (value) {
+    'auto' => InteractionToolChoiceType.auto,
+    'any' => InteractionToolChoiceType.any,
+    'none' => InteractionToolChoiceType.none,
+    'validated' => InteractionToolChoiceType.validated,
+    _ => InteractionToolChoiceType.auto,
+  };
+}
+
+/// Converts [InteractionToolChoiceType] to a string.
+String interactionToolChoiceTypeToString(InteractionToolChoiceType type) {
+  return switch (type) {
+    InteractionToolChoiceType.auto => 'auto',
+    InteractionToolChoiceType.any => 'any',
+    InteractionToolChoiceType.none => 'none',
+    InteractionToolChoiceType.validated => 'validated',
+  };
+}

--- a/packages/googleai_dart/lib/src/models/interactions/turn.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/turn.dart
@@ -1,0 +1,41 @@
+import '../copy_with_sentinel.dart';
+
+/// A conversation turn in an interaction.
+class Turn {
+  /// The originator of this turn. Must be 'user' for input or 'model' for
+  /// model output.
+  final String? role;
+
+  /// The content of the turn.
+  ///
+  /// Can be a [String] for simple text content, or a [List<dynamic>] for
+  /// multimodal content (containing Content objects).
+  final Object? content;
+
+  /// Creates a [Turn] instance.
+  const Turn({this.role, this.content});
+
+  /// Creates a [Turn] with text content.
+  const Turn.text({required this.role, required String text}) : content = text;
+
+  /// Creates a [Turn] from JSON.
+  factory Turn.fromJson(Map<String, dynamic> json) =>
+      Turn(role: json['role'] as String?, content: json['content']);
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (role != null) 'role': role,
+    if (content != null) 'content': content,
+  };
+
+  /// Creates a copy with replaced values.
+  Turn copyWith({
+    Object? role = unsetCopyWithValue,
+    Object? content = unsetCopyWithValue,
+  }) {
+    return Turn(
+      role: role == unsetCopyWithValue ? this.role : role as String?,
+      content: content == unsetCopyWithValue ? this.content : content,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/usage.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/usage.dart
@@ -1,0 +1,150 @@
+import '../copy_with_sentinel.dart';
+import 'modality_tokens.dart';
+
+/// Statistics on the interaction request's token usage.
+class InteractionUsage {
+  /// Number of tokens in the prompt (context).
+  final int? totalInputTokens;
+
+  /// A breakdown of input token usage by modality.
+  final List<ModalityTokens>? inputTokensByModality;
+
+  /// Number of tokens in the cached part of the prompt.
+  final int? totalCachedTokens;
+
+  /// A breakdown of cached token usage by modality.
+  final List<ModalityTokens>? cachedTokensByModality;
+
+  /// Total number of tokens across all generated responses.
+  final int? totalOutputTokens;
+
+  /// A breakdown of output token usage by modality.
+  final List<ModalityTokens>? outputTokensByModality;
+
+  /// Number of tokens present in tool-use prompts.
+  final int? totalToolUseTokens;
+
+  /// A breakdown of tool-use token usage by modality.
+  final List<ModalityTokens>? toolUseTokensByModality;
+
+  /// Number of tokens of thoughts for thinking models.
+  final int? totalReasoningTokens;
+
+  /// Total token count for the interaction request.
+  final int? totalTokens;
+
+  /// Creates an [InteractionUsage] instance.
+  const InteractionUsage({
+    this.totalInputTokens,
+    this.inputTokensByModality,
+    this.totalCachedTokens,
+    this.cachedTokensByModality,
+    this.totalOutputTokens,
+    this.outputTokensByModality,
+    this.totalToolUseTokens,
+    this.toolUseTokensByModality,
+    this.totalReasoningTokens,
+    this.totalTokens,
+  });
+
+  /// Creates an [InteractionUsage] from JSON.
+  factory InteractionUsage.fromJson(Map<String, dynamic> json) =>
+      InteractionUsage(
+        totalInputTokens: json['total_input_tokens'] as int?,
+        inputTokensByModality:
+            (json['input_tokens_by_modality'] as List<dynamic>?)
+                ?.map((e) => ModalityTokens.fromJson(e as Map<String, dynamic>))
+                .toList(),
+        totalCachedTokens: json['total_cached_tokens'] as int?,
+        cachedTokensByModality:
+            (json['cached_tokens_by_modality'] as List<dynamic>?)
+                ?.map((e) => ModalityTokens.fromJson(e as Map<String, dynamic>))
+                .toList(),
+        totalOutputTokens: json['total_output_tokens'] as int?,
+        outputTokensByModality:
+            (json['output_tokens_by_modality'] as List<dynamic>?)
+                ?.map((e) => ModalityTokens.fromJson(e as Map<String, dynamic>))
+                .toList(),
+        totalToolUseTokens: json['total_tool_use_tokens'] as int?,
+        toolUseTokensByModality:
+            (json['tool_use_tokens_by_modality'] as List<dynamic>?)
+                ?.map((e) => ModalityTokens.fromJson(e as Map<String, dynamic>))
+                .toList(),
+        totalReasoningTokens: json['total_reasoning_tokens'] as int?,
+        totalTokens: json['total_tokens'] as int?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (totalInputTokens != null) 'total_input_tokens': totalInputTokens,
+    if (inputTokensByModality != null)
+      'input_tokens_by_modality': inputTokensByModality!
+          .map((e) => e.toJson())
+          .toList(),
+    if (totalCachedTokens != null) 'total_cached_tokens': totalCachedTokens,
+    if (cachedTokensByModality != null)
+      'cached_tokens_by_modality': cachedTokensByModality!
+          .map((e) => e.toJson())
+          .toList(),
+    if (totalOutputTokens != null) 'total_output_tokens': totalOutputTokens,
+    if (outputTokensByModality != null)
+      'output_tokens_by_modality': outputTokensByModality!
+          .map((e) => e.toJson())
+          .toList(),
+    if (totalToolUseTokens != null) 'total_tool_use_tokens': totalToolUseTokens,
+    if (toolUseTokensByModality != null)
+      'tool_use_tokens_by_modality': toolUseTokensByModality!
+          .map((e) => e.toJson())
+          .toList(),
+    if (totalReasoningTokens != null)
+      'total_reasoning_tokens': totalReasoningTokens,
+    if (totalTokens != null) 'total_tokens': totalTokens,
+  };
+
+  /// Creates a copy with replaced values.
+  InteractionUsage copyWith({
+    Object? totalInputTokens = unsetCopyWithValue,
+    Object? inputTokensByModality = unsetCopyWithValue,
+    Object? totalCachedTokens = unsetCopyWithValue,
+    Object? cachedTokensByModality = unsetCopyWithValue,
+    Object? totalOutputTokens = unsetCopyWithValue,
+    Object? outputTokensByModality = unsetCopyWithValue,
+    Object? totalToolUseTokens = unsetCopyWithValue,
+    Object? toolUseTokensByModality = unsetCopyWithValue,
+    Object? totalReasoningTokens = unsetCopyWithValue,
+    Object? totalTokens = unsetCopyWithValue,
+  }) {
+    return InteractionUsage(
+      totalInputTokens: totalInputTokens == unsetCopyWithValue
+          ? this.totalInputTokens
+          : totalInputTokens as int?,
+      inputTokensByModality: inputTokensByModality == unsetCopyWithValue
+          ? this.inputTokensByModality
+          : inputTokensByModality as List<ModalityTokens>?,
+      totalCachedTokens: totalCachedTokens == unsetCopyWithValue
+          ? this.totalCachedTokens
+          : totalCachedTokens as int?,
+      cachedTokensByModality: cachedTokensByModality == unsetCopyWithValue
+          ? this.cachedTokensByModality
+          : cachedTokensByModality as List<ModalityTokens>?,
+      totalOutputTokens: totalOutputTokens == unsetCopyWithValue
+          ? this.totalOutputTokens
+          : totalOutputTokens as int?,
+      outputTokensByModality: outputTokensByModality == unsetCopyWithValue
+          ? this.outputTokensByModality
+          : outputTokensByModality as List<ModalityTokens>?,
+      totalToolUseTokens: totalToolUseTokens == unsetCopyWithValue
+          ? this.totalToolUseTokens
+          : totalToolUseTokens as int?,
+      toolUseTokensByModality: toolUseTokensByModality == unsetCopyWithValue
+          ? this.toolUseTokensByModality
+          : toolUseTokensByModality as List<ModalityTokens>?,
+      totalReasoningTokens: totalReasoningTokens == unsetCopyWithValue
+          ? this.totalReasoningTokens
+          : totalReasoningTokens as int?,
+      totalTokens: totalTokens == unsetCopyWithValue
+          ? this.totalTokens
+          : totalTokens as int?,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds core model classes for the Interactions API (experimental):

- `Interaction` - Main response type with id, status, outputs, usage
- `InteractionStatus` - Enum for interaction states (in_progress, completed, failed, etc.)
- `InteractionUsage` - Token usage tracking with modality breakdown
- `Turn` - Conversation turn with role and content
- `InteractionGenerationConfig` - Generation parameters for interactions
- `InteractionSpeechConfig` - Speech configuration
- `InteractionThinkingLevel` - Thinking budget levels
- `InteractionThinkingSummaries` - Thinking summary options
- `InteractionToolChoice` - Tool selection configuration
- `InteractionToolChoiceType` - Tool choice modes
- `AllowedTools` - Tool filtering configuration
- `ResponseModality` - Output modality options
- `ModalityTokens` - Token counts by modality
- `AgentConfig` - Sealed class for agent configurations

## Test plan
- [x] `dart analyze` passes
- [x] `dart test test/unit/` passes

Part 2/8 of the Interactions API implementation stack.