### PR TITLE
feat(googleai_dart): Add missing model properties from OpenAPI spec

### DIFF
--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -158,6 +158,8 @@ export 'src/models/safety/safety_rating.dart';
 export 'src/models/safety/safety_setting.dart';
 // Models - Tools
 export 'src/models/tools/code_execution_result.dart';
+export 'src/models/tools/computer_use.dart';
+export 'src/models/tools/dynamic_retrieval_config.dart';
 export 'src/models/tools/executable_code.dart';
 export 'src/models/tools/file_search.dart';
 export 'src/models/tools/function_call.dart';
@@ -165,6 +167,7 @@ export 'src/models/tools/function_calling_config.dart';
 export 'src/models/tools/function_declaration.dart';
 export 'src/models/tools/function_response.dart';
 export 'src/models/tools/google_maps.dart';
+export 'src/models/tools/google_search_retrieval.dart';
 export 'src/models/tools/mcp_server.dart';
 export 'src/models/tools/streamable_http_transport.dart';
 export 'src/models/tools/tool.dart';

--- a/packages/googleai_dart/lib/src/models/content/candidate.dart
+++ b/packages/googleai_dart/lib/src/models/content/candidate.dart
@@ -38,6 +38,14 @@ class Candidate {
   /// Grounding metadata for this candidate.
   final GroundingMetadata? groundingMetadata;
 
+  /// Attribution information for sources that contributed to a grounded answer.
+  ///
+  /// This field is populated for `GenerateAnswer` calls.
+  final List<Map<String, dynamic>>? groundingAttributions;
+
+  /// Metadata related to URL context retrieval tool.
+  final Map<String, dynamic>? urlContextMetadata;
+
   /// Creates a [Candidate].
   const Candidate({
     this.content,
@@ -50,6 +58,8 @@ class Candidate {
     this.avgLogprobs,
     this.logprobsResult,
     this.groundingMetadata,
+    this.groundingAttributions,
+    this.urlContextMetadata,
   });
 
   /// Creates a [Candidate] from JSON.
@@ -84,6 +94,10 @@ class Candidate {
             json['groundingMetadata'] as Map<String, dynamic>,
           )
         : null,
+    groundingAttributions: (json['groundingAttributions'] as List<dynamic>?)
+        ?.map((e) => e as Map<String, dynamic>)
+        .toList(),
+    urlContextMetadata: json['urlContextMetadata'] as Map<String, dynamic>?,
   );
 
   /// Converts to JSON.
@@ -102,6 +116,9 @@ class Candidate {
     if (logprobsResult != null) 'logprobsResult': logprobsResult!.toJson(),
     if (groundingMetadata != null)
       'groundingMetadata': groundingMetadata!.toJson(),
+    if (groundingAttributions != null)
+      'groundingAttributions': groundingAttributions,
+    if (urlContextMetadata != null) 'urlContextMetadata': urlContextMetadata,
   };
 
   /// Creates a copy with replaced values.
@@ -116,6 +133,8 @@ class Candidate {
     Object? avgLogprobs = unsetCopyWithValue,
     Object? logprobsResult = unsetCopyWithValue,
     Object? groundingMetadata = unsetCopyWithValue,
+    Object? groundingAttributions = unsetCopyWithValue,
+    Object? urlContextMetadata = unsetCopyWithValue,
   }) {
     return Candidate(
       content: content == unsetCopyWithValue
@@ -146,6 +165,12 @@ class Candidate {
       groundingMetadata: groundingMetadata == unsetCopyWithValue
           ? this.groundingMetadata
           : groundingMetadata as GroundingMetadata?,
+      groundingAttributions: groundingAttributions == unsetCopyWithValue
+          ? this.groundingAttributions
+          : groundingAttributions as List<Map<String, dynamic>>?,
+      urlContextMetadata: urlContextMetadata == unsetCopyWithValue
+          ? this.urlContextMetadata
+          : urlContextMetadata as Map<String, dynamic>?,
     );
   }
 }

