### PR TITLE
docs(googleai_dart): Add Interactions API docs and example

### DIFF
--- a/packages/googleai_dart/README.md
+++ b/packages/googleai_dart/README.md
@@ -105,6 +105,16 @@ Unofficial Dart client for the **[Google AI Gemini Developer API](https://ai.goo
 - ✅ Batch management (list, get, update, delete, cancel)
 - ✅ LRO polling for async batch jobs
 
+#### Interactions API (Experimental)
+
+- ✅ Server-side conversation state management
+- ✅ Multi-turn conversations with `previousInteractionId`
+- ✅ Streaming responses with SSE events
+- ✅ Function calling with automatic result handling
+- ✅ Agent support (e.g., Deep Research)
+- ✅ 17 content types (text, image, audio, function calls, etc.)
+- ✅ Background interactions with cancel support
+
 ### Quick Comparison
 
 | Aspect | Google AI | Vertex AI |
@@ -1047,6 +1057,7 @@ See the [`example/`](example/) directory for comprehensive examples:
 17. **[api_versions_example.dart](example/api_versions_example.dart)** - Using v1 (stable) vs v1beta (beta)
 18. **[vertex_ai_example.dart](example/vertex_ai_example.dart)** - Using Vertex AI with OAuth authentication
 19. **[complete_api_example.dart](example/complete_api_example.dart)** - Demonstrating 100% API coverage
+20. **[interactions_example.dart](example/interactions_example.dart)** - Interactions API for server-side state management (experimental)
 
 ## API Coverage
 
@@ -1096,6 +1107,14 @@ This client implements **78 endpoints** covering **100% of all non-deprecated Ge
 - **Document Operations**: importFile, uploadToFileSearchStore
 - **Document Management**: documents.list, documents.get, documents.delete
 - **Operations**: getOperation, getUploadOperation
+
+### Interactions Resource (`client.interactions`) - Experimental
+
+- **Creation**: create, createWithAgent, createStream
+- **Management**: get, cancel, delete
+- **Streaming**: createStream, resumeStream (SSE with event types)
+- **Content Types**: 17 types including text, image, audio, function calls, code execution, etc.
+- **Events**: InteractionStart, ContentDelta, ContentStop, InteractionComplete, Error
 
 ### Universal Operations
 

--- a/packages/googleai_dart/example/interactions_example.dart
+++ b/packages/googleai_dart/example/interactions_example.dart
@@ -1,0 +1,205 @@
+// ignore_for_file: avoid_print
+/// Demonstrates the Interactions API for server-side state management.
+///
+/// The Interactions API is an experimental API that provides:
+/// - Server-side conversation state management
+/// - Multi-turn conversations with managed context
+/// - Streaming responses with SSE events
+/// - Function calling with automatic result handling
+/// - Agent support (e.g., Deep Research)
+library;
+
+import 'package:googleai_dart/googleai_dart.dart';
+
+void main() async {
+  final client = GoogleAIClient(
+    config: const GoogleAIConfig(authProvider: ApiKeyProvider('YOUR_API_KEY')),
+  );
+
+  try {
+    // Example 1: Simple interaction (non-streaming)
+    await simpleInteraction(client);
+
+    // Example 2: Streaming interaction
+    await streamingInteraction(client);
+
+    // Example 3: Multi-turn conversation
+    await multiTurnConversation(client);
+
+    // Example 4: Function calling with interactions
+    await functionCallingInteraction(client);
+  } finally {
+    client.close();
+  }
+}
+
+/// Simple non-streaming interaction
+Future<void> simpleInteraction(GoogleAIClient client) async {
+  print('=== Simple Interaction ===\n');
+
+  final interaction = await client.interactions.create(
+    model: 'gemini-2.5-flash',
+    input: 'What is the capital of France?',
+  );
+
+  print('Status: ${interaction.status}');
+  print('Model: ${interaction.model}');
+
+  // Extract text from outputs
+  if (interaction.outputs != null) {
+    for (final output in interaction.outputs!) {
+      if (output is TextContent) {
+        print('Response: ${output.text}');
+      }
+    }
+  }
+
+  // Check usage
+  if (interaction.usage != null) {
+    print('Input tokens: ${interaction.usage!.totalInputTokens}');
+    print('Output tokens: ${interaction.usage!.totalOutputTokens}');
+  }
+
+  print('');
+}
+
+/// Streaming interaction with real-time events
+Future<void> streamingInteraction(GoogleAIClient client) async {
+  print('=== Streaming Interaction ===\n');
+
+  await for (final event in client.interactions.createStream(
+    model: 'gemini-2.5-flash',
+    input: 'Write a haiku about programming.',
+  )) {
+    switch (event) {
+      case InteractionStartEvent():
+        print('Stream started: ${event.interaction?.id}');
+      case ContentDeltaEvent():
+        // Handle incremental content updates
+        final delta = event.delta;
+        if (delta is TextDelta) {
+          // Print text as it streams in
+          print(delta.text);
+        }
+      case ContentStopEvent():
+        print('\nContent block completed (index: ${event.index})');
+      case InteractionCompleteEvent():
+        print('Stream completed');
+        print('Total tokens: ${event.interaction?.usage?.totalTokens}');
+      case ErrorEvent():
+        print('Error: ${event.error?.message}');
+      default:
+        // Handle other event types as needed
+        break;
+    }
+  }
+
+  print('');
+}
+
+/// Multi-turn conversation using previousInteractionId
+Future<void> multiTurnConversation(GoogleAIClient client) async {
+  print('=== Multi-turn Conversation ===\n');
+
+  // First turn
+  final turn1 = await client.interactions.create(
+    model: 'gemini-2.5-flash',
+    input: 'My name is Alice.',
+  );
+  print('Turn 1 - User: My name is Alice.');
+  _printTextOutputs(turn1);
+
+  // Second turn - references the first interaction
+  final turn2 = await client.interactions.create(
+    model: 'gemini-2.5-flash',
+    input: 'What is my name?',
+    previousInteractionId: turn1.id,
+  );
+  print('Turn 2 - User: What is my name?');
+  _printTextOutputs(turn2);
+
+  print('');
+}
+
+/// Function calling with the Interactions API
+Future<void> functionCallingInteraction(GoogleAIClient client) async {
+  print('=== Function Calling Interaction ===\n');
+
+  // Define a function tool
+  const tools = [
+    FunctionTool(
+      name: 'get_weather',
+      description: 'Get the current weather for a location',
+      parameters: {
+        'type': 'object',
+        'properties': {
+          'location': {
+            'type': 'string',
+            'description': 'The city name',
+          },
+        },
+        'required': ['location'],
+      },
+    ),
+  ];
+
+  // Stream the interaction to see function calls in real-time
+  await for (final event in client.interactions.createStream(
+    model: 'gemini-2.5-flash',
+    input: 'What is the weather in Paris?',
+    tools: tools,
+  )) {
+    switch (event) {
+      case ContentStartEvent():
+        // Content is starting - could be text or function call
+        final content = event.content;
+        if (content != null) {
+          print('Content starting: ${content.type}');
+        }
+      case ContentDeltaEvent():
+        final delta = event.delta;
+        if (delta is TextDelta) {
+          print('Text: ${delta.text}');
+        } else if (delta is FunctionCallDelta) {
+          // Function call arguments arrive incrementally
+          if (delta.name != null) {
+            print('Function: ${delta.name}');
+          }
+          if (delta.arguments != null) {
+            print('Arguments: ${delta.arguments}');
+          }
+        }
+      case InteractionCompleteEvent():
+        print('Interaction complete');
+        // Check if we need to handle function results
+        if (event.interaction?.status == InteractionStatus.requiresAction) {
+          print('Action required: execute function and continue');
+        }
+        // Check for function calls in the final output
+        final outputs = event.interaction?.outputs;
+        if (outputs != null) {
+          for (final output in outputs) {
+            if (output is FunctionCallContent) {
+              print('Function call: ${output.name}');
+              print('Arguments: ${output.arguments}');
+            }
+          }
+        }
+      default:
+        break;
+    }
+  }
+
+  print('');
+}
+
+/// Helper to print text outputs from an interaction
+void _printTextOutputs(Interaction interaction) {
+  if (interaction.outputs != null) {
+    for (final output in interaction.outputs!) {
+      if (output is TextContent) {
+        print('Assistant: ${output.text}');
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds documentation and example for the Interactions API:

### New Example
- `interactions_example.dart` - Comprehensive example with 4 usage patterns:
  - Simple non-streaming interaction
  - Streaming with real-time events
  - Multi-turn conversation with `previousInteractionId`
  - Function calling with tool definitions

### README Updates
- Added Interactions API to Features section (under "Google AI Only")
- Added Interactions Resource to API Coverage section
- Added example to Examples list

## Test plan
- [x] `dart analyze example/interactions_example.dart` passes
- [x] Example code compiles

Part 9/9 of the Interactions API implementation stack.