### PR TITLE
docs: add Tuning Engines OpenAI-compatible example

### DIFF
--- a/docs/modules/model_io/models/chat_models/integrations/openai.md
+++ b/docs/modules/model_io/models/chat_models/integrations/openai.md
@@ -50,6 +50,23 @@ final client = ChatOpenAI(
 );
 ```
 
+For teams using Tuning Engines as a governed OpenAI-compatible endpoint, use a
+Tuning Engines inference key and base URL. LangChain.dart still owns the chain,
+agent, and tool behavior, while Tuning Engines can centralize model access,
+policy checks, traces, audit logs, and usage/cost reporting:
+
+```dart
+final tuningEnginesApiKey = Platform.environment['TUNING_ENGINES_API_KEY'];
+
+final chatModel = ChatOpenAI(
+  apiKey: tuningEnginesApiKey,
+  baseUrl: 'https://api.tuningengines.com/v1',
+  defaultOptions: const ChatOpenAIOptions(
+    model: 'gpt-4o',
+  ),
+);
+```
+
 ### Invocation
 
 Now you can generate completions by calling the `invoke` method:


### PR DESCRIPTION
## Summary
- add a Tuning Engines example to the ChatOpenAI integration docs
- show apiKey, baseUrl, and model setup using the existing proxy/custom endpoint support
- clarify that LangChain.dart keeps owning chains, agents, and tools while Tuning Engines handles governance, traces, and usage reporting

## Why
We are an AI infrastructure team using LangChain.dart with Tuning Engines. Since the docs already show OpenAI-compatible services and custom base URLs, this gives Dart teams a concrete setup path for governed model access, policy checks, traces, audit logs, and usage/cost reporting. It would mean a lot to us if this is useful, and I am happy to adjust the wording or placement.

## Validation
- git diff --check
- checked ChatOpenAI constructor supports baseUrl and headers