--- a/packages/googleai_dart/lib/src/models/generation/generation_config.dart
+++ b/packages/googleai_dart/lib/src/models/generation/generation_config.dart
@@ -67,6 +67,23 @@ class GenerationConfig {
   /// MEDIA_RESOLUTION_MEDIUM, MEDIA_RESOLUTION_HIGH.
   final String? mediaResolution;
 
+  /// Response JSON schema for structured output.
+  ///
+  /// This is separate from [responseSchema] and provides additional
+  /// schema configuration options.
+  final Map<String, dynamic>? responseJsonSchema;
+
+  /// Enables enhanced civic answers.
+  ///
+  /// It may not be available for all models.
+  final bool? enableEnhancedCivicAnswers;
+
+  /// The speech generation config.
+  ///
+  /// Contains voice configuration for speech output including
+  /// single-voice and multi-speaker setups.
+  final Map<String, dynamic>? speechConfig;
+
   /// Creates a [GenerationConfig].
   const GenerationConfig({
     this.candidateCount,
@@ -86,6 +103,9 @@ class GenerationConfig {
     this.logprobs,
     this.responseModalities,
     this.mediaResolution,
+    this.responseJsonSchema,
+    this.enableEnhancedCivicAnswers,
+    this.speechConfig,
   });
 
   /// Creates a [GenerationConfig] from JSON.
@@ -115,6 +135,9 @@ class GenerationConfig {
         responseModalities: (json['responseModalities'] as List?)
             ?.cast<String>(),
         mediaResolution: json['mediaResolution'] as String?,
+        responseJsonSchema: json['responseJsonSchema'] as Map<String, dynamic>?,
+        enableEnhancedCivicAnswers: json['enableEnhancedCivicAnswers'] as bool?,
+        speechConfig: json['speechConfig'] as Map<String, dynamic>?,
       );
 
   /// Converts to JSON.
@@ -136,6 +159,10 @@ class GenerationConfig {
     if (logprobs != null) 'logprobs': logprobs,
     if (responseModalities != null) 'responseModalities': responseModalities,
     if (mediaResolution != null) 'mediaResolution': mediaResolution,
+    if (responseJsonSchema != null) 'responseJsonSchema': responseJsonSchema,
+    if (enableEnhancedCivicAnswers != null)
+      'enableEnhancedCivicAnswers': enableEnhancedCivicAnswers,
+    if (speechConfig != null) 'speechConfig': speechConfig,
   };
 
   /// Creates a copy with replaced values.
@@ -157,6 +184,9 @@ class GenerationConfig {
     Object? logprobs = unsetCopyWithValue,
     Object? responseModalities = unsetCopyWithValue,
     Object? mediaResolution = unsetCopyWithValue,
+    Object? responseJsonSchema = unsetCopyWithValue,
+    Object? enableEnhancedCivicAnswers = unsetCopyWithValue,
+    Object? speechConfig = unsetCopyWithValue,
   }) {
     return GenerationConfig(
       candidateCount: candidateCount == unsetCopyWithValue
@@ -204,6 +234,16 @@ class GenerationConfig {
       mediaResolution: mediaResolution == unsetCopyWithValue
           ? this.mediaResolution
           : mediaResolution as String?,
+      responseJsonSchema: responseJsonSchema == unsetCopyWithValue
+          ? this.responseJsonSchema
+          : responseJsonSchema as Map<String, dynamic>?,
+      enableEnhancedCivicAnswers:
+          enableEnhancedCivicAnswers == unsetCopyWithValue
+          ? this.enableEnhancedCivicAnswers
+          : enableEnhancedCivicAnswers as bool?,
+      speechConfig: speechConfig == unsetCopyWithValue
+          ? this.speechConfig
+          : speechConfig as Map<String, dynamic>?,
     );
   }
 }

--- a/packages/googleai_dart/lib/src/models/tools/computer_use.dart
+++ b/packages/googleai_dart/lib/src/models/tools/computer_use.dart
@@ -1,0 +1,58 @@
+import '../copy_with_sentinel.dart';
+
+/// Computer Use tool type.
+///
+/// Allows the model to interact directly with the computer. If enabled,
+/// it automatically populates computer-use specific Function Declarations.
+class ComputerUse {
+  /// The environment being operated.
+  ///
+  /// Currently only 'ENVIRONMENT_BROWSER' is supported.
+  final String? environment;
+
+  /// List of predefined functions to exclude from the model call.
+  ///
+  /// By default, predefined functions are included in the final model call.
+  /// Some can be explicitly excluded to use a more restricted action space
+  /// or to provide improved definitions for predefined functions.
+  final List<String>? excludedPredefinedFunctions;
+
+  /// Creates a [ComputerUse].
+  const ComputerUse({this.environment, this.excludedPredefinedFunctions});
+
+  /// Creates a [ComputerUse] from JSON.
+  factory ComputerUse.fromJson(Map<String, dynamic> json) => ComputerUse(
+    environment: json['environment'] as String?,
+    excludedPredefinedFunctions:
+        (json['excludedPredefinedFunctions'] as List<dynamic>?)?.cast<String>(),
+  );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (environment != null) 'environment': environment,
+    if (excludedPredefinedFunctions != null)
+      'excludedPredefinedFunctions': excludedPredefinedFunctions,
+  };
+
+  /// Creates a copy with replaced values.
+  ComputerUse copyWith({
+    Object? environment = unsetCopyWithValue,
+    Object? excludedPredefinedFunctions = unsetCopyWithValue,
+  }) {
+    return ComputerUse(
+      environment: environment == unsetCopyWithValue
+          ? this.environment
+          : environment as String?,
+      excludedPredefinedFunctions:
+          excludedPredefinedFunctions == unsetCopyWithValue
+          ? this.excludedPredefinedFunctions
+          : excludedPredefinedFunctions as List<String>?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'ComputerUse('
+      'environment: $environment, '
+      'excludedPredefinedFunctions: $excludedPredefinedFunctions)';
+}

--- a/packages/googleai_dart/lib/src/models/tools/dynamic_retrieval_config.dart
+++ b/packages/googleai_dart/lib/src/models/tools/dynamic_retrieval_config.dart
@@ -1,0 +1,49 @@
+import '../copy_with_sentinel.dart';
+
+/// Describes the options to customize dynamic retrieval.
+class DynamicRetrievalConfig {
+  /// The mode of the predictor to be used in dynamic retrieval.
+  ///
+  /// Values: 'MODE_UNSPECIFIED', 'MODE_DYNAMIC'
+  /// - MODE_UNSPECIFIED: Always trigger retrieval.
+  /// - MODE_DYNAMIC: Run retrieval only when system decides it is necessary.
+  final String? mode;
+
+  /// The threshold to be used in dynamic retrieval.
+  ///
+  /// If not set, a system default value is used.
+  final double? dynamicThreshold;
+
+  /// Creates a [DynamicRetrievalConfig].
+  const DynamicRetrievalConfig({this.mode, this.dynamicThreshold});
+
+  /// Creates a [DynamicRetrievalConfig] from JSON.
+  factory DynamicRetrievalConfig.fromJson(Map<String, dynamic> json) =>
+      DynamicRetrievalConfig(
+        mode: json['mode'] as String?,
+        dynamicThreshold: (json['dynamicThreshold'] as num?)?.toDouble(),
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (mode != null) 'mode': mode,
+    if (dynamicThreshold != null) 'dynamicThreshold': dynamicThreshold,
+  };
+
+  /// Creates a copy with replaced values.
+  DynamicRetrievalConfig copyWith({
+    Object? mode = unsetCopyWithValue,
+    Object? dynamicThreshold = unsetCopyWithValue,
+  }) {
+    return DynamicRetrievalConfig(
+      mode: mode == unsetCopyWithValue ? this.mode : mode as String?,
+      dynamicThreshold: dynamicThreshold == unsetCopyWithValue
+          ? this.dynamicThreshold
+          : dynamicThreshold as double?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'DynamicRetrievalConfig(mode: $mode, dynamicThreshold: $dynamicThreshold)';
+}

--- a/packages/googleai_dart/lib/src/models/tools/google_search_retrieval.dart
+++ b/packages/googleai_dart/lib/src/models/tools/google_search_retrieval.dart
@@ -1,0 +1,42 @@
+import '../copy_with_sentinel.dart';
+import 'dynamic_retrieval_config.dart';
+
+/// Tool to retrieve public web data for grounding, powered by Google.
+class GoogleSearchRetrieval {
+  /// Specifies the dynamic retrieval configuration for the given source.
+  final DynamicRetrievalConfig? dynamicRetrievalConfig;
+
+  /// Creates a [GoogleSearchRetrieval].
+  const GoogleSearchRetrieval({this.dynamicRetrievalConfig});
+
+  /// Creates a [GoogleSearchRetrieval] from JSON.
+  factory GoogleSearchRetrieval.fromJson(Map<String, dynamic> json) =>
+      GoogleSearchRetrieval(
+        dynamicRetrievalConfig: json['dynamicRetrievalConfig'] != null
+            ? DynamicRetrievalConfig.fromJson(
+                json['dynamicRetrievalConfig'] as Map<String, dynamic>,
+              )
+            : null,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (dynamicRetrievalConfig != null)
+      'dynamicRetrievalConfig': dynamicRetrievalConfig!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  GoogleSearchRetrieval copyWith({
+    Object? dynamicRetrievalConfig = unsetCopyWithValue,
+  }) {
+    return GoogleSearchRetrieval(
+      dynamicRetrievalConfig: dynamicRetrievalConfig == unsetCopyWithValue
+          ? this.dynamicRetrievalConfig
+          : dynamicRetrievalConfig as DynamicRetrievalConfig?,
+    );
+  }
+
+  @override
+  String toString() =>
+      'GoogleSearchRetrieval(dynamicRetrievalConfig: $dynamicRetrievalConfig)';
+}

--- a/packages/googleai_dart/lib/src/models/tools/tool.dart
+++ b/packages/googleai_dart/lib/src/models/tools/tool.dart
@@ -1,7 +1,9 @@
 import '../copy_with_sentinel.dart';
+import 'computer_use.dart';
 import 'file_search.dart';
 import 'function_declaration.dart';
 import 'google_maps.dart';
+import 'google_search_retrieval.dart';
 import 'mcp_server.dart';
 
 /// Tool that the model may use to generate a response.
@@ -25,6 +27,25 @@ class Tool {
   /// Google Maps tool that provides geospatial context.
   final GoogleMaps? googleMaps;
 
+  /// URL context tool that fetches and analyzes web content.
+  ///
+  /// Enables the model to retrieve and process content from URLs provided
+  /// in the prompt. Supports HTML, JSON, text, XML, CSS, JavaScript, CSV,
+  /// RTF, images, and PDFs. Maximum 20 URLs per request, 34MB per URL.
+  final Map<String, dynamic>? urlContext;
+
+  /// Tool to support the model interacting directly with the computer.
+  ///
+  /// If enabled, it automatically populates computer-use specific
+  /// Function Declarations.
+  final ComputerUse? computerUse;
+
+  /// Retrieval tool that is powered by Google search.
+  ///
+  /// This is different from [googleSearch] - it provides dynamic retrieval
+  /// configuration options.
+  final GoogleSearchRetrieval? googleSearchRetrieval;
+
   /// Creates a [Tool].
   const Tool({
     this.functionDeclarations,
@@ -33,6 +54,9 @@ class Tool {
     this.fileSearch,
     this.mcpServers,
     this.googleMaps,
+    this.urlContext,
+    this.computerUse,
+    this.googleSearchRetrieval,
   });
 
   /// Creates a [Tool] from JSON.
@@ -57,6 +81,15 @@ class Tool {
     googleMaps: json['googleMaps'] != null
         ? GoogleMaps.fromJson(json['googleMaps'] as Map<String, dynamic>)
         : null,
+    urlContext: json['urlContext'] as Map<String, dynamic>?,
+    computerUse: json['computerUse'] != null
+        ? ComputerUse.fromJson(json['computerUse'] as Map<String, dynamic>)
+        : null,
+    googleSearchRetrieval: json['googleSearchRetrieval'] != null
+        ? GoogleSearchRetrieval.fromJson(
+            json['googleSearchRetrieval'] as Map<String, dynamic>,
+          )
+        : null,
   );
 
   /// Converts to JSON.
@@ -71,6 +104,10 @@ class Tool {
     if (mcpServers != null)
       'mcpServers': mcpServers!.map((e) => e.toJson()).toList(),
     if (googleMaps != null) 'googleMaps': googleMaps!.toJson(),
+    if (urlContext != null) 'urlContext': urlContext,
+    if (computerUse != null) 'computerUse': computerUse!.toJson(),
+    if (googleSearchRetrieval != null)
+      'googleSearchRetrieval': googleSearchRetrieval!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -81,6 +118,9 @@ class Tool {
     Object? fileSearch = unsetCopyWithValue,
     Object? mcpServers = unsetCopyWithValue,
     Object? googleMaps = unsetCopyWithValue,
+    Object? urlContext = unsetCopyWithValue,
+    Object? computerUse = unsetCopyWithValue,
+    Object? googleSearchRetrieval = unsetCopyWithValue,
   }) {
     return Tool(
       functionDeclarations: functionDeclarations == unsetCopyWithValue
@@ -101,6 +141,15 @@ class Tool {
       googleMaps: googleMaps == unsetCopyWithValue
           ? this.googleMaps
           : googleMaps as GoogleMaps?,
+      urlContext: urlContext == unsetCopyWithValue
+          ? this.urlContext
+          : urlContext as Map<String, dynamic>?,
+      computerUse: computerUse == unsetCopyWithValue
+          ? this.computerUse
+          : computerUse as ComputerUse?,
+      googleSearchRetrieval: googleSearchRetrieval == unsetCopyWithValue
+          ? this.googleSearchRetrieval
+          : googleSearchRetrieval as GoogleSearchRetrieval?,
     );
   }
 }


### PR DESCRIPTION
## Summary
Add missing model properties from Google AI OpenAPI specification.

## Changes
### New Models
- `ComputerUse` - Tool for browser automation (environment, excludedPredefinedFunctions)
- `GoogleSearchRetrieval` - Search retrieval with dynamic config
- `DynamicRetrievalConfig` - Mode and threshold for retrieval

### Updated Models
- `Tool`: Added computerUse, googleSearchRetrieval properties
- `Candidate`: Added groundingAttributions, urlContextMetadata properties
- `GenerationConfig`: Added responseJsonSchema, enableEnhancedCivicAnswers, speechConfig properties

## Test Plan
- [x] dart analyze passes
- [x] dart test passes (617 tests)
- [x] verify_model_properties.py shows all properties present