### PR TITLE
docs(googleai_dart): Add documentation for grounding tools

### DIFF
--- a/packages/googleai_dart/example/file_search_example.dart
+++ b/packages/googleai_dart/example/file_search_example.dart
@@ -1,0 +1,238 @@
+// ignore_for_file: avoid_print, avoid_dynamic_calls
+/// Demonstrates File Search with FileSearchStores for semantic retrieval.
+///
+/// FileSearchStores enable you to upload documents and perform semantic
+/// search over them during generation (RAG - Retrieval Augmented Generation).
+///
+/// Key features:
+/// - Create and manage file search stores
+/// - Upload files with custom chunking configuration
+/// - Add custom metadata for filtering
+/// - Use File Search in generation requests
+/// - Access grounding metadata with citations
+///
+/// Note: FileSearchStores API is only available with Google AI (not Vertex AI).
+///
+/// See: https://ai.google.dev/gemini-api/docs/file-search
+library;
+
+import 'dart:io' as io;
+
+import 'package:googleai_dart/googleai_dart.dart';
+
+Future<void> main() async {
+  final apiKey = io.Platform.environment['GOOGLEAI_API_KEY'];
+  if (apiKey == null) {
+    io.stderr.writeln('No GOOGLEAI_API_KEY environment variable');
+    io.exit(1);
+  }
+
+  final client = GoogleAIClient(
+    config: GoogleAIConfig(authProvider: ApiKeyProvider(apiKey)),
+  );
+
+  try {
+    print('=== Example 1: FileSearchStore Management ===\n');
+    await fileSearchStoreManagement(client);
+
+    print('\n=== Example 2: Using FileSearch with generateContent ===\n');
+    await fileSearchWithGenerateContent(client);
+
+    print('\n=== Example 3: Using FileSearchTool with Interactions API ===\n');
+    await fileSearchWithInteractions(client);
+  } finally {
+    client.close();
+  }
+}
+
+/// Demonstrates FileSearchStore creation and management.
+Future<void> fileSearchStoreManagement(GoogleAIClient client) async {
+  // Create a new FileSearchStore
+  print('Creating FileSearchStore...');
+  final store = await client.fileSearchStores.create(
+    displayName: 'Example Knowledge Base',
+  );
+  print('Created store: ${store.name}');
+  print('Display name: ${store.displayName}');
+
+  try {
+    // Upload a file with custom chunking and metadata
+    print('\nUploading file with custom configuration...');
+
+    // For this example, we'll create a sample text file
+    final sampleFile = io.File('/tmp/sample_doc.txt');
+    await sampleFile.writeAsString('''
+# Introduction to Dart
+
+Dart is a client-optimized language for fast apps on any platform.
+It is developed by Google and is used to build mobile, desktop,
+server, and web applications.
+
+## Key Features
+
+1. Optimized for UI: Dart is designed for building user interfaces
+   with features like hot reload for instant updates.
+
+2. Productive development: Dart offers sound null safety,
+   async-await for asynchronous code, and a rich standard library.
+
+3. Fast on all platforms: Dart compiles to ARM and x64 machine code
+   for mobile, desktop, and backend. Or compile to JavaScript for web.
+
+## Getting Started
+
+To get started with Dart, install the Dart SDK from dart.dev.
+''');
+
+    final uploadResponse = await client.fileSearchStores.upload(
+      parent: store.name!,
+      filePath: sampleFile.path,
+      mimeType: 'text/plain',
+      request: const UploadToFileSearchStoreRequest(
+        displayName: 'Dart Introduction',
+        // Configure chunking for better retrieval
+        chunkingConfig: ChunkingConfig(
+          whiteSpaceConfig: WhiteSpaceConfig(
+            maxTokensPerChunk: 200,
+            maxOverlapTokens: 20,
+          ),
+        ),
+        // Add custom metadata for filtering
+        customMetadata: [
+          FileSearchCustomMetadata(key: 'category', stringValue: 'programming'),
+          FileSearchCustomMetadata(key: 'language', stringValue: 'dart'),
+          FileSearchCustomMetadata(key: 'year', numericValue: 2024),
+        ],
+      ),
+    );
+    print('Uploaded document: ${uploadResponse.documentName}');
+
+    // List documents in the store
+    print('\nListing documents...');
+    final docs = await client.fileSearchStores.listDocuments(
+      parent: store.name!,
+    );
+    for (final doc in docs.documents ?? []) {
+      print('  - ${doc.displayName} (${doc.name})');
+    }
+
+    // Use the store for generation
+    print('\nQuerying the knowledge base...');
+    final response = await client.models.generateContent(
+      model: 'gemini-2.5-flash',
+      request: GenerateContentRequest(
+        contents: const [
+          Content(
+            parts: [TextPart('What are the key features of Dart?')],
+            role: 'user',
+          ),
+        ],
+        tools: [
+          Tool(
+            fileSearch: FileSearch(
+              fileSearchStoreNames: [store.name!],
+              topK: 5,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    print('Response: ${_extractText(response)}');
+
+    // Access grounding metadata (citations)
+    final metadata = response.candidates?.first.groundingMetadata;
+    if (metadata?.groundingChunks != null) {
+      print('\nSources:');
+      for (final chunk in metadata!.groundingChunks!) {
+        if (chunk.retrievedContext != null) {
+          print('  - ${chunk.retrievedContext!.title}');
+          if (chunk.retrievedContext!.uri != null) {
+            print('    URI: ${chunk.retrievedContext!.uri}');
+          }
+        }
+      }
+    }
+  } finally {
+    // Clean up: delete the store
+    print('\nCleaning up...');
+    await client.fileSearchStores.delete(name: store.name!);
+    print('Deleted store: ${store.name}');
+  }
+}
+
+/// Using FileSearch with generateContent and metadata filtering.
+Future<void> fileSearchWithGenerateContent(GoogleAIClient client) async {
+  // This example shows the API structure for filtering by metadata
+  // In a real scenario, you would use an existing store with documents
+
+  print('FileSearch with metadata filter example:');
+  print(r'''
+// Filter documents by metadata
+final response = await client.models.generateContent(
+  model: 'gemini-2.5-flash',
+  request: GenerateContentRequest(
+    contents: [...],
+    tools: [
+      Tool(
+        fileSearch: FileSearch(
+          fileSearchStoreNames: ['fileSearchStores/your-store-id'],
+          topK: 5,
+          // Filter to only search documents by a specific author
+          metadataFilter: 'author = "Jane Doe"',
+        ),
+      ),
+    ],
+  ),
+);
+
+// Other filter examples:
+// - metadataFilter: 'year > 2020'
+// - metadataFilter: 'category = "technical"'
+// - metadataFilter: 'author = "John" AND year >= 2023'
+''');
+}
+
+/// Using FileSearchTool with the Interactions API.
+Future<void> fileSearchWithInteractions(GoogleAIClient client) async {
+  print('FileSearchTool with Interactions API example:');
+  print(r'''
+// Stream responses with file search
+await for (final event in client.interactions.createStream(
+  model: 'gemini-2.5-flash',
+  input: 'Summarize the key points from my documents',
+  tools: [
+    FileSearchTool(
+      fileSearchStoreNames: ['fileSearchStores/your-store-id'],
+      topK: 5,
+    ),
+  ],
+)) {
+  switch (event) {
+    case ContentDeltaEvent():
+      final delta = event.delta;
+      if (delta is TextDelta) {
+        print(delta.text);
+      } else if (delta is FileSearchResultDelta) {
+        // File search results received
+        print('Retrieved ${delta.results?.length} document chunks');
+      }
+    default:
+      break;
+  }
+}
+''');
+}
+
+/// Helper to extract text from a GenerateContentResponse.
+String _extractText(GenerateContentResponse response) {
+  final buffer = StringBuffer();
+  for (final candidate in response.candidates ?? []) {
+    for (final part in candidate.content?.parts ?? []) {
+      if (part is TextPart) {
+        buffer.write(part.text);
+      }
+    }
+  }
+  return buffer.toString();
+}

--- a/packages/googleai_dart/example/google_maps_example.dart
+++ b/packages/googleai_dart/example/google_maps_example.dart
@@ -1,0 +1,185 @@
+// ignore_for_file: avoid_print, avoid_dynamic_calls, prefer_const_constructors
+/// Demonstrates Google Maps grounding for geospatial context.
+///
+/// Google Maps grounding enables the model to access location and place
+/// information to provide contextual responses about places.
+///
+/// Key features:
+/// - Provide user location context via latitude/longitude
+/// - Get place information (name, URI, place ID)
+/// - Receive widget context token for rendering interactive maps
+///
+/// See: https://ai.google.dev/gemini-api/docs/maps-grounding
+library;
+
+import 'dart:io';
+
+import 'package:googleai_dart/googleai_dart.dart';
+
+Future<void> main() async {
+  final apiKey = Platform.environment['GOOGLEAI_API_KEY'];
+  if (apiKey == null) {
+    stderr.writeln('No GOOGLEAI_API_KEY environment variable');
+    exit(1);
+  }
+
+  final client = GoogleAIClient(
+    config: GoogleAIConfig(authProvider: ApiKeyProvider(apiKey)),
+  );
+
+  try {
+    print('=== Example 1: Basic Google Maps Grounding ===\n');
+    await basicMapsGrounding(client);
+
+    print('\n=== Example 2: Maps with Location Context ===\n');
+    await mapsWithLocationContext(client);
+
+    print('\n=== Example 3: Maps with Widget Token ===\n');
+    await mapsWithWidgetToken(client);
+  } finally {
+    client.close();
+  }
+}
+
+/// Basic Google Maps grounding without location context.
+Future<void> basicMapsGrounding(GoogleAIClient client) async {
+  final response = await client.models.generateContent(
+    model: 'gemini-2.5-flash',
+    request: const GenerateContentRequest(
+      contents: [
+        Content(
+          parts: [TextPart('What are the best pizza places in New York City?')],
+          role: 'user',
+        ),
+      ],
+      // Enable Google Maps grounding
+      tools: [Tool(googleMaps: GoogleMaps())],
+    ),
+  );
+
+  print('Response: ${_extractText(response)}\n');
+
+  // Access grounding metadata with place information
+  final metadata = response.candidates?.first.groundingMetadata;
+  if (metadata != null) {
+    printPlaceInfo(metadata);
+  }
+}
+
+/// Google Maps grounding with user location context.
+Future<void> mapsWithLocationContext(GoogleAIClient client) async {
+  final response = await client.models.generateContent(
+    model: 'gemini-2.5-flash',
+    request: GenerateContentRequest(
+      contents: const [
+        Content(
+          parts: [TextPart('Find Italian restaurants near me')],
+          role: 'user',
+        ),
+      ],
+      // Enable Google Maps grounding
+      tools: const [Tool(googleMaps: GoogleMaps())],
+      // Provide user location for context (as Map)
+      toolConfig: {
+        'retrievalConfig': {
+          'latLng': {
+            'latitude': 40.758896, // Times Square, New York
+            'longitude': -73.985130,
+          },
+          'languageCode': 'en-US',
+        },
+      },
+    ),
+  );
+
+  print('Response: ${_extractText(response)}\n');
+
+  // Access grounding metadata
+  final metadata = response.candidates?.first.groundingMetadata;
+  if (metadata != null) {
+    printPlaceInfo(metadata);
+  }
+}
+
+/// Google Maps grounding with widget token for rendering.
+Future<void> mapsWithWidgetToken(GoogleAIClient client) async {
+  final response = await client.models.generateContent(
+    model: 'gemini-2.5-flash',
+    request: GenerateContentRequest(
+      contents: const [
+        Content(
+          parts: [
+            TextPart(
+              'What are some popular tourist attractions near the Eiffel Tower?',
+            ),
+          ],
+          role: 'user',
+        ),
+      ],
+      // Enable Google Maps with widget support
+      tools: const [Tool(googleMaps: GoogleMaps(enableWidget: true))],
+      // Provide location near Eiffel Tower
+      toolConfig: {
+        'retrievalConfig': {
+          'latLng': {'latitude': 48.858370, 'longitude': 2.294481},
+          'languageCode': 'en-US',
+        },
+      },
+    ),
+  );
+
+  print('Response: ${_extractText(response)}\n');
+
+  // Access grounding metadata
+  final metadata = response.candidates?.first.groundingMetadata;
+  if (metadata != null) {
+    printPlaceInfo(metadata);
+
+    // Widget context token for rendering Google Maps widget
+    if (metadata.googleMapsWidgetContextToken != null) {
+      print('\nWidget Context Token available!');
+      print('Token: ${metadata.googleMapsWidgetContextToken}');
+      print('\nTo render the widget in a web app, use:');
+      print(
+        '<gmp-place-contextual '
+        'context-token="${metadata.googleMapsWidgetContextToken}">'
+        '</gmp-place-contextual>',
+      );
+    }
+  }
+}
+
+/// Helper to print place information from grounding metadata.
+void printPlaceInfo(GroundingMetadata metadata) {
+  if (metadata.groundingChunks != null) {
+    print('Places referenced:');
+    for (final chunk in metadata.groundingChunks!) {
+      if (chunk.maps != null) {
+        final maps = chunk.maps!;
+        print('  - ${maps.title ?? "Unknown"}');
+        if (maps.uri != null) {
+          print('    URL: ${maps.uri}');
+        }
+        if (maps.placeId != null) {
+          print('    Place ID: ${maps.placeId}');
+        }
+        if (maps.text != null) {
+          print('    Description: ${maps.text}');
+        }
+      }
+    }
+  }
+}
+
+/// Helper to extract text from a GenerateContentResponse.
+String _extractText(GenerateContentResponse response) {
+  final buffer = StringBuffer();
+  for (final candidate in response.candidates ?? []) {
+    for (final part in candidate.content?.parts ?? []) {
+      if (part is TextPart) {
+        buffer.write(part.text);
+      }
+    }
+  }
+  return buffer.toString();
+}

--- a/packages/googleai_dart/example/google_search_example.dart
+++ b/packages/googleai_dart/example/google_search_example.dart
@@ -1,0 +1,160 @@
+// ignore_for_file: avoid_print, avoid_dynamic_calls
+/// Demonstrates Google Search grounding for real-time web information.
+///
+/// Google Search grounding enables the model to access current web information
+/// to provide up-to-date, accurate responses with source citations.
+///
+/// Key features:
+/// - Real-time web search during generation
+/// - Grounding metadata with source citations
+/// - Search entry point widget for attribution
+///
+/// See: https://ai.google.dev/gemini-api/docs/google-search
+library;
+
+import 'dart:io';
+
+import 'package:googleai_dart/googleai_dart.dart';
+
+Future<void> main() async {
+  final apiKey = Platform.environment['GOOGLEAI_API_KEY'];
+  if (apiKey == null) {
+    stderr.writeln('No GOOGLEAI_API_KEY environment variable');
+    exit(1);
+  }
+
+  final client = GoogleAIClient(
+    config: GoogleAIConfig(authProvider: ApiKeyProvider(apiKey)),
+  );
+
+  try {
+    print('=== Example 1: Google Search with generateContent ===\n');
+    await googleSearchWithGenerateContent(client);
+
+    print('\n=== Example 2: Google Search with Interactions API ===\n');
+    await googleSearchWithInteractions(client);
+  } finally {
+    client.close();
+  }
+}
+
+/// Google Search grounding using the generateContent API.
+Future<void> googleSearchWithGenerateContent(GoogleAIClient client) async {
+  final response = await client.models.generateContent(
+    model: 'gemini-2.5-flash',
+    request: const GenerateContentRequest(
+      contents: [
+        Content(
+          parts: [TextPart('Who won Euro 2024 and what was the final score?')],
+          role: 'user',
+        ),
+      ],
+      // Enable Google Search grounding with an empty map
+      tools: [Tool(googleSearch: {})],
+    ),
+  );
+
+  // Print the generated response
+  print('Response: ${_extractText(response)}\n');
+
+  // Access grounding metadata
+  final metadata = response.candidates?.first.groundingMetadata;
+  if (metadata != null) {
+    // Search queries executed by the model
+    if (metadata.webSearchQueries != null) {
+      print('Search queries:');
+      for (final query in metadata.webSearchQueries!) {
+        print('  - $query');
+      }
+    }
+
+    // Web sources used for grounding
+    if (metadata.groundingChunks != null) {
+      print('\nSources:');
+      for (final chunk in metadata.groundingChunks!) {
+        if (chunk.web != null) {
+          print('  - ${chunk.web!.title}');
+          print('    ${chunk.web!.uri}');
+        }
+      }
+    }
+
+    // Grounding supports - links text segments to sources
+    if (metadata.groundingSupports != null) {
+      print('\nGrounding supports: ${metadata.groundingSupports!.length}');
+    }
+
+    // Search entry point - HTML/CSS widget for attribution (required to display)
+    if (metadata.searchEntryPoint?.renderedContent != null) {
+      print('\nSearch widget available (use for attribution)');
+      // The renderedContent contains HTML that should be displayed
+      // to comply with attribution requirements
+    }
+  }
+}
+
+/// Google Search grounding using the Interactions API (streaming).
+Future<void> googleSearchWithInteractions(GoogleAIClient client) async {
+  print("Question: What are today's top technology news?\n");
+  print('Response (streaming):');
+
+  await for (final event in client.interactions.createStream(
+    model: 'gemini-2.5-flash',
+    input: "What are today's top technology news? Give me 3 headlines.",
+    tools: const [GoogleSearchTool()],
+  )) {
+    switch (event) {
+      case InteractionStartEvent():
+        print('[Stream started: ${event.interaction?.id}]');
+      case ContentStartEvent():
+        // Content block is starting
+        final content = event.content;
+        if (content != null) {
+          print('[Content type: ${content.type}]');
+        }
+      case ContentDeltaEvent():
+        final delta = event.delta;
+        if (delta is TextDelta) {
+          // Print text as it streams
+          stdout.write(delta.text);
+        } else if (delta is GoogleSearchCallDelta) {
+          // Model is making a search call
+          if (delta.queries != null && delta.queries!.isNotEmpty) {
+            print('\n[Searching: ${delta.queries!.join(", ")}]');
+          }
+        } else if (delta is GoogleSearchResultDelta) {
+          // Search results received
+          print('\n[Search results received]');
+        }
+      case ContentStopEvent():
+        print('\n[Content block completed]');
+      case InteractionCompleteEvent():
+        print('\n[Stream completed]');
+        // Access final usage stats
+        if (event.interaction?.usage != null) {
+          final usage = event.interaction!.usage!;
+          print(
+            'Tokens - Input: ${usage.totalInputTokens}, '
+            'Output: ${usage.totalOutputTokens}',
+          );
+        }
+      case ErrorEvent():
+        print('\n[Error: ${event.error?.message}]');
+      default:
+        break;
+    }
+  }
+}
+
+/// Helper to extract text from a GenerateContentResponse.
+String _extractText(GenerateContentResponse response) {
+  final buffer = StringBuffer();
+  for (final candidate in response.candidates ?? []) {
+    for (final part in candidate.content?.parts ?? []) {
+      if (part is TextPart) {
+        buffer.write(part.text);
+      }
+    }
+  }
+  return buffer.toString();
+}

--- a/packages/googleai_dart/example/url_context_example.dart
+++ b/packages/googleai_dart/example/url_context_example.dart
@@ -1,0 +1,155 @@
+// ignore_for_file: avoid_print, avoid_dynamic_calls
+/// Demonstrates URL Context tool for fetching and analyzing web content.
+///
+/// The URL Context tool enables the model to retrieve and process content
+/// from specific URLs provided in the prompt.
+///
+/// Key features:
+/// - Fetch and analyze content from up to 20 URLs per request
+/// - Supports HTML, JSON, text, XML, CSS, JavaScript, CSV, RTF, images, PDFs
+/// - Maximum 34MB content per URL
+///
+/// Limitations:
+/// - Does NOT support: paywalled content, YouTube videos, Google Workspace
+///   files, video/audio files
+///
+/// See: https://ai.google.dev/gemini-api/docs/url-context
+library;
+
+import 'dart:io';
+
+import 'package:googleai_dart/googleai_dart.dart';
+
+Future<void> main() async {
+  final apiKey = Platform.environment['GOOGLEAI_API_KEY'];
+  if (apiKey == null) {
+    stderr.writeln('No GOOGLEAI_API_KEY environment variable');
+    exit(1);
+  }
+
+  final client = GoogleAIClient(
+    config: GoogleAIConfig(authProvider: ApiKeyProvider(apiKey)),
+  );
+
+  try {
+    print('=== Example 1: URL Context with generateContent ===\n');
+    await urlContextWithGenerateContent(client);
+
+    print('\n=== Example 2: URL Context with Interactions API ===\n');
+    await urlContextWithInteractions(client);
+
+    print('\n=== Example 3: Comparing Multiple URLs ===\n');
+    await compareMultipleUrls(client);
+  } finally {
+    client.close();
+  }
+}
+
+/// URL Context using the generateContent API.
+Future<void> urlContextWithGenerateContent(GoogleAIClient client) async {
+  final response = await client.models.generateContent(
+    model: 'gemini-2.5-flash',
+    request: const GenerateContentRequest(
+      contents: [
+        Content(
+          parts: [
+            TextPart(
+              'Summarize the main points from this page: '
+              'https://dart.dev/overview',
+            ),
+          ],
+          role: 'user',
+        ),
+      ],
+      // Enable URL Context with an empty map
+      tools: [Tool(urlContext: {})],
+    ),
+  );
+
+  print('Response:');
+  print(_extractText(response));
+
+  // Note: The API may return URL context metadata in the response
+  // for tracking which URLs were successfully fetched
+}
+
+/// URL Context using the Interactions API (streaming).
+Future<void> urlContextWithInteractions(GoogleAIClient client) async {
+  print('Analyzing URL content (streaming):\n');
+
+  await for (final event in client.interactions.createStream(
+    model: 'gemini-2.5-flash',
+    input:
+        'What are the key features mentioned on https://pub.dev/packages/googleai_dart ?',
+    tools: const [UrlContextTool()],
+  )) {
+    switch (event) {
+      case InteractionStartEvent():
+        print('[Stream started]');
+      case ContentStartEvent():
+        final content = event.content;
+        if (content != null) {
+          print('[Content type: ${content.type}]');
+        }
+      case ContentDeltaEvent():
+        final delta = event.delta;
+        if (delta is TextDelta) {
+          stdout.write(delta.text);
+        } else if (delta is UrlContextCallDelta) {
+          // Model is fetching a URL
+          if (delta.urls != null && delta.urls!.isNotEmpty) {
+            print('\n[Fetching URLs: ${delta.urls!.join(", ")}]');
+          }
+        } else if (delta is UrlContextResultDelta) {
+          // URL content retrieved
+          print('\n[URL content retrieved]');
+        }
+      case ContentStopEvent():
+        print('\n[Content completed]');
+      case InteractionCompleteEvent():
+        print('[Stream completed]');
+      default:
+        break;
+    }
+  }
+}
+
+/// Compare content from multiple URLs.
+Future<void> compareMultipleUrls(GoogleAIClient client) async {
+  // You can reference up to 20 URLs in a single request
+  final response = await client.models.generateContent(
+    model: 'gemini-2.5-flash',
+    request: const GenerateContentRequest(
+      contents: [
+        Content(
+          parts: [
+            TextPart(
+              'Compare the documentation styles of these two pages:\n'
+              '1. https://dart.dev/language\n'
+              '2. https://flutter.dev/development\n\n'
+              'Which one is more beginner-friendly and why?',
+            ),
+          ],
+          role: 'user',
+        ),
+      ],
+      tools: [Tool(urlContext: {})],
+    ),
+  );
+
+  print('Comparison:');
+  print(_extractText(response));
+}
+
+/// Helper to extract text from a GenerateContentResponse.
+String _extractText(GenerateContentResponse response) {
+  final buffer = StringBuffer();
+  for (final candidate in response.candidates ?? []) {
+    for (final part in candidate.content?.parts ?? []) {
+      if (part is TextPart) {
+        buffer.write(part.text);
+      }
+    }
+  }
+  return buffer.toString();
+}


### PR DESCRIPTION
## Summary
Add comprehensive documentation for grounding tools in googleai_dart.

## Changes
- **README.md**: Added "Grounding Tools" section with collapsible documentation for:
  - Google Search grounding
  - URL Context (fetch and analyze web content)
  - File Search (semantic retrieval)
  - Google Maps (geospatial context)
- **Examples**: Added complete example files:
  - `google_search_example.dart`
  - `url_context_example.dart`
  - `file_search_example.dart`
  - `google_maps_example.dart`

## Test Plan
- [x] Example files compile (dart analyze)
- [x] README code patterns validated (verify_readme_code.py)