### PR TITLE
feat(googleai_dart): Add Interactions API content types

### DIFF
--- a/packages/googleai_dart/lib/src/models/interactions/content/annotation.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/annotation.dart
@@ -1,0 +1,49 @@
+part of 'content.dart';
+
+/// Citation information for model-generated content.
+class Annotation {
+  /// Start of segment of the response that is attributed to this source.
+  /// Index indicates the start of the segment, measured in bytes.
+  final int? startIndex;
+
+  /// End of the attributed segment, exclusive.
+  final int? endIndex;
+
+  /// Source attributed for a portion of the text. Could be a URL, title, or
+  /// other identifier.
+  final String? source;
+
+  /// Creates an [Annotation] instance.
+  const Annotation({this.startIndex, this.endIndex, this.source});
+
+  /// Creates an [Annotation] from JSON.
+  factory Annotation.fromJson(Map<String, dynamic> json) => Annotation(
+    startIndex: json['start_index'] as int?,
+    endIndex: json['end_index'] as int?,
+    source: json['source'] as String?,
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (startIndex != null) 'start_index': startIndex,
+    if (endIndex != null) 'end_index': endIndex,
+    if (source != null) 'source': source,
+  };
+
+  /// Creates a copy with replaced values.
+  Annotation copyWith({
+    Object? startIndex = unsetCopyWithValue,
+    Object? endIndex = unsetCopyWithValue,
+    Object? source = unsetCopyWithValue,
+  }) {
+    return Annotation(
+      startIndex: startIndex == unsetCopyWithValue
+          ? this.startIndex
+          : startIndex as int?,
+      endIndex: endIndex == unsetCopyWithValue
+          ? this.endIndex
+          : endIndex as int?,
+      source: source == unsetCopyWithValue ? this.source : source as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/audio_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/audio_content.dart
@@ -1,0 +1,49 @@
+part of 'content.dart';
+
+/// An audio content block.
+class AudioContent extends InteractionContent {
+  @override
+  String get type => 'audio';
+
+  /// Base64-encoded audio data.
+  final String? data;
+
+  /// URI of the audio.
+  final String? uri;
+
+  /// The MIME type of the audio.
+  final String? mimeType;
+
+  /// Creates an [AudioContent] instance.
+  const AudioContent({this.data, this.uri, this.mimeType});
+
+  /// Creates an [AudioContent] from JSON.
+  factory AudioContent.fromJson(Map<String, dynamic> json) => AudioContent(
+    data: json['data'] as String?,
+    uri: json['uri'] as String?,
+    mimeType: json['mime_type'] as String?,
+  );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (data != null) 'data': data,
+    if (uri != null) 'uri': uri,
+    if (mimeType != null) 'mime_type': mimeType,
+  };
+
+  /// Creates a copy with replaced values.
+  AudioContent copyWith({
+    Object? data = unsetCopyWithValue,
+    Object? uri = unsetCopyWithValue,
+    Object? mimeType = unsetCopyWithValue,
+  }) {
+    return AudioContent(
+      data: data == unsetCopyWithValue ? this.data : data as String?,
+      uri: uri == unsetCopyWithValue ? this.uri : uri as String?,
+      mimeType: mimeType == unsetCopyWithValue
+          ? this.mimeType
+          : mimeType as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/code_execution_call_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/code_execution_call_content.dart
@@ -1,0 +1,55 @@
+part of 'content.dart';
+
+/// A code execution call content block.
+class CodeExecutionCallContent extends InteractionContent {
+  @override
+  String get type => 'code_execution_call';
+
+  /// A unique ID for this specific tool call.
+  final String? id;
+
+  /// The programming language of the code.
+  final String? language;
+
+  /// The code to execute.
+  final String? code;
+
+  /// Creates a [CodeExecutionCallContent] instance.
+  const CodeExecutionCallContent({this.id, this.language, this.code});
+
+  /// Creates a [CodeExecutionCallContent] from JSON.
+  factory CodeExecutionCallContent.fromJson(Map<String, dynamic> json) {
+    final arguments = json['arguments'] as Map<String, dynamic>?;
+    return CodeExecutionCallContent(
+      id: json['id'] as String?,
+      language: arguments?['language'] as String?,
+      code: arguments?['code'] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (id != null) 'id': id,
+    if (language != null || code != null)
+      'arguments': {
+        if (language != null) 'language': language,
+        if (code != null) 'code': code,
+      },
+  };
+
+  /// Creates a copy with replaced values.
+  CodeExecutionCallContent copyWith({
+    Object? id = unsetCopyWithValue,
+    Object? language = unsetCopyWithValue,
+    Object? code = unsetCopyWithValue,
+  }) {
+    return CodeExecutionCallContent(
+      id: id == unsetCopyWithValue ? this.id : id as String?,
+      language: language == unsetCopyWithValue
+          ? this.language
+          : language as String?,
+      code: code == unsetCopyWithValue ? this.code : code as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/code_execution_result_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/code_execution_result_content.dart
@@ -1,0 +1,62 @@
+part of 'content.dart';
+
+/// A code execution result content block.
+class CodeExecutionResultContent extends InteractionContent {
+  @override
+  String get type => 'code_execution_result';
+
+  /// ID to match the ID from the code execution call block.
+  final String? callId;
+
+  /// The output of the code execution.
+  final String? result;
+
+  /// Whether the code execution resulted in an error.
+  final bool? isError;
+
+  /// A signature hash for backend validation.
+  final String? signature;
+
+  /// Creates a [CodeExecutionResultContent] instance.
+  const CodeExecutionResultContent({
+    this.callId,
+    this.result,
+    this.isError,
+    this.signature,
+  });
+
+  /// Creates a [CodeExecutionResultContent] from JSON.
+  factory CodeExecutionResultContent.fromJson(Map<String, dynamic> json) =>
+      CodeExecutionResultContent(
+        callId: json['call_id'] as String?,
+        result: json['result'] as String?,
+        isError: json['is_error'] as bool?,
+        signature: json['signature'] as String?,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (callId != null) 'call_id': callId,
+    if (result != null) 'result': result,
+    if (isError != null) 'is_error': isError,
+    if (signature != null) 'signature': signature,
+  };
+
+  /// Creates a copy with replaced values.
+  CodeExecutionResultContent copyWith({
+    Object? callId = unsetCopyWithValue,
+    Object? result = unsetCopyWithValue,
+    Object? isError = unsetCopyWithValue,
+    Object? signature = unsetCopyWithValue,
+  }) {
+    return CodeExecutionResultContent(
+      callId: callId == unsetCopyWithValue ? this.callId : callId as String?,
+      result: result == unsetCopyWithValue ? this.result : result as String?,
+      isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
+      signature: signature == unsetCopyWithValue
+          ? this.signature
+          : signature as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/content.dart
@@ -1,0 +1,59 @@
+import '../../copy_with_sentinel.dart';
+
+part 'annotation.dart';
+part 'audio_content.dart';
+part 'code_execution_call_content.dart';
+part 'code_execution_result_content.dart';
+part 'document_content.dart';
+part 'file_search_result_content.dart';
+part 'function_call_content.dart';
+part 'function_result_content.dart';
+part 'google_search_call_content.dart';
+part 'google_search_result_content.dart';
+part 'image_content.dart';
+part 'mcp_server_tool_call_content.dart';
+part 'mcp_server_tool_result_content.dart';
+part 'text_content.dart';
+part 'thought_content.dart';
+part 'url_context_call_content.dart';
+part 'url_context_result_content.dart';
+part 'video_content.dart';
+
+/// The content of an interaction response.
+///
+/// This is a sealed class with 17 subtypes representing different content
+/// types in the Interactions API.
+sealed class InteractionContent {
+  /// The type discriminator for this content.
+  String get type;
+
+  const InteractionContent();
+
+  /// Creates an [InteractionContent] from JSON.
+  factory InteractionContent.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'text' => TextContent.fromJson(json),
+      'image' => ImageContent.fromJson(json),
+      'audio' => AudioContent.fromJson(json),
+      'document' => DocumentContent.fromJson(json),
+      'video' => VideoContent.fromJson(json),
+      'thought' => ThoughtContent.fromJson(json),
+      'function_call' => FunctionCallContent.fromJson(json),
+      'function_result' => FunctionResultContent.fromJson(json),
+      'code_execution_call' => CodeExecutionCallContent.fromJson(json),
+      'code_execution_result' => CodeExecutionResultContent.fromJson(json),
+      'url_context_call' => UrlContextCallContent.fromJson(json),
+      'url_context_result' => UrlContextResultContent.fromJson(json),
+      'google_search_call' => GoogleSearchCallContent.fromJson(json),
+      'google_search_result' => GoogleSearchResultContent.fromJson(json),
+      'mcp_server_tool_call' => McpServerToolCallContent.fromJson(json),
+      'mcp_server_tool_result' => McpServerToolResultContent.fromJson(json),
+      'file_search_result' => FileSearchResultContent.fromJson(json),
+      _ => throw ArgumentError('Unknown content type: $type'),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/document_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/document_content.dart
@@ -1,0 +1,50 @@
+part of 'content.dart';
+
+/// A document content block.
+class DocumentContent extends InteractionContent {
+  @override
+  String get type => 'document';
+
+  /// Base64-encoded document data.
+  final String? data;
+
+  /// URI of the document.
+  final String? uri;
+
+  /// The MIME type of the document.
+  final String? mimeType;
+
+  /// Creates a [DocumentContent] instance.
+  const DocumentContent({this.data, this.uri, this.mimeType});
+
+  /// Creates a [DocumentContent] from JSON.
+  factory DocumentContent.fromJson(Map<String, dynamic> json) =>
+      DocumentContent(
+        data: json['data'] as String?,
+        uri: json['uri'] as String?,
+        mimeType: json['mime_type'] as String?,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (data != null) 'data': data,
+    if (uri != null) 'uri': uri,
+    if (mimeType != null) 'mime_type': mimeType,
+  };
+
+  /// Creates a copy with replaced values.
+  DocumentContent copyWith({
+    Object? data = unsetCopyWithValue,
+    Object? uri = unsetCopyWithValue,
+    Object? mimeType = unsetCopyWithValue,
+  }) {
+    return DocumentContent(
+      data: data == unsetCopyWithValue ? this.data : data as String?,
+      uri: uri == unsetCopyWithValue ? this.uri : uri as String?,
+      mimeType: mimeType == unsetCopyWithValue
+          ? this.mimeType
+          : mimeType as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/file_search_result_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/file_search_result_content.dart
@@ -1,0 +1,81 @@
+part of 'content.dart';
+
+/// A File Search result content block.
+class FileSearchResultContent extends InteractionContent {
+  @override
+  String get type => 'file_search_result';
+
+  /// The results of the File Search.
+  final List<FileSearchResult>? result;
+
+  /// Creates a [FileSearchResultContent] instance.
+  const FileSearchResultContent({this.result});
+
+  /// Creates a [FileSearchResultContent] from JSON.
+  factory FileSearchResultContent.fromJson(Map<String, dynamic> json) =>
+      FileSearchResultContent(
+        result: (json['result'] as List<dynamic>?)
+            ?.map((e) => FileSearchResult.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (result != null) 'result': result!.map((e) => e.toJson()).toList(),
+  };
+
+  /// Creates a copy with replaced values.
+  FileSearchResultContent copyWith({Object? result = unsetCopyWithValue}) {
+    return FileSearchResultContent(
+      result: result == unsetCopyWithValue
+          ? this.result
+          : result as List<FileSearchResult>?,
+    );
+  }
+}
+
+/// A File Search result item.
+class FileSearchResult {
+  /// The title of the search result.
+  final String? title;
+
+  /// The text of the search result.
+  final String? text;
+
+  /// The name of the file search store.
+  final String? fileSearchStore;
+
+  /// Creates a [FileSearchResult] instance.
+  const FileSearchResult({this.title, this.text, this.fileSearchStore});
+
+  /// Creates a [FileSearchResult] from JSON.
+  factory FileSearchResult.fromJson(Map<String, dynamic> json) =>
+      FileSearchResult(
+        title: json['title'] as String?,
+        text: json['text'] as String?,
+        fileSearchStore: json['file_search_store'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (title != null) 'title': title,
+    if (text != null) 'text': text,
+    if (fileSearchStore != null) 'file_search_store': fileSearchStore,
+  };
+
+  /// Creates a copy with replaced values.
+  FileSearchResult copyWith({
+    Object? title = unsetCopyWithValue,
+    Object? text = unsetCopyWithValue,
+    Object? fileSearchStore = unsetCopyWithValue,
+  }) {
+    return FileSearchResult(
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+      text: text == unsetCopyWithValue ? this.text : text as String?,
+      fileSearchStore: fileSearchStore == unsetCopyWithValue
+          ? this.fileSearchStore
+          : fileSearchStore as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/function_call_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/function_call_content.dart
@@ -1,0 +1,54 @@
+part of 'content.dart';
+
+/// A function tool call content block.
+class FunctionCallContent extends InteractionContent {
+  @override
+  String get type => 'function_call';
+
+  /// A unique ID for this specific tool call.
+  final String id;
+
+  /// The name of the tool to call.
+  final String name;
+
+  /// The arguments to pass to the function.
+  final Map<String, dynamic> arguments;
+
+  /// Creates a [FunctionCallContent] instance.
+  const FunctionCallContent({
+    required this.id,
+    required this.name,
+    required this.arguments,
+  });
+
+  /// Creates a [FunctionCallContent] from JSON.
+  factory FunctionCallContent.fromJson(Map<String, dynamic> json) =>
+      FunctionCallContent(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        arguments: json['arguments'] as Map<String, dynamic>,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'name': name,
+    'arguments': arguments,
+  };
+
+  /// Creates a copy with replaced values.
+  FunctionCallContent copyWith({
+    Object? id = unsetCopyWithValue,
+    Object? name = unsetCopyWithValue,
+    Object? arguments = unsetCopyWithValue,
+  }) {
+    return FunctionCallContent(
+      id: id == unsetCopyWithValue ? this.id : id! as String,
+      name: name == unsetCopyWithValue ? this.name : name! as String,
+      arguments: arguments == unsetCopyWithValue
+          ? this.arguments
+          : arguments! as Map<String, dynamic>,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/function_result_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/function_result_content.dart
@@ -1,0 +1,60 @@
+part of 'content.dart';
+
+/// A function tool result content block.
+class FunctionResultContent extends InteractionContent {
+  @override
+  String get type => 'function_result';
+
+  /// ID to match the ID from the function call block.
+  final String callId;
+
+  /// The result of the tool call.
+  final Object result;
+
+  /// The name of the tool that was called.
+  final String? name;
+
+  /// Whether the tool call resulted in an error.
+  final bool? isError;
+
+  /// Creates a [FunctionResultContent] instance.
+  const FunctionResultContent({
+    required this.callId,
+    required this.result,
+    this.name,
+    this.isError,
+  });
+
+  /// Creates a [FunctionResultContent] from JSON.
+  factory FunctionResultContent.fromJson(Map<String, dynamic> json) =>
+      FunctionResultContent(
+        callId: json['call_id'] as String,
+        result: json['result'] as Object,
+        name: json['name'] as String?,
+        isError: json['is_error'] as bool?,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'call_id': callId,
+    'result': result,
+    if (name != null) 'name': name,
+    if (isError != null) 'is_error': isError,
+  };
+
+  /// Creates a copy with replaced values.
+  FunctionResultContent copyWith({
+    Object? callId = unsetCopyWithValue,
+    Object? result = unsetCopyWithValue,
+    Object? name = unsetCopyWithValue,
+    Object? isError = unsetCopyWithValue,
+  }) {
+    return FunctionResultContent(
+      callId: callId == unsetCopyWithValue ? this.callId : callId! as String,
+      result: result == unsetCopyWithValue ? this.result : result!,
+      name: name == unsetCopyWithValue ? this.name : name as String?,
+      isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/google_search_call_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/google_search_call_content.dart
@@ -1,0 +1,45 @@
+part of 'content.dart';
+
+/// A Google Search call content block.
+class GoogleSearchCallContent extends InteractionContent {
+  @override
+  String get type => 'google_search_call';
+
+  /// A unique ID for this specific tool call.
+  final String? id;
+
+  /// Web search queries for the following-up web search.
+  final List<String>? queries;
+
+  /// Creates a [GoogleSearchCallContent] instance.
+  const GoogleSearchCallContent({this.id, this.queries});
+
+  /// Creates a [GoogleSearchCallContent] from JSON.
+  factory GoogleSearchCallContent.fromJson(Map<String, dynamic> json) {
+    final arguments = json['arguments'] as Map<String, dynamic>?;
+    return GoogleSearchCallContent(
+      id: json['id'] as String?,
+      queries: (arguments?['queries'] as List<dynamic>?)?.cast<String>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (id != null) 'id': id,
+    if (queries != null) 'arguments': {'queries': queries},
+  };
+
+  /// Creates a copy with replaced values.
+  GoogleSearchCallContent copyWith({
+    Object? id = unsetCopyWithValue,
+    Object? queries = unsetCopyWithValue,
+  }) {
+    return GoogleSearchCallContent(
+      id: id == unsetCopyWithValue ? this.id : id as String?,
+      queries: queries == unsetCopyWithValue
+          ? this.queries
+          : queries as List<String>?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/google_search_result_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/google_search_result_content.dart
@@ -1,0 +1,102 @@
+part of 'content.dart';
+
+/// A Google Search result content block.
+class GoogleSearchResultContent extends InteractionContent {
+  @override
+  String get type => 'google_search_result';
+
+  /// ID to match the ID from the Google Search call block.
+  final String? callId;
+
+  /// The results of the Google Search.
+  final List<GoogleSearchResult>? result;
+
+  /// Whether the Google Search resulted in an error.
+  final bool? isError;
+
+  /// The signature of the Google Search result.
+  final String? signature;
+
+  /// Creates a [GoogleSearchResultContent] instance.
+  const GoogleSearchResultContent({
+    this.callId,
+    this.result,
+    this.isError,
+    this.signature,
+  });
+
+  /// Creates a [GoogleSearchResultContent] from JSON.
+  factory GoogleSearchResultContent.fromJson(Map<String, dynamic> json) =>
+      GoogleSearchResultContent(
+        callId: json['call_id'] as String?,
+        result: (json['result'] as List<dynamic>?)
+            ?.map((e) => GoogleSearchResult.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        isError: json['is_error'] as bool?,
+        signature: json['signature'] as String?,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (callId != null) 'call_id': callId,
+    if (result != null) 'result': result!.map((e) => e.toJson()).toList(),
+    if (isError != null) 'is_error': isError,
+    if (signature != null) 'signature': signature,
+  };
+
+  /// Creates a copy with replaced values.
+  GoogleSearchResultContent copyWith({
+    Object? callId = unsetCopyWithValue,
+    Object? result = unsetCopyWithValue,
+    Object? isError = unsetCopyWithValue,
+    Object? signature = unsetCopyWithValue,
+  }) {
+    return GoogleSearchResultContent(
+      callId: callId == unsetCopyWithValue ? this.callId : callId as String?,
+      result: result == unsetCopyWithValue
+          ? this.result
+          : result as List<GoogleSearchResult>?,
+      isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
+      signature: signature == unsetCopyWithValue
+          ? this.signature
+          : signature as String?,
+    );
+  }
+}
+
+/// A Google Search result item.
+class GoogleSearchResult {
+  /// The URL of the search result.
+  final String? url;
+
+  /// The title of the search result.
+  final String? title;
+
+  /// Creates a [GoogleSearchResult] instance.
+  const GoogleSearchResult({this.url, this.title});
+
+  /// Creates a [GoogleSearchResult] from JSON.
+  factory GoogleSearchResult.fromJson(Map<String, dynamic> json) =>
+      GoogleSearchResult(
+        url: json['url'] as String?,
+        title: json['title'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (url != null) 'url': url,
+    if (title != null) 'title': title,
+  };
+
+  /// Creates a copy with replaced values.
+  GoogleSearchResult copyWith({
+    Object? url = unsetCopyWithValue,
+    Object? title = unsetCopyWithValue,
+  }) {
+    return GoogleSearchResult(
+      url: url == unsetCopyWithValue ? this.url : url as String?,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/image_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/image_content.dart
@@ -1,0 +1,58 @@
+part of 'content.dart';
+
+/// An image content block.
+class ImageContent extends InteractionContent {
+  @override
+  String get type => 'image';
+
+  /// Base64-encoded image data.
+  final String? data;
+
+  /// URI of the image.
+  final String? uri;
+
+  /// The MIME type of the image.
+  final String? mimeType;
+
+  /// The resolution of the media.
+  final String? resolution;
+
+  /// Creates an [ImageContent] instance.
+  const ImageContent({this.data, this.uri, this.mimeType, this.resolution});
+
+  /// Creates an [ImageContent] from JSON.
+  factory ImageContent.fromJson(Map<String, dynamic> json) => ImageContent(
+    data: json['data'] as String?,
+    uri: json['uri'] as String?,
+    mimeType: json['mime_type'] as String?,
+    resolution: json['resolution'] as String?,
+  );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (data != null) 'data': data,
+    if (uri != null) 'uri': uri,
+    if (mimeType != null) 'mime_type': mimeType,
+    if (resolution != null) 'resolution': resolution,
+  };
+
+  /// Creates a copy with replaced values.
+  ImageContent copyWith({
+    Object? data = unsetCopyWithValue,
+    Object? uri = unsetCopyWithValue,
+    Object? mimeType = unsetCopyWithValue,
+    Object? resolution = unsetCopyWithValue,
+  }) {
+    return ImageContent(
+      data: data == unsetCopyWithValue ? this.data : data as String?,
+      uri: uri == unsetCopyWithValue ? this.uri : uri as String?,
+      mimeType: mimeType == unsetCopyWithValue
+          ? this.mimeType
+          : mimeType as String?,
+      resolution: resolution == unsetCopyWithValue
+          ? this.resolution
+          : resolution as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/mcp_server_tool_call_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/mcp_server_tool_call_content.dart
@@ -1,0 +1,64 @@
+part of 'content.dart';
+
+/// An MCP Server tool call content block.
+class McpServerToolCallContent extends InteractionContent {
+  @override
+  String get type => 'mcp_server_tool_call';
+
+  /// A unique ID for this specific tool call.
+  final String id;
+
+  /// The name of the tool which was called.
+  final String name;
+
+  /// The name of the used MCP server.
+  final String serverName;
+
+  /// The JSON object of arguments for the function.
+  final Map<String, dynamic> arguments;
+
+  /// Creates a [McpServerToolCallContent] instance.
+  const McpServerToolCallContent({
+    required this.id,
+    required this.name,
+    required this.serverName,
+    required this.arguments,
+  });
+
+  /// Creates a [McpServerToolCallContent] from JSON.
+  factory McpServerToolCallContent.fromJson(Map<String, dynamic> json) =>
+      McpServerToolCallContent(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        serverName: json['server_name'] as String,
+        arguments: json['arguments'] as Map<String, dynamic>,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'name': name,
+    'server_name': serverName,
+    'arguments': arguments,
+  };
+
+  /// Creates a copy with replaced values.
+  McpServerToolCallContent copyWith({
+    Object? id = unsetCopyWithValue,
+    Object? name = unsetCopyWithValue,
+    Object? serverName = unsetCopyWithValue,
+    Object? arguments = unsetCopyWithValue,
+  }) {
+    return McpServerToolCallContent(
+      id: id == unsetCopyWithValue ? this.id : id! as String,
+      name: name == unsetCopyWithValue ? this.name : name! as String,
+      serverName: serverName == unsetCopyWithValue
+          ? this.serverName
+          : serverName! as String,
+      arguments: arguments == unsetCopyWithValue
+          ? this.arguments
+          : arguments! as Map<String, dynamic>,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/mcp_server_tool_result_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/mcp_server_tool_result_content.dart
@@ -1,0 +1,70 @@
+part of 'content.dart';
+
+/// An MCP Server tool result content block.
+class McpServerToolResultContent extends InteractionContent {
+  @override
+  String get type => 'mcp_server_tool_result';
+
+  /// ID to match the ID from the MCP server tool call block.
+  final String? callId;
+
+  /// Name of the tool which is called for this specific tool call.
+  final String? name;
+
+  /// The name of the used MCP server.
+  final String? serverName;
+
+  /// The result of the tool call.
+  final Object? result;
+
+  /// Whether the tool call resulted in an error.
+  final bool? isError;
+
+  /// Creates a [McpServerToolResultContent] instance.
+  const McpServerToolResultContent({
+    this.callId,
+    this.name,
+    this.serverName,
+    this.result,
+    this.isError,
+  });
+
+  /// Creates a [McpServerToolResultContent] from JSON.
+  factory McpServerToolResultContent.fromJson(Map<String, dynamic> json) =>
+      McpServerToolResultContent(
+        callId: json['call_id'] as String?,
+        name: json['name'] as String?,
+        serverName: json['server_name'] as String?,
+        result: json['result'],
+        isError: json['is_error'] as bool?,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (callId != null) 'call_id': callId,
+    if (name != null) 'name': name,
+    if (serverName != null) 'server_name': serverName,
+    if (result != null) 'result': result,
+    if (isError != null) 'is_error': isError,
+  };
+
+  /// Creates a copy with replaced values.
+  McpServerToolResultContent copyWith({
+    Object? callId = unsetCopyWithValue,
+    Object? name = unsetCopyWithValue,
+    Object? serverName = unsetCopyWithValue,
+    Object? result = unsetCopyWithValue,
+    Object? isError = unsetCopyWithValue,
+  }) {
+    return McpServerToolResultContent(
+      callId: callId == unsetCopyWithValue ? this.callId : callId as String?,
+      name: name == unsetCopyWithValue ? this.name : name as String?,
+      serverName: serverName == unsetCopyWithValue
+          ? this.serverName
+          : serverName as String?,
+      result: result == unsetCopyWithValue ? this.result : result,
+      isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/text_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/text_content.dart
@@ -1,0 +1,45 @@
+part of 'content.dart';
+
+/// A text content block.
+class TextContent extends InteractionContent {
+  @override
+  String get type => 'text';
+
+  /// The text content.
+  final String? text;
+
+  /// Citation information for model-generated content.
+  final List<Annotation>? annotations;
+
+  /// Creates a [TextContent] instance.
+  const TextContent({this.text, this.annotations});
+
+  /// Creates a [TextContent] from JSON.
+  factory TextContent.fromJson(Map<String, dynamic> json) => TextContent(
+    text: json['text'] as String?,
+    annotations: (json['annotations'] as List<dynamic>?)
+        ?.map((e) => Annotation.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (text != null) 'text': text,
+    if (annotations != null)
+      'annotations': annotations!.map((e) => e.toJson()).toList(),
+  };
+
+  /// Creates a copy with replaced values.
+  TextContent copyWith({
+    Object? text = unsetCopyWithValue,
+    Object? annotations = unsetCopyWithValue,
+  }) {
+    return TextContent(
+      text: text == unsetCopyWithValue ? this.text : text as String?,
+      annotations: annotations == unsetCopyWithValue
+          ? this.annotations
+          : annotations as List<Annotation>?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/thought_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/thought_content.dart
@@ -1,0 +1,44 @@
+part of 'content.dart';
+
+/// A thought content block.
+class ThoughtContent extends InteractionContent {
+  @override
+  String get type => 'thought';
+
+  /// Signature to match the backend source to be part of the generation.
+  final String? signature;
+
+  /// A summary of the thought.
+  final List<dynamic>? summary;
+
+  /// Creates a [ThoughtContent] instance.
+  const ThoughtContent({this.signature, this.summary});
+
+  /// Creates a [ThoughtContent] from JSON.
+  factory ThoughtContent.fromJson(Map<String, dynamic> json) => ThoughtContent(
+    signature: json['signature'] as String?,
+    summary: json['summary'] as List<dynamic>?,
+  );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (signature != null) 'signature': signature,
+    if (summary != null) 'summary': summary,
+  };
+
+  /// Creates a copy with replaced values.
+  ThoughtContent copyWith({
+    Object? signature = unsetCopyWithValue,
+    Object? summary = unsetCopyWithValue,
+  }) {
+    return ThoughtContent(
+      signature: signature == unsetCopyWithValue
+          ? this.signature
+          : signature as String?,
+      summary: summary == unsetCopyWithValue
+          ? this.summary
+          : summary as List<dynamic>?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/url_context_call_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/url_context_call_content.dart
@@ -1,0 +1,43 @@
+part of 'content.dart';
+
+/// A URL context call content block.
+class UrlContextCallContent extends InteractionContent {
+  @override
+  String get type => 'url_context_call';
+
+  /// A unique ID for this specific tool call.
+  final String? id;
+
+  /// The URLs to fetch.
+  final List<String>? urls;
+
+  /// Creates a [UrlContextCallContent] instance.
+  const UrlContextCallContent({this.id, this.urls});
+
+  /// Creates a [UrlContextCallContent] from JSON.
+  factory UrlContextCallContent.fromJson(Map<String, dynamic> json) {
+    final arguments = json['arguments'] as Map<String, dynamic>?;
+    return UrlContextCallContent(
+      id: json['id'] as String?,
+      urls: (arguments?['urls'] as List<dynamic>?)?.cast<String>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (id != null) 'id': id,
+    if (urls != null) 'arguments': {'urls': urls},
+  };
+
+  /// Creates a copy with replaced values.
+  UrlContextCallContent copyWith({
+    Object? id = unsetCopyWithValue,
+    Object? urls = unsetCopyWithValue,
+  }) {
+    return UrlContextCallContent(
+      id: id == unsetCopyWithValue ? this.id : id as String?,
+      urls: urls == unsetCopyWithValue ? this.urls : urls as List<String>?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/url_context_result_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/url_context_result_content.dart
@@ -1,0 +1,102 @@
+part of 'content.dart';
+
+/// A URL context result content block.
+class UrlContextResultContent extends InteractionContent {
+  @override
+  String get type => 'url_context_result';
+
+  /// ID to match the ID from the URL context call block.
+  final String? callId;
+
+  /// The results of the URL context.
+  final List<UrlContextResult>? result;
+
+  /// Whether the URL context resulted in an error.
+  final bool? isError;
+
+  /// The signature of the URL context result.
+  final String? signature;
+
+  /// Creates a [UrlContextResultContent] instance.
+  const UrlContextResultContent({
+    this.callId,
+    this.result,
+    this.isError,
+    this.signature,
+  });
+
+  /// Creates a [UrlContextResultContent] from JSON.
+  factory UrlContextResultContent.fromJson(Map<String, dynamic> json) =>
+      UrlContextResultContent(
+        callId: json['call_id'] as String?,
+        result: (json['result'] as List<dynamic>?)
+            ?.map((e) => UrlContextResult.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        isError: json['is_error'] as bool?,
+        signature: json['signature'] as String?,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (callId != null) 'call_id': callId,
+    if (result != null) 'result': result!.map((e) => e.toJson()).toList(),
+    if (isError != null) 'is_error': isError,
+    if (signature != null) 'signature': signature,
+  };
+
+  /// Creates a copy with replaced values.
+  UrlContextResultContent copyWith({
+    Object? callId = unsetCopyWithValue,
+    Object? result = unsetCopyWithValue,
+    Object? isError = unsetCopyWithValue,
+    Object? signature = unsetCopyWithValue,
+  }) {
+    return UrlContextResultContent(
+      callId: callId == unsetCopyWithValue ? this.callId : callId as String?,
+      result: result == unsetCopyWithValue
+          ? this.result
+          : result as List<UrlContextResult>?,
+      isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
+      signature: signature == unsetCopyWithValue
+          ? this.signature
+          : signature as String?,
+    );
+  }
+}
+
+/// A URL context result item.
+class UrlContextResult {
+  /// The URL that was fetched.
+  final String? url;
+
+  /// The status of the URL fetch.
+  final String? status;
+
+  /// Creates a [UrlContextResult] instance.
+  const UrlContextResult({this.url, this.status});
+
+  /// Creates a [UrlContextResult] from JSON.
+  factory UrlContextResult.fromJson(Map<String, dynamic> json) =>
+      UrlContextResult(
+        url: json['url'] as String?,
+        status: json['status'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (url != null) 'url': url,
+    if (status != null) 'status': status,
+  };
+
+  /// Creates a copy with replaced values.
+  UrlContextResult copyWith({
+    Object? url = unsetCopyWithValue,
+    Object? status = unsetCopyWithValue,
+  }) {
+    return UrlContextResult(
+      url: url == unsetCopyWithValue ? this.url : url as String?,
+      status: status == unsetCopyWithValue ? this.status : status as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/content/video_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/video_content.dart
@@ -1,0 +1,58 @@
+part of 'content.dart';
+
+/// A video content block.
+class VideoContent extends InteractionContent {
+  @override
+  String get type => 'video';
+
+  /// Base64-encoded video data.
+  final String? data;
+
+  /// URI of the video.
+  final String? uri;
+
+  /// The MIME type of the video.
+  final String? mimeType;
+
+  /// The resolution of the media.
+  final String? resolution;
+
+  /// Creates a [VideoContent] instance.
+  const VideoContent({this.data, this.uri, this.mimeType, this.resolution});
+
+  /// Creates a [VideoContent] from JSON.
+  factory VideoContent.fromJson(Map<String, dynamic> json) => VideoContent(
+    data: json['data'] as String?,
+    uri: json['uri'] as String?,
+    mimeType: json['mime_type'] as String?,
+    resolution: json['resolution'] as String?,
+  );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (data != null) 'data': data,
+    if (uri != null) 'uri': uri,
+    if (mimeType != null) 'mime_type': mimeType,
+    if (resolution != null) 'resolution': resolution,
+  };
+
+  /// Creates a copy with replaced values.
+  VideoContent copyWith({
+    Object? data = unsetCopyWithValue,
+    Object? uri = unsetCopyWithValue,
+    Object? mimeType = unsetCopyWithValue,
+    Object? resolution = unsetCopyWithValue,
+  }) {
+    return VideoContent(
+      data: data == unsetCopyWithValue ? this.data : data as String?,
+      uri: uri == unsetCopyWithValue ? this.uri : uri as String?,
+      mimeType: mimeType == unsetCopyWithValue
+          ? this.mimeType
+          : mimeType as String?,
+      resolution: resolution == unsetCopyWithValue
+          ? this.resolution
+          : resolution as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/interactions.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/interactions.dart
@@ -1,5 +1,6 @@
 export 'agent_config.dart';
 export 'allowed_tools.dart';
+export 'content/content.dart';
 export 'generation_config.dart';
 export 'interaction.dart';
 export 'interaction_status.dart';


### PR DESCRIPTION
Add content type sealed class with 17 subtypes for the Interactions API.