### PR TITLE
feat(googleai_dart): Update default models to Gemini 3 family

### DIFF
--- a/packages/googleai_dart/MIGRATION.md
+++ b/packages/googleai_dart/MIGRATION.md
@@ -77,7 +77,7 @@ import 'package:googleai_dart/googleai_dart.dart';
 
 // Before
 final r1 = await old.generateContent(
-  modelId: 'gemini-2.5-flash',
+  modelId: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [Content(parts: [TextPart('Hello')], role: 'user')],
   ),
@@ -85,7 +85,7 @@ final r1 = await old.generateContent(
 
 // After
 final r2 = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [Content(parts: [TextPart('Hello')], role: 'user')],
   ),
@@ -102,13 +102,13 @@ final r2 = await client.models.generateContent(
 ```dart
 // Before
 await for (final chunk in old.streamGenerateContent(
-  modelId: 'gemini-2.5-flash',
+  modelId: 'gemini-3-flash-preview',
   request: request,
 )) { /* ... */ }
 
 // After
 await for (final chunk in client.models.streamGenerateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: request,
 )) { /* ... */ }
 ```
@@ -145,7 +145,7 @@ final batch = await client.models.batchEmbedContents(
 ```dart
 // Before
 final t1 = await old.countTokens(
-  modelId: 'gemini-2.5-flash',
+  modelId: 'gemini-3-flash-preview',
   request: CountTokensRequest(
     contents: [Content(parts: [TextPart('Hello')], role: 'user')],
   ),
@@ -153,7 +153,7 @@ final t1 = await old.countTokens(
 
 // After
 final t2 = await client.models.countTokens(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: CountTokensRequest(
     contents: [Content(parts: [TextPart('Hello')], role: 'user')],
   ),
@@ -165,11 +165,11 @@ final t2 = await client.models.countTokens(
 ```dart
 // Before
 final list1 = await old.listModels();
-final m1 = await old.getModel(modelId: 'gemini-2.5-flash');
+final m1 = await old.getModel(modelId: 'gemini-3-flash-preview');
 
 // After
 final list2 = await client.models.list();
-final m2 = await client.models.get(model: 'gemini-2.5-flash');
+final m2 = await client.models.get(model: 'gemini-3-flash-preview');
 ```
 
 ## 7) Files API (New, Google AI only)
@@ -202,7 +202,7 @@ await client.files.delete(name: file.name);
 // Create cached content with system instructions
 final cached = await client.cachedContents.create(
   cachedContent: CachedContent(
-    model: 'models/gemini-1.5-flash-8b',
+    model: 'models/gemini-3-flash-preview',
     systemInstruction: Content(
       parts: [TextPart('You are a helpful assistant.')],
     ),
@@ -212,7 +212,7 @@ final cached = await client.cachedContents.create(
 
 // Use cached content in generation
 final res = await client.models.generateContent(
-  model: 'gemini-1.5-flash-8b',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     cachedContent: cached.name,
     contents: [Content(parts: [TextPart('Explain Pythagoras')], role: 'user')],
@@ -232,10 +232,10 @@ await client.cachedContents.delete(name: cached.name!);
 
 ```dart
 final batch = await client.models.batchGenerateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   batch: GenerateContentBatch(
     displayName: 'My Batch',
-    model: 'models/gemini-2.5-flash',
+    model: 'models/gemini-3-flash-preview',
     inputConfig: InputConfig(
       requests: InlinedRequests(
         requests: [

--- a/packages/googleai_dart/README.md
+++ b/packages/googleai_dart/README.md
@@ -165,7 +165,7 @@ final client = GoogleAIClient(
 );
 
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [
       Content(
@@ -261,7 +261,7 @@ final vertexClient = GoogleAIClient(
 
 // Use the same API as Google AI
 final response = await vertexClient.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [
       Content(
@@ -379,7 +379,7 @@ final client = GoogleAIClient(
 );
 
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [
       Content(
@@ -406,7 +406,7 @@ import 'package:googleai_dart/googleai_dart.dart';
 
 // Assumes you have a configured client instance
 await for (final chunk in client.models.streamGenerateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: request,
 )) {
   // Process each chunk as it arrives
@@ -433,7 +433,7 @@ final abortController = Completer<void>();
 
 // Start request with abort capability
 final requestFuture = client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: request,
   abortTrigger: abortController.future,
 );
@@ -454,7 +454,7 @@ This works for both regular and streaming requests. You can also use it with tim
 ```dart
 // Auto-cancel after 30 seconds
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: request,
   abortTrigger: Future.delayed(Duration(seconds: 30)),
 );
@@ -490,7 +490,7 @@ final tools = [
 ];
 
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [/* ... */],
     tools: tools,
@@ -511,7 +511,7 @@ Ground responses with real-time web information:
 
 ```dart
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [
       Content(
@@ -555,7 +555,7 @@ Or use the Interactions API for streaming:
 
 ```dart
 await for (final event in client.interactions.createStream(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   input: 'What are today\'s top technology news?',
   tools: [GoogleSearchTool()],
 )) {
@@ -580,7 +580,7 @@ Fetch and analyze content from specific URLs (up to 20 URLs, max 34MB per URL):
 
 ```dart
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [
       Content(
@@ -607,7 +607,7 @@ Or with the Interactions API:
 
 ```dart
 await for (final event in client.interactions.createStream(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   input: 'Summarize https://pub.dev/packages/googleai_dart',
   tools: [UrlContextTool()],
 )) {
@@ -632,7 +632,7 @@ Add geospatial context for location-based queries:
 
 ```dart
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [
       Content(
@@ -706,7 +706,7 @@ final uploadResponse = await client.fileSearchStores.upload(
 
 // Use FileSearch in generation with optional metadata filter
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [
       Content(
@@ -797,7 +797,7 @@ while (file.state == FileState.processing) {
 
 // Use the file in a prompt
 final response = await client.models.generateContent(
-  model: 'gemini-2.0-flash-exp',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [
       Content(
@@ -847,7 +847,7 @@ import 'package:googleai_dart/googleai_dart.dart';
 // Create cached content with system instructions
 final cachedContent = await client.cachedContents.create(
   cachedContent: const CachedContent(
-    model: 'models/gemini-1.5-flash-8b',
+    model: 'models/gemini-3-flash-preview',
     displayName: 'Math Expert Cache',
     systemInstruction: Content(
       parts: [TextPart('You are an expert mathematician...')],
@@ -858,7 +858,7 @@ final cachedContent = await client.cachedContents.create(
 
 // Use cached content in requests (saves tokens!)
 final response = await client.models.generateContent(
-  model: 'gemini-1.5-flash-8b',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     cachedContent: cachedContent.name,
     contents: [
@@ -871,7 +871,7 @@ final response = await client.models.generateContent(
 await client.cachedContents.update(
   name: cachedContent.name!,
   cachedContent: const CachedContent(
-    model: 'models/gemini-1.5-flash-8b',
+    model: 'models/gemini-3-flash-preview',
     ttl: '7200s', // Extend to 2 hours
   ),
   updateMask: 'ttl',
@@ -974,11 +974,11 @@ import 'package:googleai_dart/googleai_dart.dart';
 
 // Assumes you have a configured client instance
 // Create a batch for processing multiple requests
+// The model in the batch is auto-populated from the method parameter
 final batch = await client.models.batchGenerateContent(
-  model: 'gemini-2.0-flash-exp',
+  model: 'gemini-3-flash-preview',
   batch: const GenerateContentBatch(
     displayName: 'My Batch Job',
-    model: 'models/gemini-2.0-flash-exp',
     inputConfig: InputConfig(
       requests: InlinedRequests(
         requests: [
@@ -1157,10 +1157,10 @@ await for (final chunk in client.tunedModels.streamGenerateContent(
 }
 
 // Batch generation with a tuned model
+// The model in the batch is auto-populated from the tunedModel parameter
 final batch = await client.tunedModels.batchGenerateContent(
   tunedModel: 'my-model-abc123',
   batch: const GenerateContentBatch(
-    model: 'models/placeholder',
     displayName: 'My Batch Job',
     inputConfig: InputConfig(
       requests: InlinedRequests(

--- a/packages/googleai_dart/example/abort_example.dart
+++ b/packages/googleai_dart/example/abort_example.dart
@@ -20,7 +20,7 @@ void main() async {
 
     // Start a long-running request
     final requestFuture = client.models.generateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: const GenerateContentRequest(
         contents: [
           Content(
@@ -92,7 +92,7 @@ void main() async {
 
     // Start streaming
     await for (final chunk in streamingClient.models.streamGenerateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: const GenerateContentRequest(
         contents: [
           Content(

--- a/packages/googleai_dart/example/api_versions_example.dart
+++ b/packages/googleai_dart/example/api_versions_example.dart
@@ -68,7 +68,7 @@ Future<void> usingV1(String apiKey) async {
     print('Generating content with v1 API...');
 
     final response = await client.models.generateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: const GenerateContentRequest(
         contents: [
           Content(
@@ -110,7 +110,7 @@ Future<void> usingV1Beta(String apiKey) async {
     print('Generating content with v1beta API...');
 
     final response = await client.models.generateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: const GenerateContentRequest(
         contents: [
           Content(
@@ -150,7 +150,7 @@ Future<void> usingDefault(String apiKey) async {
     print('Generating content with default config (v1beta)...');
 
     final response = await client.models.generateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: const GenerateContentRequest(
         contents: [
           Content(parts: [TextPart('What is machine learning?')], role: 'user'),

--- a/packages/googleai_dart/example/batch_example.dart
+++ b/packages/googleai_dart/example/batch_example.dart
@@ -102,9 +102,7 @@ void main() async {
     print('4. Updating batch display name...');
     final updatedBatch = await client.batches.updateGenerateContentBatch(
       name: generateBatch.name!,
-      batch: const GenerateContentBatch(
-        displayName: 'Math Questions Batch v2',
-      ),
+      batch: const GenerateContentBatch(displayName: 'Math Questions Batch v2'),
       updateMask: 'displayName',
     );
     print('   ✓ Updated display name: ${updatedBatch.displayName}\n');

--- a/packages/googleai_dart/example/caching_example.dart
+++ b/packages/googleai_dart/example/caching_example.dart
@@ -39,7 +39,7 @@ Future<void> demonstrateCaching(GoogleAIClient client) async {
   print('1. Creating cached content with system instructions...');
   final cachedContent = await client.cachedContents.create(
     cachedContent: const CachedContent(
-      model: 'models/gemini-1.5-flash-8b',
+      model: 'models/gemini-3-flash-preview',
       displayName: 'Math Expert Cache',
       systemInstruction: Content(
         parts: [
@@ -69,7 +69,7 @@ Future<void> demonstrateCaching(GoogleAIClient client) async {
   // 2. Use cached content in a request
   print('2. Using cached content in generation...');
   final response = await client.models.generateContent(
-    model: 'gemini-1.5-flash-8b',
+    model: 'gemini-3-flash-preview',
     request: GenerateContentRequest(
       cachedContent: cachedContent.name,
       contents: const [
@@ -118,7 +118,7 @@ Future<void> demonstrateCaching(GoogleAIClient client) async {
   final updated = await client.cachedContents.update(
     name: cachedContent.name!,
     cachedContent: const CachedContent(
-      model: 'models/gemini-1.5-flash-8b',
+      model: 'models/gemini-3-flash-preview',
       ttl: '7200s', // Extend to 2 hours
     ),
     updateMask: 'ttl',
@@ -132,7 +132,7 @@ Future<void> demonstrateCaching(GoogleAIClient client) async {
   // final updatedWithExpireTime = await client.cachedContents.update(
   //   name: cachedContent.name!,
   //   cachedContent: CachedContent(
-  //     model: 'models/gemini-1.5-flash-8b',
+  //     model: 'models/gemini-3-flash-preview',
   //     expireTime: absoluteExpiry,
   //   ),
   //   updateMask: 'expireTime',

--- a/packages/googleai_dart/example/complete_api_example.dart
+++ b/packages/googleai_dart/example/complete_api_example.dart
@@ -20,7 +20,7 @@ void main() async {
     // List operations for a specific model
     // This is useful for monitoring async tasks like batch processing
     final modelOps = await client.models
-        .operations(model: 'models/gemini-2.0-flash-exp')
+        .operations(model: 'models/gemini-3-flash-preview')
         .list(pageSize: 5);
     final ops = modelOps.operations;
     print('Operations for model: ${ops.length}');

--- a/packages/googleai_dart/example/error_handling_example.dart
+++ b/packages/googleai_dart/example/error_handling_example.dart
@@ -12,7 +12,7 @@ void main() async {
   try {
     // Make a request that might fail
     final response = await client.models.generateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: const GenerateContentRequest(
         contents: [
           Content(parts: [TextPart('Hello!')], role: 'user'),

--- a/packages/googleai_dart/example/example.dart
+++ b/packages/googleai_dart/example/example.dart
@@ -24,7 +24,7 @@ void main() async {
   try {
     // Generate content using Gemini
     final response = await client.models.generateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: const GenerateContentRequest(
         contents: [
           Content(

--- a/packages/googleai_dart/example/file_search_example.dart
+++ b/packages/googleai_dart/example/file_search_example.dart
@@ -119,7 +119,7 @@ To get started with Dart, install the Dart SDK from dart.dev.
     // Use the store for generation
     print('\nQuerying the knowledge base...');
     final response = await client.models.generateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: GenerateContentRequest(
         contents: const [
           Content(
@@ -170,7 +170,7 @@ Future<void> fileSearchWithGenerateContent(GoogleAIClient client) async {
   print(r'''
 // Filter documents by metadata
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [...],
     tools: [
@@ -199,7 +199,7 @@ Future<void> fileSearchWithInteractions(GoogleAIClient client) async {
   print(r'''
 // Stream responses with file search
 await for (final event in client.interactions.createStream(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   input: 'Summarize the key points from my documents',
   tools: [
     FileSearchTool(

--- a/packages/googleai_dart/example/files_example.dart
+++ b/packages/googleai_dart/example/files_example.dart
@@ -118,7 +118,7 @@ void main() async {
     print('\n💡 You can now use this file in prompts:');
     print('   ```dart');
     print('   final response = await client.models.generateContent(');
-    print('     model: "gemini-2.0-flash-exp",');
+    print('     model: "gemini-3-flash-preview",');
     print('     request: GenerateContentRequest(');
     print('       contents: [');
     print('         Content(');

--- a/packages/googleai_dart/example/function_calling_example.dart
+++ b/packages/googleai_dart/example/function_calling_example.dart
@@ -55,7 +55,7 @@ void main() async {
     print('Asking: What is the weather in London?\n');
 
     final response = await client.models.generateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: GenerateContentRequest(
         contents: [
           const Content(

--- a/packages/googleai_dart/example/generate_content.dart
+++ b/packages/googleai_dart/example/generate_content.dart
@@ -25,7 +25,7 @@ void main() async {
 
     // Generate content
     final response = await client.models.generateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: request,
     );
 

--- a/packages/googleai_dart/example/google_maps_example.dart
+++ b/packages/googleai_dart/example/google_maps_example.dart
@@ -44,7 +44,7 @@ Future<void> main() async {
 /// Basic Google Maps grounding without location context.
 Future<void> basicMapsGrounding(GoogleAIClient client) async {
   final response = await client.models.generateContent(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     request: const GenerateContentRequest(
       contents: [
         Content(
@@ -69,7 +69,7 @@ Future<void> basicMapsGrounding(GoogleAIClient client) async {
 /// Google Maps grounding with user location context.
 Future<void> mapsWithLocationContext(GoogleAIClient client) async {
   final response = await client.models.generateContent(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     request: GenerateContentRequest(
       contents: const [
         Content(
@@ -104,7 +104,7 @@ Future<void> mapsWithLocationContext(GoogleAIClient client) async {
 /// Google Maps grounding with widget token for rendering.
 Future<void> mapsWithWidgetToken(GoogleAIClient client) async {
   final response = await client.models.generateContent(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     request: GenerateContentRequest(
       contents: const [
         Content(

--- a/packages/googleai_dart/example/google_search_example.dart
+++ b/packages/googleai_dart/example/google_search_example.dart
@@ -41,7 +41,7 @@ Future<void> main() async {
 /// Google Search grounding using the generateContent API.
 Future<void> googleSearchWithGenerateContent(GoogleAIClient client) async {
   final response = await client.models.generateContent(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     request: const GenerateContentRequest(
       contents: [
         Content(
@@ -99,7 +99,7 @@ Future<void> googleSearchWithInteractions(GoogleAIClient client) async {
   print('Response (streaming):');
 
   await for (final event in client.interactions.createStream(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     input: "What are today's top technology news? Give me 3 headlines.",
     tools: const [GoogleSearchTool()],
   )) {

--- a/packages/googleai_dart/example/interactions_example.dart
+++ b/packages/googleai_dart/example/interactions_example.dart
@@ -38,7 +38,7 @@ Future<void> simpleInteraction(GoogleAIClient client) async {
   print('=== Simple Interaction ===\n');
 
   final interaction = await client.interactions.create(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     input: 'What is the capital of France?',
   );
 
@@ -68,7 +68,7 @@ Future<void> streamingInteraction(GoogleAIClient client) async {
   print('=== Streaming Interaction ===\n');
 
   await for (final event in client.interactions.createStream(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     input: 'Write a haiku about programming.',
   )) {
     switch (event) {
@@ -103,7 +103,7 @@ Future<void> multiTurnConversation(GoogleAIClient client) async {
 
   // First turn
   final turn1 = await client.interactions.create(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     input: 'My name is Alice.',
   );
   print('Turn 1 - User: My name is Alice.');
@@ -111,7 +111,7 @@ Future<void> multiTurnConversation(GoogleAIClient client) async {
 
   // Second turn - references the first interaction
   final turn2 = await client.interactions.create(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     input: 'What is my name?',
     previousInteractionId: turn1.id,
   );
@@ -142,7 +142,7 @@ Future<void> functionCallingInteraction(GoogleAIClient client) async {
 
   // Stream the interaction to see function calls in real-time
   await for (final event in client.interactions.createStream(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     input: 'What is the weather in Paris?',
     tools: tools,
   )) {

--- a/packages/googleai_dart/example/oauth_refresh_example.dart
+++ b/packages/googleai_dart/example/oauth_refresh_example.dart
@@ -113,7 +113,7 @@ void main() async {
     // In production with real OAuth tokens, this would succeed.
     try {
       await client.models.generateContent(
-        model: 'gemini-2.5-flash',
+        model: 'gemini-3-flash-preview',
         request: const GenerateContentRequest(
           contents: [
             Content(parts: [TextPart('Say hello')], role: 'user'),
@@ -139,7 +139,7 @@ void main() async {
 
     try {
       await client.models.generateContent(
-        model: 'gemini-2.5-flash',
+        model: 'gemini-3-flash-preview',
         request: const GenerateContentRequest(
           contents: [
             Content(parts: [TextPart('Say hello again')], role: 'user'),

--- a/packages/googleai_dart/example/streaming_example.dart
+++ b/packages/googleai_dart/example/streaming_example.dart
@@ -14,7 +14,7 @@ void main() async {
 
     // Stream content generation - receives chunks as they're generated
     await for (final chunk in client.models.streamGenerateContent(
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3-flash-preview',
       request: const GenerateContentRequest(
         contents: [
           Content(

--- a/packages/googleai_dart/example/url_context_example.dart
+++ b/packages/googleai_dart/example/url_context_example.dart
@@ -48,7 +48,7 @@ Future<void> main() async {
 /// URL Context using the generateContent API.
 Future<void> urlContextWithGenerateContent(GoogleAIClient client) async {
   final response = await client.models.generateContent(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     request: const GenerateContentRequest(
       contents: [
         Content(
@@ -78,7 +78,7 @@ Future<void> urlContextWithInteractions(GoogleAIClient client) async {
   print('Analyzing URL content (streaming):\n');
 
   await for (final event in client.interactions.createStream(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     input:
         'What are the key features mentioned on https://pub.dev/packages/googleai_dart ?',
     tools: const [UrlContextTool()],
@@ -118,7 +118,7 @@ Future<void> urlContextWithInteractions(GoogleAIClient client) async {
 Future<void> compareMultipleUrls(GoogleAIClient client) async {
   // You can reference up to 20 URLs in a single request
   final response = await client.models.generateContent(
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3-flash-preview',
     request: const GenerateContentRequest(
       contents: [
         Content(

--- a/packages/googleai_dart/example/vertex_ai_example.dart
+++ b/packages/googleai_dart/example/vertex_ai_example.dart
@@ -126,7 +126,7 @@ final client = GoogleAIClient(
 
 // Use the same API as Google AI!
 final response = await client.models.generateContent(
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3-flash-preview',
   request: GenerateContentRequest(
     contents: [
       Content(

--- a/packages/googleai_dart/lib/src/client/googleai_client.dart
+++ b/packages/googleai_dart/lib/src/client/googleai_client.dart
@@ -52,7 +52,7 @@ import 'retry_wrapper.dart';
 ///
 /// // Generate content
 /// final response = await client.models.generateContent(
-///   model: 'gemini-2.5-flash',
+///   model: 'gemini-3-flash-preview',
 ///   request: GenerateContentRequest(
 ///     contents: [
 ///       Content(parts: [TextPart('Hello!')], role: 'user'),

--- a/packages/googleai_dart/lib/src/models/caching/cached_content.dart
+++ b/packages/googleai_dart/lib/src/models/caching/cached_content.dart
@@ -13,7 +13,7 @@ import 'cached_content_usage_metadata.dart';
 /// ## Creating Cached Content
 ///
 /// **Required fields**:
-/// - [model]: The model to use with this cache (e.g., "models/gemini-1.5-flash")
+/// - [model]: The model to use with this cache (e.g., "models/gemini-3-flash-preview")
 ///
 /// **Expiration** (must provide one):
 /// - [ttl]: Duration string (e.g., "3600s" for 1 hour, "7200s" for 2 hours)
@@ -53,7 +53,7 @@ import 'cached_content_usage_metadata.dart';
 /// // Create cache with system instruction
 /// final cache = await client.createCachedContent(
 ///   cachedContent: CachedContent(
-///     model: 'models/gemini-1.5-flash',
+///     model: 'models/gemini-3-flash-preview',
 ///     displayName: 'Math Expert',
 ///     systemInstruction: Content(
 ///       parts: [TextPart('You are a math expert...')],
@@ -64,7 +64,7 @@ import 'cached_content_usage_metadata.dart';
 ///
 /// // Use cache in generation requests
 /// final response = await client.generateContent(
-///   model: 'gemini-1.5-flash',
+///   model: 'gemini-3-flash-preview',
 ///   request: GenerateContentRequest(
 ///     cachedContent: cache.name,
 ///     contents: [Content(parts: [TextPart('What is 2+2?')])],
@@ -84,7 +84,7 @@ class CachedContent {
 
   /// Required. Immutable. The model to use with this cached content.
   ///
-  /// Format: `models/{model}` (e.g., "models/gemini-1.5-flash-8b")
+  /// Format: `models/{model}` (e.g., "models/gemini-3-flash-preview-8b")
   ///
   /// The cached content can only be used with this specific model.
   final String? model;

--- a/packages/googleai_dart/lib/src/models/models/model.dart
+++ b/packages/googleai_dart/lib/src/models/models/model.dart
@@ -5,7 +5,7 @@ class Model {
   /// The resource name in format `models/{model}`.
   final String name;
 
-  /// The name of the base model (e.g., "gemini-1.5-flash").
+  /// The name of the base model (e.g., "gemini-3-flash-preview").
   final String? baseModelId;
 
   /// The human-readable name (e.g., "Gemini 1.5 Pro").

--- a/packages/googleai_dart/lib/src/resources/interactions_resource.dart
+++ b/packages/googleai_dart/lib/src/resources/interactions_resource.dart
@@ -32,7 +32,7 @@ class InteractionsResource extends ResourceBase {
 
   /// Creates a new interaction.
   ///
-  /// The [model] specifies which model to use (e.g., "gemini-2.5-flash").
+  /// The [model] specifies which model to use (e.g., "gemini-3-flash-preview").
   /// The [input] can be a [String], a [List<InteractionContent>], or
   /// a list of turns for multi-turn conversations.
   ///

--- a/packages/googleai_dart/test/integration/test_config.dart
+++ b/packages/googleai_dart/test/integration/test_config.dart
@@ -5,7 +5,7 @@
 library;
 
 /// The default generative model to use for content generation tests.
-const defaultGenerativeModel = 'gemini-2.5-flash';
+const defaultGenerativeModel = 'gemini-3-flash-preview';
 
 /// The default embedding model to use for embedding tests.
 const defaultEmbeddingModel = 'gemini-embedding-001';

--- a/packages/googleai_dart/test/unit/models/interactions/interaction_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/interaction_test.dart
@@ -7,7 +7,7 @@ void main() {
       test('creates Interaction with all fields', () {
         final json = {
           'id': 'abc-123',
-          'model': 'gemini-2.5-flash',
+          'model': 'gemini-3-flash-preview',
           'status': 'completed',
           'created': '2024-01-15T10:30:00Z',
           'updated': '2024-01-15T10:31:00Z',
@@ -29,7 +29,7 @@ void main() {
         final interaction = Interaction.fromJson(json);
 
         expect(interaction.id, 'abc-123');
-        expect(interaction.model, 'gemini-2.5-flash');
+        expect(interaction.model, 'gemini-3-flash-preview');
         expect(interaction.status, InteractionStatus.completed);
         expect(interaction.created, DateTime.parse('2024-01-15T10:30:00Z'));
         expect(interaction.updated, DateTime.parse('2024-01-15T10:31:00Z'));
@@ -112,7 +112,7 @@ void main() {
       final original = Interaction(
         id: 'roundtrip-789',
         status: InteractionStatus.inProgress,
-        model: 'gemini-2.5-flash',
+        model: 'gemini-3-flash-preview',
         created: DateTime.parse('2024-03-10T12:00:00Z'),
         usage: const InteractionUsage(
           totalInputTokens: 50,

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
@@ -174,8 +174,8 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
     this.appCheck,
     this.auth,
     this.location,
-  })  : _currentModel = defaultOptions.model ?? '',
-        _currentBackend = defaultBackend {
+  }) : _currentModel = defaultOptions.model ?? '',
+       _currentBackend = defaultBackend {
     _firebaseClient = _createFirebaseClient(_currentModel);
   }
 
@@ -329,11 +329,11 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
 
     final firebaseAI = switch (effectiveBackend) {
       FirebaseAIBackend.vertexAI => FirebaseAI.vertexAI(
-          app: app,
-          appCheck: appCheck,
-          auth: auth,
-          location: location,
-        ),
+        app: app,
+        appCheck: appCheck,
+        auth: auth,
+        location: location,
+      ),
       FirebaseAIBackend.googleAI => FirebaseAI.googleAI(app: app),
     };
 

--- a/packages/openai_dart/test/image_gen_usage_test.dart
+++ b/packages/openai_dart/test/image_gen_usage_test.dart
@@ -81,8 +81,7 @@ void main() {
       expect(json['total_tokens'], 1500);
       expect(json['input_tokens'], 1000);
       expect(json['output_tokens'], 500);
-      final inputDetails =
-          json['input_tokens_details'] as Map<String, dynamic>;
+      final inputDetails = json['input_tokens_details'] as Map<String, dynamic>;
       expect(inputDetails['text_tokens'], 700);
       expect(inputDetails['image_tokens'], 300);
     });

--- a/packages/openai_dart/test/images_response_test.dart
+++ b/packages/openai_dart/test/images_response_test.dart
@@ -46,7 +46,11 @@ void main() {
     });
 
     test('deserializes with opaque background', () {
-      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'background': 'opaque'};
+      final json = {
+        'created': 1700000000,
+        'data': <Map<String, dynamic>>[],
+        'background': 'opaque',
+      };
 
       final response = ImagesResponse.fromJson(json);
 
@@ -54,7 +58,11 @@ void main() {
     });
 
     test('deserializes with webp output format', () {
-      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'output_format': 'webp'};
+      final json = {
+        'created': 1700000000,
+        'data': <Map<String, dynamic>>[],
+        'output_format': 'webp',
+      };
 
       final response = ImagesResponse.fromJson(json);
 
@@ -62,7 +70,11 @@ void main() {
     });
 
     test('deserializes with jpeg output format', () {
-      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'output_format': 'jpeg'};
+      final json = {
+        'created': 1700000000,
+        'data': <Map<String, dynamic>>[],
+        'output_format': 'jpeg',
+      };
 
       final response = ImagesResponse.fromJson(json);
 
@@ -70,7 +82,11 @@ void main() {
     });
 
     test('deserializes with 1024x1536 size', () {
-      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'size': '1024x1536'};
+      final json = {
+        'created': 1700000000,
+        'data': <Map<String, dynamic>>[],
+        'size': '1024x1536',
+      };
 
       final response = ImagesResponse.fromJson(json);
 
@@ -78,7 +94,11 @@ void main() {
     });
 
     test('deserializes with 1536x1024 size', () {
-      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'size': '1536x1024'};
+      final json = {
+        'created': 1700000000,
+        'data': <Map<String, dynamic>>[],
+        'size': '1536x1024',
+      };
 
       final response = ImagesResponse.fromJson(json);
 
@@ -86,7 +106,11 @@ void main() {
     });
 
     test('deserializes with low quality', () {
-      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'quality': 'low'};
+      final json = {
+        'created': 1700000000,
+        'data': <Map<String, dynamic>>[],
+        'quality': 'low',
+      };
 
       final response = ImagesResponse.fromJson(json);
 
@@ -94,7 +118,11 @@ void main() {
     });
 
     test('deserializes with medium quality', () {
-      final json = {'created': 1700000000, 'data': <Map<String, dynamic>>[], 'quality': 'medium'};
+      final json = {
+        'created': 1700000000,
+        'data': <Map<String, dynamic>>[],
+        'quality': 'medium',
+      };
 
       final response = ImagesResponse.fromJson(json);
 


### PR DESCRIPTION
## Summary

Updates all examples, tests, and documentation to use the new Gemini 3 model family (`gemini-3-flash-preview`) as the default.

## Changes

- Updated all examples to use `gemini-3-flash-preview`
- Updated README.md with new model names and batch API improvements
- Updated MIGRATION.md with model transition guidance
- Updated test configuration to use `gemini-3-flash-preview`
- Updated default model constants in client

## Files Changed

| Category | Files |
|----------|-------|
| Examples | 18 example files updated |
| Documentation | README.md, MIGRATION.md |
| Source | googleai_client.dart, cached_content.dart, model.dart, interactions_resource.dart |
| Tests | test_config.dart, interaction_test.dart |

## Test plan

- [x] All unit tests pass
- [x] `dart analyze` passes with no issues