### PR TITLE
fix(langchain_openai): map Responses API finish reason for tool calls and content filter

### DIFF
--- a/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
@@ -199,7 +199,7 @@ extension ResponseMapper on oai.Response {
     return ChatResult(
       id: id,
       output: AIChatMessage(content: _mapOpenAIOutputItems(output)),
-      finishReason: _mapFinishReason(status),
+      finishReason: _mapFinishReason(this),
       metadata: {'model': model, 'created_at': createdAt},
       usage: _mapResponseUsage(usage),
     );
@@ -642,11 +642,22 @@ extension ChatOpenAIResponsesTruncationMapper on ChatOpenAIResponsesTruncation {
   };
 }
 
-FinishReason _mapFinishReason(final oai.ResponseStatus status) =>
-    switch (status) {
-      oai.ResponseStatus.completed => FinishReason.stop,
+/// Maps a [oai.Response] to a [FinishReason].
+///
+/// The Responses API reports `completed` even when the model requested a tool
+/// call (the tool intent lives in the output items, not in `status`), so tool
+/// calls are detected via [oai.Response.hasToolCalls]. An `incomplete` response
+/// is a `length` stop only when truncated by `max_output_tokens`; a
+/// `content_filter` reason maps to [FinishReason.contentFilter].
+FinishReason _mapFinishReason(final oai.Response response) =>
+    switch (response.status) {
+      oai.ResponseStatus.completed =>
+        response.hasToolCalls ? FinishReason.toolCalls : FinishReason.stop,
+      oai.ResponseStatus.incomplete =>
+        response.incompleteDetails?.reason == 'content_filter'
+            ? FinishReason.contentFilter
+            : FinishReason.length,
       oai.ResponseStatus.failed => FinishReason.unspecified,
-      oai.ResponseStatus.incomplete => FinishReason.length,
       oai.ResponseStatus.inProgress => FinishReason.unspecified,
       oai.ResponseStatus.queued => FinishReason.unspecified,
       oai.ResponseStatus.cancelled => FinishReason.unspecified,

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
@@ -326,7 +326,8 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
           usage: _mapResponseUsage(usage),
           streaming: true,
         );
-      case oai.ResponseCompletedEvent(:final response):
+      case oai.ResponseCompletedEvent(:final response) ||
+          oai.ResponseIncompleteEvent(:final response):
         final result = response.toChatResult();
         return ChatResult(
           id: result.id,
@@ -647,8 +648,8 @@ extension ChatOpenAIResponsesTruncationMapper on ChatOpenAIResponsesTruncation {
 /// The Responses API reports `completed` even when the model requested a tool
 /// call (the tool intent lives in the output items, not in `status`), so tool
 /// calls are detected via [oai.Response.hasToolCalls]. An `incomplete` response
-/// is a `length` stop only when truncated by `max_output_tokens`; a
-/// `content_filter` reason maps to [FinishReason.contentFilter].
+/// maps to `length` unless its reason is `content_filter`, which maps to
+/// [FinishReason.contentFilter].
 FinishReason _mapFinishReason(final oai.Response response) =>
     switch (response.status) {
       oai.ResponseStatus.completed =>

--- a/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
@@ -242,6 +242,60 @@ void main() {
 
         expect(result.finishReason, FinishReason.contentFilter);
       });
+
+      test('maps a completed tool-call stream to toolCalls', () {
+        final accumulator = oai.ResponseStreamAccumulator()
+          ..add(
+            oai.ResponseCompletedEvent(
+              response: responseFromJson(
+                status: 'completed',
+                output: [functionCallItem],
+              ),
+            ),
+          );
+
+        final result = accumulator.toChatResult();
+
+        expect(result, isNotNull);
+        expect(result!.finishReason, FinishReason.toolCalls);
+        expect(result.streaming, isTrue);
+      });
+
+      test('maps an incomplete stream to length', () {
+        final accumulator = oai.ResponseStreamAccumulator()
+          ..add(
+            oai.ResponseIncompleteEvent(
+              response: responseFromJson(
+                status: 'incomplete',
+                incompleteDetails: {'reason': 'max_output_tokens'},
+              ),
+            ),
+          );
+
+        final result = accumulator.toChatResult();
+
+        expect(result, isNotNull);
+        expect(result!.finishReason, FinishReason.length);
+        expect(result.streaming, isTrue);
+      });
+
+      test('maps a content-filtered incomplete stream to contentFilter', () {
+        final accumulator = oai.ResponseStreamAccumulator()
+          ..add(
+            oai.ResponseIncompleteEvent(
+              response: responseFromJson(
+                status: 'incomplete',
+                incompleteDetails: {'reason': 'content_filter'},
+              ),
+            ),
+          );
+
+        final result = accumulator.toChatResult();
+
+        expect(result, isNotNull);
+        expect(result!.finishReason, FinishReason.contentFilter);
+        expect(result.streaming, isTrue);
+      });
     });
 
     group('createResponseRequest', () {

--- a/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
@@ -1,4 +1,5 @@
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/tools.dart';
 import 'package:langchain_openai/langchain_openai.dart';
 import 'package:langchain_openai/src/chat_models/chat_openai_responses_mappers.dart';
@@ -181,6 +182,65 @@ void main() {
         );
         final result = format.toTextConfig();
         expect(result, isA<oai.TextConfig>());
+      });
+    });
+
+    group('Response finish reason mapping', () {
+      oai.Response responseFromJson({
+        required String status,
+        List<Map<String, dynamic>> output = const [],
+        Map<String, dynamic>? incompleteDetails,
+      }) {
+        return oai.Response.fromJson({
+          'id': 'resp_1',
+          'object': 'response',
+          'created_at': 0,
+          'status': status,
+          'output': output,
+          if (incompleteDetails != null)
+            'incomplete_details': incompleteDetails,
+        });
+      }
+
+      const functionCallItem = <String, dynamic>{
+        'type': 'function_call',
+        'id': 'fc_1',
+        'call_id': 'call_1',
+        'name': 'get_weather',
+        'arguments': '{"location":"Barcelona"}',
+      };
+
+      test('maps a completed response without tool calls to stop', () {
+        final result = responseFromJson(status: 'completed').toChatResult();
+        expect(result.finishReason, FinishReason.stop);
+      });
+
+      test('maps a completed response with tool calls to toolCalls', () {
+        final result = responseFromJson(
+          status: 'completed',
+          output: [functionCallItem],
+        ).toChatResult();
+
+        expect(result.finishReason, FinishReason.toolCalls);
+        expect(result.output.toolCalls, isNotEmpty);
+      });
+
+      test('maps an incomplete response to length by default', () {
+        final result = responseFromJson(
+          status: 'incomplete',
+          incompleteDetails: {'reason': 'max_output_tokens'},
+        ).toChatResult();
+
+        expect(result.finishReason, FinishReason.length);
+      });
+
+      test('maps a content-filtered incomplete response to contentFilter', () {
+        final result = responseFromJson(
+          status: 'incomplete',
+          incompleteDetails: {'reason': 'content_filter'},
+        ).toChatResult();
+
+        expect(result.finishReason, FinishReason.contentFilter);
       });
     });
 


