### PR TITLE
feat(langchain_firebase): Migrate to firebase_ai and add Google AI backend support

### DIFF
--- a/docs/modules/model_io/models/chat_models/integrations/firebase_vertex_ai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/firebase_vertex_ai.md
@@ -1,13 +1,20 @@
-# Vertex AI for Firebase
+# Firebase AI (Vertex AI / Google AI)
 
-The [Vertex AI Gemini API](https://firebase.google.com/docs/vertex-ai) gives you access to the latest generative AI models from Google: the Gemini models. If you need to call the Vertex AI Gemini API directly from your mobile or web app you can use the `ChatFirebaseVertexAI` class instead of the [`ChatVertexAI`](/modules/model_io/models/chat_models/integrations/gcp_vertex_ai.md) class which is designed to be used on the server-side. 
+The [Firebase AI Logic](https://firebase.google.com/docs/ai-logic) gives you access to the latest generative AI models from Google: the Gemini models. If you need to call the Gemini API directly from your mobile or web app you can use the `ChatFirebaseVertexAI` class instead of the [`ChatVertexAI`](/modules/model_io/models/chat_models/integrations/gcp_vertex_ai.md) class which is designed to be used on the server-side.
 
 `ChatFirebaseVertexAI` is built specifically for use with mobile and web apps, offering security options against unauthorized clients as well as integrations with other Firebase services.
+
+## Supported Backends
+
+`ChatFirebaseVertexAI` supports two backends:
+
+- **Vertex AI** (default): Requires Blaze plan (pay-as-you-go). Best for production use.
+- **Google AI**: Available on free Spark plan. Good for development and testing.
 
 ## Key capabilities
 
 - **Multimodal input**: The Gemini models are multimodal, so prompts sent to the Gemini API can include text, images (even PDFs), video, and audio.
-- **Growing suite of capabilities**: You can call the Gemini API directly from your mobile or web app, build an AI chat experience, use function calling, and more. 
+- **Growing suite of capabilities**: You can call the Gemini API directly from your mobile or web app, build an AI chat experience, use function calling, and more.
 - **Security for production apps**: Use Firebase App Check to protect the Vertex AI Gemini API from abuse by unauthorized clients.
 - **Robust infrastructure**: Take advantage of scalable infrastructure that's built for use with mobile and web apps, like managing structured data with Firebase database offerings (like Cloud Firestore) and dynamically setting run-time configurations with Firebase Remote Config.
 
@@ -15,25 +22,30 @@ The [Vertex AI Gemini API](https://firebase.google.com/docs/vertex-ai) gives you
 
 ### 1. Set up a Firebase project
 
-Check the [Firebase documentation](https://firebase.google.com/docs/vertex-ai/get-started?platform=flutter) for the latest information on how to set up the Vertex AI for Firebase in your Firebase project.
+Check the [Firebase documentation](https://firebase.google.com/docs/ai-logic/get-started?platform=flutter) for the latest information on how to set up Firebase AI in your Firebase project.
 
-In summary, you need to:
+**For Vertex AI backend:**
 1. Upgrade your billing plan to the Blaze pay-as-you-go pricing plan.
 2. Enable the required APIs (`aiplatform.googleapis.com` and `firebaseml.googleapis.com`).
 3. Integrate the Firebase SDK into your app (if you haven't already).
-4. Recommended: Enable Firebase App Check to protect the Vertex AI Gemini API from abuse by unauthorized clients.
+4. Recommended: Enable Firebase App Check to protect the API from abuse.
 
-### 2. Add the LangChain.dart Google package
+**For Google AI backend:**
+1. You can use the free Spark plan.
+2. Configure your Gemini API key in the Firebase console.
+3. Integrate the Firebase SDK into your app (if you haven't already).
 
-Add the `langchain_google` package to your `pubspec.yaml` file.
+### 2. Add the LangChain.dart Firebase package
+
+Add the `langchain_firebase` package to your `pubspec.yaml` file.
 
 ```yaml
 dependencies:
   langchain: {version}
-  langchain_google: {version}
+  langchain_firebase: {version}
 ```
 
-Internally, `langchain_google` uses the [`firebase_vertexai`](https://pub.dev/packages/firebase_vertexai) SDK to interact with the Vertex AI for Firebase API.
+Internally, `langchain_firebase` uses the [`firebase_ai`](https://pub.dev/packages/firebase_ai) SDK to interact with the Firebase AI Logic API.
 
 ### 3. Initialize your Firebase app
 
@@ -41,7 +53,9 @@ Internally, `langchain_google` uses the [`firebase_vertexai`](https://pub.dev/pa
 await Firebase.initializeApp();
 ```
 
-### 4. Call the Vertex AI Gemini API
+### 4. Call the Gemini API
+
+**Using Vertex AI backend (default):**
 
 ```dart
 final chatModel = ChatFirebaseVertexAI();
@@ -61,7 +75,15 @@ print(res);
 // -> 'J'adore programmer.'
 ```
 
-> Check out the [sample project](https://github.com/davidmigloz/langchain_dart/tree/main/packages/langchain_firebase/example) to see a complete project using Vertex AI for Firebase.
+**Using Google AI backend:**
+
+```dart
+final chatModel = ChatFirebaseVertexAI(
+  defaultBackend: FirebaseAIBackend.googleAI,
+);
+```
+
+> Check out the [sample project](https://github.com/davidmigloz/langchain_dart/tree/main/packages/langchain_firebase/example) to see a complete project using Firebase AI.
 
 ## Available models
 
@@ -187,4 +209,4 @@ final chatModel = ChatFirebaseVertexAI(
 ## Alternatives
 
 - [`ChatVertexAI`](/modules/model_io/models/chat_models/integrations/gcp_vertex_ai.md): Use this class to call the Vertex AI Gemini API from the server-side.
-- [`ChatGoogleGenerativeAI`](/modules/model_io/models/chat_models/integrations/googleai.md): Use this class to call the "Google AI" version of the Gemini API that provides free-of-charge access (within limits and where available). This API is not intended for production use but for experimentation and prototyping. After you're familiar with how a Gemini API works, migrate to the Vertex AI for Firebase, which have many additional features important for mobile and web apps, like protecting the API from abuse using Firebase App Check.
+- [`ChatGoogleGenerativeAI`](/modules/model_io/models/chat_models/integrations/googleai.md): Use this class to call the Google AI Gemini API from a pure Dart environment (server-side or CLI apps).

--- a/docs_v2/docs/05-integrations/firebase_vertex_ai.md
+++ b/docs_v2/docs/05-integrations/firebase_vertex_ai.md
@@ -1,13 +1,20 @@
-# Vertex AI for Firebase
+# Firebase AI (Vertex AI / Google AI)
 
-The [Vertex AI Gemini API](https://firebase.google.com/docs/vertex-ai) gives you access to the latest generative AI models from Google: the Gemini models. If you need to call the Vertex AI Gemini API directly from your mobile or web app you can use the `ChatFirebaseVertexAI` class instead of the [`ChatVertexAI`](./gcp_vertex_ai.md) class which is designed to be used on the server-side. 
+The [Firebase AI Logic](https://firebase.google.com/docs/ai-logic) gives you access to the latest generative AI models from Google: the Gemini models. If you need to call the Gemini API directly from your mobile or web app you can use the `ChatFirebaseVertexAI` class instead of the [`ChatVertexAI`](./gcp_vertex_ai.md) class which is designed to be used on the server-side.
 
 `ChatFirebaseVertexAI` is built specifically for use with mobile and web apps, offering security options against unauthorized clients as well as integrations with other Firebase services.
+
+## Supported Backends
+
+`ChatFirebaseVertexAI` supports two backends:
+
+- **Vertex AI** (default): Requires Blaze plan (pay-as-you-go). Best for production use.
+- **Google AI**: Available on free Spark plan. Good for development and testing.
 
 ## Key capabilities
 
 - **Multimodal input**: The Gemini models are multimodal, so prompts sent to the Gemini API can include text, images (even PDFs), video, and audio.
-- **Growing suite of capabilities**: You can call the Gemini API directly from your mobile or web app, build an AI chat experience, use function calling, and more. 
+- **Growing suite of capabilities**: You can call the Gemini API directly from your mobile or web app, build an AI chat experience, use function calling, and more.
 - **Security for production apps**: Use Firebase App Check to protect the Vertex AI Gemini API from abuse by unauthorized clients.
 - **Robust infrastructure**: Take advantage of scalable infrastructure that's built for use with mobile and web apps, like managing structured data with Firebase database offerings (like Cloud Firestore) and dynamically setting run-time configurations with Firebase Remote Config.
 
@@ -15,25 +22,30 @@ The [Vertex AI Gemini API](https://firebase.google.com/docs/vertex-ai) gives you
 
 ### 1. Set up a Firebase project
 
-Check the [Firebase documentation](https://firebase.google.com/docs/vertex-ai/get-started?platform=flutter) for the latest information on how to set up the Vertex AI for Firebase in your Firebase project.
+Check the [Firebase documentation](https://firebase.google.com/docs/ai-logic/get-started?platform=flutter) for the latest information on how to set up Firebase AI in your Firebase project.
 
-In summary, you need to:
+**For Vertex AI backend:**
 1. Upgrade your billing plan to the Blaze pay-as-you-go pricing plan.
 2. Enable the required APIs (`aiplatform.googleapis.com` and `firebaseml.googleapis.com`).
 3. Integrate the Firebase SDK into your app (if you haven't already).
-4. Recommended: Enable Firebase App Check to protect the Vertex AI Gemini API from abuse by unauthorized clients.
+4. Recommended: Enable Firebase App Check to protect the API from abuse.
 
-### 2. Add the LangChain.dart Google package
+**For Google AI backend:**
+1. You can use the free Spark plan.
+2. Configure your Gemini API key in the Firebase console.
+3. Integrate the Firebase SDK into your app (if you haven't already).
 
-Add the `langchain_google` package to your `pubspec.yaml` file.
+### 2. Add the LangChain.dart Firebase package
+
+Add the `langchain_firebase` package to your `pubspec.yaml` file.
 
 ```yaml
 dependencies:
   langchain: {version}
-  langchain_google: {version}
+  langchain_firebase: {version}
 ```
 
-Internally, `langchain_google` uses the [`firebase_vertexai`](https://pub.dev/packages/firebase_vertexai) SDK to interact with the Vertex AI for Firebase API.
+Internally, `langchain_firebase` uses the [`firebase_ai`](https://pub.dev/packages/firebase_ai) SDK to interact with the Firebase AI Logic API.
 
 ### 3. Initialize your Firebase app
 
@@ -41,7 +53,9 @@ Internally, `langchain_google` uses the [`firebase_vertexai`](https://pub.dev/pa
 await Firebase.initializeApp();
 ```
 
-### 4. Call the Vertex AI Gemini API
+### 4. Call the Gemini API
+
+**Using Vertex AI backend (default):**
 
 ```dart
 final chatModel = ChatFirebaseVertexAI();
@@ -61,7 +75,15 @@ print(res);
 // -> 'J'adore programmer.'
 ```
 
-> Check out the [sample project](https://github.com/davidmigloz/langchain_dart/tree/main/packages/langchain_firebase/example) to see a complete project using Vertex AI for Firebase.
+**Using Google AI backend:**
+
+```dart
+final chatModel = ChatFirebaseVertexAI(
+  defaultBackend: FirebaseAIBackend.googleAI,
+);
+```
+
+> Check out the [sample project](https://github.com/davidmigloz/langchain_dart/tree/main/packages/langchain_firebase/example) to see a complete project using Firebase AI.
 
 ## Available models
 
@@ -174,7 +196,9 @@ final res = await model.invoke(
 
 You can use Firebase App Check to protect the Vertex AI Gemini API from abuse by unauthorized clients. Check the [Firebase documentation](https://firebase.google.com/docs/vertex-ai/app-check) for more information.
 
-## Locations
+> Note: Firebase App Check only applies to the Vertex AI backend.
+
+## Locations (Vertex AI only)
 
 When initializing the Vertex AI service, you can optionally specify a location in which to run the service and access a model. If you don't specify a location, the default is us-central1. See the list of [available locations](https://firebase.google.com/docs/vertex-ai/locations?platform=flutter#available-locations).
 
@@ -184,7 +208,9 @@ final chatModel = ChatFirebaseVertexAI(
 );
 ```
 
+> Note: The location parameter only applies to the Vertex AI backend.
+
 ## Alternatives
 
 - [`ChatVertexAI`](./gcp_vertex_ai.md): Use this class to call the Vertex AI Gemini API from the server-side.
-- [`ChatGoogleGenerativeAI`](./googleai.md): Use this class to call the "Google AI" version of the Gemini API that provides free-of-charge access (within limits and where available). This API is not intended for production use but for experimentation and prototyping. After you're familiar with how a Gemini API works, migrate to the Vertex AI for Firebase, which have many additional features important for mobile and web apps, like protecting the API from abuse using Firebase App Check.
+- [`ChatGoogleGenerativeAI`](./googleai.md): Use this class to call the Google AI Gemini API from a pure Dart environment (server-side or CLI apps).

--- a/packages/langchain_firebase/example/README.md
+++ b/packages/langchain_firebase/example/README.md
@@ -1,8 +1,8 @@
-# firebase_vertexai_example
+# firebase_ai_example
 
 Example project to show how to use the Firebase integration module for LangChain.dart.
 
-This example project is a port of the original [firebase_vertexai_example](https://github.com/firebase/flutterfire/tree/master/packages/firebase_vertexai/firebase_vertexai/example) using LangChain.dart.
+This example project demonstrates how to use Firebase AI (Vertex AI / Google AI backends) with LangChain.dart.
 
 ## Getting Started
 

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
@@ -1,9 +1,7 @@
 // ignore_for_file: public_member_api_docs
 import 'dart:convert';
 
-// ignore: implementation_imports
-import 'package:firebase_ai/src/content.dart';
-import 'package:firebase_vertexai/firebase_vertexai.dart' as f;
+import 'package:firebase_ai/firebase_ai.dart' as f;
 import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/tools.dart';
@@ -132,9 +130,9 @@ extension GenerateContentResponseMapper on f.GenerateContentResponse {
                 final f.InlineDataPart p => base64Encode(p.bytes),
                 final f.FileData p => p.fileUri,
                 f.FunctionResponse() || f.FunctionCall() => '',
-                ExecutableCodePart() => '',
-                CodeExecutionResultPart() => '',
-                UnknownPart() => '',
+                f.ExecutableCodePart() => '',
+                f.CodeExecutionResultPart() => '',
+                f.UnknownPart() => '',
               },
             )
             .nonNulls

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/types.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/types.dart
@@ -23,6 +23,7 @@ class ChatFirebaseVertexAIOptions extends ChatModelOptions {
     this.responseMimeType,
     this.responseSchema,
     this.safetySettings,
+    this.backend,
     super.tools,
     super.toolChoice,
     super.concurrencyLimit,
@@ -117,6 +118,14 @@ class ChatFirebaseVertexAIOptions extends ChatModelOptions {
   /// the default safety setting for that category.
   final List<ChatFirebaseVertexAISafetySetting>? safetySettings;
 
+  /// The Firebase AI backend to use.
+  ///
+  /// - [FirebaseAIBackend.vertexAI] (default): Vertex AI Gemini API.
+  ///   Requires Blaze plan (pay-as-you-go). Best for production.
+  /// - [FirebaseAIBackend.googleAI]: Gemini Developer API.
+  ///   Available on Spark plan (free tier). Good for development/testing.
+  final FirebaseAIBackend? backend;
+
   @override
   ChatFirebaseVertexAIOptions copyWith({
     final String? model,
@@ -128,6 +137,7 @@ class ChatFirebaseVertexAIOptions extends ChatModelOptions {
     final List<String>? stopSequences,
     final String? responseMimeType,
     final List<ChatFirebaseVertexAISafetySetting>? safetySettings,
+    final FirebaseAIBackend? backend,
     final List<ToolSpec>? tools,
     final ChatToolChoice? toolChoice,
     final int? concurrencyLimit,
@@ -142,6 +152,7 @@ class ChatFirebaseVertexAIOptions extends ChatModelOptions {
       stopSequences: stopSequences ?? this.stopSequences,
       responseMimeType: responseMimeType ?? this.responseMimeType,
       safetySettings: safetySettings ?? this.safetySettings,
+      backend: backend ?? this.backend,
       tools: tools ?? this.tools,
       toolChoice: toolChoice ?? this.toolChoice,
       concurrencyLimit: concurrencyLimit ?? this.concurrencyLimit,
@@ -162,6 +173,7 @@ class ChatFirebaseVertexAIOptions extends ChatModelOptions {
       stopSequences: other?.stopSequences,
       responseMimeType: other?.responseMimeType,
       safetySettings: other?.safetySettings,
+      backend: other?.backend,
       tools: other?.tools,
       toolChoice: other?.toolChoice,
       concurrencyLimit: other?.concurrencyLimit,
@@ -185,6 +197,7 @@ class ChatFirebaseVertexAIOptions extends ChatModelOptions {
           safetySettings,
           other.safetySettings,
         ) &&
+        backend == other.backend &&
         const ListEquality<ToolSpec>().equals(tools, other.tools) &&
         toolChoice == other.toolChoice &&
         concurrencyLimit == other.concurrencyLimit;
@@ -203,6 +216,7 @@ class ChatFirebaseVertexAIOptions extends ChatModelOptions {
         const ListEquality<ChatFirebaseVertexAISafetySetting>().hash(
           safetySettings,
         ) ^
+        backend.hashCode ^
         const ListEquality<ToolSpec>().hash(tools) ^
         toolChoice.hashCode ^
         concurrencyLimit.hashCode;
@@ -289,4 +303,15 @@ enum ChatFirebaseVertexAISafetySettingThreshold {
 
   /// Always show regardless of probability of unsafe content.
   blockNone,
+}
+
+/// The Firebase AI backend to use.
+enum FirebaseAIBackend {
+  /// Vertex AI Gemini API - requires Blaze plan (pay-as-you-go).
+  /// Recommended for production use.
+  vertexAI,
+
+  /// Gemini Developer API - available on Spark plan (free tier).
+  /// Has rate limits but no billing required.
+  googleAI,
 }

--- a/packages/langchain_firebase/pubspec.yaml
+++ b/packages/langchain_firebase/pubspec.yaml
@@ -27,7 +27,6 @@ dependencies:
   firebase_app_check: ^0.4.1+1
   firebase_auth: ^6.1.1
   firebase_core: ^4.2.0
-  firebase_vertexai: ^2.2.0
   langchain_core: 0.4.0+1
   meta: ^1.16.0
   uuid: ^4.5.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,7 +77,6 @@ melos:
         firebase_app_check: ^0.4.1+1
         firebase_auth: ^6.1.1
         firebase_core: ^4.2.0
-        firebase_vertexai: ^2.2.0 # TODO Migrate to new FirebaseAI module
         flat_buffers: ^25.9.23
         flutter_bloc: ^9.1.1
         flutter_markdown: ^0.7.7 # Package will be discontinued. Migrate to flutter_markdown_plus


### PR DESCRIPTION
## Summary

- Migrate from discontinued `firebase_vertexai` to `firebase_ai` package
- Add `FirebaseAIBackend` enum with `vertexAI` (default) and `googleAI` options
- Add `defaultBackend` parameter to `ChatFirebaseVertexAI` for backend selection at construction
- Add `backend` parameter to `ChatFirebaseVertexAIOptions` for per-request override
- Update documentation with dual-backend setup instructions

## Motivation

The `langchain_firebase` package has 100/160 pub points due to:
1. **Static analysis error (0/50 points)**: `FinishReason.malformedFunctionCall` not matched (already fixed locally)
2. **Discontinued dependency (0/10 points)**: `firebase_vertexai` is discontinued

This PR migrates to `firebase_ai` and adds support for both Vertex AI and Google AI backends.

## Breaking Changes

None. Fully backward compatible - existing code works without changes (default backend is `vertexAI`).

## Usage

**Vertex AI backend (default):**
```dart
final chatModel = ChatFirebaseVertexAI();
```

**Google AI backend:**
```dart
final chatModel = ChatFirebaseVertexAI(
  defaultBackend: FirebaseAIBackend.googleAI,
);
```

## Test plan

- [x] `melos bootstrap` succeeds
- [x] `flutter analyze packages/langchain_firebase` passes with no issues
- [ ] Manual testing with Firebase project