### PR DESCRIPTION
## Summary

- Maps OpenAI Responses API finish reasons from the full `Response`, rather than from `status` alone.
- Reports completed responses containing function calls as `FinishReason.toolCalls`.
- Distinguishes content-filtered incomplete responses from token-limit truncation.
- Applies the same mapping to terminal `response.completed` and `response.incomplete` streaming events.

## Problem

The Responses API can report a response as `completed` even when its output requests a function call. The tool intent is carried by the output items, so mapping only `Response.status` incorrectly produced `FinishReason.stop` and could prevent agent loops from executing the requested tool.

Likewise, every `incomplete` response was mapped to `FinishReason.length`, including responses stopped by the content filter.

## Mapping

| Responses API result | LangChain finish reason |
| --- | --- |
| `completed` with function-call output | `toolCalls` |
| `completed` without function-call output | `stop` |
| `incomplete` with `content_filter` | `contentFilter` |
| Other `incomplete` response | `length` |
| Non-terminal or failed status | `unspecified` |

The mapper now receives the complete `Response` and uses `Response.hasToolCalls` plus `incompleteDetails.reason`. Terminal streaming events reuse that same mapping, keeping streamed and non-streamed behavior consistent.

## Rebase notes

This PR has been rebased onto the ordered AI content-block implementation already on `main`. The response output continues to use the block-native mapper; this change is limited to finish-reason behavior.

## Test plan

- [x] Format the changed files.
- [x] Run `dart analyze` for `langchain_openai`.
- [x] Run the focused Responses mapper suite (28 tests).
- [x] Run all non-live `langchain_openai` tests (30 tests).
- [x] Cover non-streamed `stop`, `toolCalls`, `length`, and `contentFilter` mappings.
- [x] Cover streamed tool-call completion, token-limit incompletion, and content-filter incompletion.
