### PR TITLE
fix(chat-models): Preserve Gemini thought signatures across tool-call round trips (#942)

### DIFF
--- a/packages/langchain_core/lib/src/chat_models/types.dart
+++ b/packages/langchain_core/lib/src/chat_models/types.dart
@@ -394,6 +394,7 @@ class AIChatMessage extends ChatMessage {
               ...?thisToolCall?.arguments,
               ...?otherToolCall?.arguments,
             },
+            metadata: {...?thisToolCall?.metadata, ...?otherToolCall?.metadata},
           ),
         );
       }
@@ -426,6 +427,7 @@ class AIChatMessageToolCall {
     required this.name,
     required this.argumentsRaw,
     required this.arguments,
+    this.metadata = const {},
   });
 
   /// The id of the tool to call.
@@ -449,6 +451,12 @@ class AIChatMessageToolCall {
   /// Validate the arguments in your code before calling your tool.
   final Map<String, dynamic> arguments;
 
+  /// Provider-specific data attached to this tool call that must survive a
+  /// tool-call round trip (e.g. Google's `thoughtSignature`, which thinking
+  /// models require to be sent back with the function call in the next
+  /// request).
+  final Map<String, dynamic> metadata;
+
   /// Converts the [AIChatMessageToolCall] to a [Map].
   Map<String, dynamic> toMap() {
     return {
@@ -456,6 +464,7 @@ class AIChatMessageToolCall {
       'name': name,
       'argumentsRaw': argumentsRaw,
       'arguments': arguments,
+      'metadata': metadata,
     };
   }
 
@@ -466,6 +475,7 @@ class AIChatMessageToolCall {
         name: map['name'] as String,
         argumentsRaw: map['argumentsRaw'] as String,
         arguments: (map['arguments'] as Map<String, dynamic>?) ?? {},
+        metadata: (map['metadata'] as Map<String, dynamic>?) ?? {},
       );
 
   @override
@@ -475,12 +485,17 @@ class AIChatMessageToolCall {
         id == other.id &&
             name == other.name &&
             argumentsRaw == other.argumentsRaw &&
-            mapEquals(arguments, other.arguments);
+            mapEquals(arguments, other.arguments) &&
+            mapEquals(metadata, other.metadata);
   }
 
   @override
   int get hashCode =>
-      id.hashCode ^ name.hashCode ^ argumentsRaw.hashCode ^ arguments.hashCode;
+      id.hashCode ^
+      name.hashCode ^
+      argumentsRaw.hashCode ^
+      arguments.hashCode ^
+      metadata.hashCode;
 
   @override
   String toString() {
@@ -490,6 +505,7 @@ AIChatMessageToolCall{
   name: $name,
   argumentsRaw: $argumentsRaw,
   arguments: $arguments,
+  metadata: $metadata,
 }''';
   }
 }

--- a/packages/langchain_core/lib/src/chat_models/types.dart
+++ b/packages/langchain_core/lib/src/chat_models/types.dart
@@ -394,7 +394,10 @@ class AIChatMessage extends ChatMessage {
               ...?thisToolCall?.arguments,
               ...?otherToolCall?.arguments,
             },
-            metadata: {...?thisToolCall?.metadata, ...?otherToolCall?.metadata},
+            providerData: _mergeProviderData(
+              thisToolCall?.providerData ?? const {},
+              otherToolCall?.providerData ?? const {},
+            ),
           ),
         );
       }
@@ -427,7 +430,7 @@ class AIChatMessageToolCall {
     required this.name,
     required this.argumentsRaw,
     required this.arguments,
-    this.metadata = const {},
+    this.providerData = const {},
   });
 
   /// The id of the tool to call.
@@ -451,11 +454,12 @@ class AIChatMessageToolCall {
   /// Validate the arguments in your code before calling your tool.
   final Map<String, dynamic> arguments;
 
-  /// Provider-specific data attached to this tool call that must survive a
-  /// tool-call round trip (e.g. Google's `thoughtSignature`, which thinking
-  /// models require to be sent back with the function call in the next
-  /// request).
-  final Map<String, dynamic> metadata;
+  /// Provider-specific data attached to this tool call.
+  ///
+  /// Data must be nested under a provider namespace to avoid collisions. For
+  /// example, Google's `thoughtSignature` is stored under the `google` key so
+  /// it can survive a tool-call round trip.
+  final Map<String, dynamic> providerData;
 
   /// Converts the [AIChatMessageToolCall] to a [Map].
   Map<String, dynamic> toMap() {
@@ -464,7 +468,7 @@ class AIChatMessageToolCall {
       'name': name,
       'argumentsRaw': argumentsRaw,
       'arguments': arguments,
-      'metadata': metadata,
+      'providerData': providerData,
     };
   }
 
@@ -475,7 +479,7 @@ class AIChatMessageToolCall {
         name: map['name'] as String,
         argumentsRaw: map['argumentsRaw'] as String,
         arguments: (map['arguments'] as Map<String, dynamic>?) ?? {},
-        metadata: (map['metadata'] as Map<String, dynamic>?) ?? {},
+        providerData: (map['providerData'] as Map<String, dynamic>?) ?? {},
       );
 
   @override
@@ -486,16 +490,20 @@ class AIChatMessageToolCall {
             name == other.name &&
             argumentsRaw == other.argumentsRaw &&
             mapEquals(arguments, other.arguments) &&
-            mapEquals(metadata, other.metadata);
+            mapEquals(providerData, other.providerData);
   }
 
   @override
-  int get hashCode =>
-      id.hashCode ^
-      name.hashCode ^
-      argumentsRaw.hashCode ^
-      arguments.hashCode ^
-      metadata.hashCode;
+  int get hashCode {
+    const deepCollectionEquality = DeepCollectionEquality();
+    return Object.hash(
+      id,
+      name,
+      argumentsRaw,
+      deepCollectionEquality.hash(arguments),
+      deepCollectionEquality.hash(providerData),
+    );
+  }
 
   @override
   String toString() {
@@ -505,9 +513,25 @@ AIChatMessageToolCall{
   name: $name,
   argumentsRaw: $argumentsRaw,
   arguments: $arguments,
-  metadata: $metadata,
+  providerData: $providerData,
 }''';
   }
+}
+
+Map<String, dynamic> _mergeProviderData(
+  final Map<String, dynamic> first,
+  final Map<String, dynamic> second,
+) {
+  final merged = <String, dynamic>{...first};
+  for (final entry in second.entries) {
+    final previous = merged[entry.key];
+    final next = entry.value;
+    merged[entry.key] =
+        previous is Map<String, dynamic> && next is Map<String, dynamic>
+        ? _mergeProviderData(previous, next)
+        : next;
+  }
+  return merged;
 }
 
 /// {@template tool_chat_message}

--- a/packages/langchain_core/test/chat_models/ai_chat_message_tool_call_test.dart
+++ b/packages/langchain_core/test/chat_models/ai_chat_message_tool_call_test.dart
@@ -2,7 +2,7 @@ import 'package:langchain_core/chat_models.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('AIChatMessageToolCall metadata', () {
+  group('AIChatMessageToolCall provider data', () {
     test('defaults to an empty map', () {
       const toolCall = AIChatMessageToolCall(
         id: 'call_1',
@@ -10,7 +10,7 @@ void main() {
         argumentsRaw: '{}',
         arguments: {},
       );
-      expect(toolCall.metadata, isEmpty);
+      expect(toolCall.providerData, isEmpty);
     });
 
     test('stores provider-specific entries', () {
@@ -19,9 +19,14 @@ void main() {
         name: 'getWeather',
         argumentsRaw: '{}',
         arguments: {},
-        metadata: {'thought_signature': 'c2lnbmF0dXJl'},
+        providerData: {
+          'google': {'thoughtSignature': 'c2lnbmF0dXJl'},
+        },
       );
-      expect(toolCall.metadata['thought_signature'], 'c2lnbmF0dXJl');
+      expect(
+        (toolCall.providerData['google'] as Map)['thoughtSignature'],
+        'c2lnbmF0dXJl',
+      );
     });
 
     test('round-trips through toMap/fromMap', () {
@@ -30,11 +35,27 @@ void main() {
         name: 'getWeather',
         argumentsRaw: '{}',
         arguments: {},
-        metadata: {'thought_signature': 'c2lnbmF0dXJl'},
+        providerData: {
+          'google': {'thoughtSignature': 'c2lnbmF0dXJl'},
+        },
       );
       final restored = AIChatMessageToolCall.fromMap(toolCall.toMap());
       expect(restored, toolCall);
-      expect(restored.metadata['thought_signature'], 'c2lnbmF0dXJl');
+      expect(
+        (restored.providerData['google'] as Map)['thoughtSignature'],
+        'c2lnbmF0dXJl',
+      );
+    });
+
+    test('deserializes legacy maps without provider data', () {
+      final restored = AIChatMessageToolCall.fromMap(const {
+        'id': 'call_1',
+        'name': 'getWeather',
+        'argumentsRaw': '{}',
+        'arguments': <String, dynamic>{},
+      });
+
+      expect(restored.providerData, isEmpty);
     });
 
     test('is included in equality', () {
@@ -43,7 +64,9 @@ void main() {
         name: 'getWeather',
         argumentsRaw: '{}',
         arguments: {},
-        metadata: {'thought_signature': 'c2lnbmF0dXJl'},
+        providerData: {
+          'google': {'thoughtSignature': 'c2lnbmF0dXJl'},
+        },
       );
       const withoutMetadata = AIChatMessageToolCall(
         id: 'call_1',
@@ -53,10 +76,34 @@ void main() {
       );
       expect(withMetadata, isNot(equals(withoutMetadata)));
     });
+
+    test('equal values have equal hashes', () {
+      const first = AIChatMessageToolCall(
+        id: 'call_1',
+        name: 'getWeather',
+        argumentsRaw: '{"city":"Madrid"}',
+        arguments: {'city': 'Madrid'},
+        providerData: {
+          'google': {'thoughtSignature': 'c2lnbmF0dXJl'},
+        },
+      );
+      const second = AIChatMessageToolCall(
+        id: 'call_1',
+        name: 'getWeather',
+        argumentsRaw: '{"city":"Madrid"}',
+        arguments: {'city': 'Madrid'},
+        providerData: {
+          'google': {'thoughtSignature': 'c2lnbmF0dXJl'},
+        },
+      );
+
+      expect(first, second);
+      expect(first.hashCode, second.hashCode);
+    });
   });
 
-  group('AIChatMessage.concat tool-call metadata', () {
-    test('preserves metadata when merging streamed chunks', () {
+  group('AIChatMessage.concat tool-call provider data', () {
+    test('preserves provider data when merging streamed chunks', () {
       const first = AIChatMessage(
         content: '',
         toolCalls: [
@@ -65,7 +112,9 @@ void main() {
             name: 'getWea',
             argumentsRaw: '{"city":',
             arguments: {},
-            metadata: {'thought_signature': 'c2lnbmF0dXJl'},
+            providerData: {
+              'google': {'thoughtSignature': 'c2lnbmF0dXJl'},
+            },
           ),
         ],
       );
@@ -85,12 +134,13 @@ void main() {
 
       expect(merged.toolCalls.single.name, 'getWeather');
       expect(
-        merged.toolCalls.single.metadata['thought_signature'],
+        (merged.toolCalls.single.providerData['google']
+            as Map)['thoughtSignature'],
         'c2lnbmF0dXJl',
       );
     });
 
-    test('later chunks win on conflicting metadata keys', () {
+    test('later chunks win on conflicting nested provider-data keys', () {
       const first = AIChatMessage(
         content: '',
         toolCalls: [
@@ -99,7 +149,9 @@ void main() {
             name: 'getWeather',
             argumentsRaw: '{}',
             arguments: {},
-            metadata: {'thought_signature': 'old'},
+            providerData: {
+              'google': {'thoughtSignature': 'old', 'retained': true},
+            },
           ),
         ],
       );
@@ -111,14 +163,20 @@ void main() {
             name: '',
             argumentsRaw: '',
             arguments: {},
-            metadata: {'thought_signature': 'new'},
+            providerData: {
+              'google': {'thoughtSignature': 'new'},
+            },
           ),
         ],
       );
 
       final merged = first.concat(second);
 
-      expect(merged.toolCalls.single.metadata['thought_signature'], 'new');
+      final googleData =
+          merged.toolCalls.single.providerData['google']
+              as Map<String, dynamic>;
+      expect(googleData['thoughtSignature'], 'new');
+      expect(googleData['retained'], isTrue);
     });
   });
 }

--- a/packages/langchain_core/test/chat_models/ai_chat_message_tool_call_test.dart
+++ b/packages/langchain_core/test/chat_models/ai_chat_message_tool_call_test.dart
@@ -1,0 +1,124 @@
+import 'package:langchain_core/chat_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AIChatMessageToolCall metadata', () {
+    test('defaults to an empty map', () {
+      const toolCall = AIChatMessageToolCall(
+        id: 'call_1',
+        name: 'getWeather',
+        argumentsRaw: '{}',
+        arguments: {},
+      );
+      expect(toolCall.metadata, isEmpty);
+    });
+
+    test('stores provider-specific entries', () {
+      const toolCall = AIChatMessageToolCall(
+        id: 'call_1',
+        name: 'getWeather',
+        argumentsRaw: '{}',
+        arguments: {},
+        metadata: {'thought_signature': 'c2lnbmF0dXJl'},
+      );
+      expect(toolCall.metadata['thought_signature'], 'c2lnbmF0dXJl');
+    });
+
+    test('round-trips through toMap/fromMap', () {
+      const toolCall = AIChatMessageToolCall(
+        id: 'call_1',
+        name: 'getWeather',
+        argumentsRaw: '{}',
+        arguments: {},
+        metadata: {'thought_signature': 'c2lnbmF0dXJl'},
+      );
+      final restored = AIChatMessageToolCall.fromMap(toolCall.toMap());
+      expect(restored, toolCall);
+      expect(restored.metadata['thought_signature'], 'c2lnbmF0dXJl');
+    });
+
+    test('is included in equality', () {
+      const withMetadata = AIChatMessageToolCall(
+        id: 'call_1',
+        name: 'getWeather',
+        argumentsRaw: '{}',
+        arguments: {},
+        metadata: {'thought_signature': 'c2lnbmF0dXJl'},
+      );
+      const withoutMetadata = AIChatMessageToolCall(
+        id: 'call_1',
+        name: 'getWeather',
+        argumentsRaw: '{}',
+        arguments: {},
+      );
+      expect(withMetadata, isNot(equals(withoutMetadata)));
+    });
+  });
+
+  group('AIChatMessage.concat tool-call metadata', () {
+    test('preserves metadata when merging streamed chunks', () {
+      const first = AIChatMessage(
+        content: '',
+        toolCalls: [
+          AIChatMessageToolCall(
+            id: 'call_1',
+            name: 'getWea',
+            argumentsRaw: '{"city":',
+            arguments: {},
+            metadata: {'thought_signature': 'c2lnbmF0dXJl'},
+          ),
+        ],
+      );
+      const second = AIChatMessage(
+        content: '',
+        toolCalls: [
+          AIChatMessageToolCall(
+            id: 'call_1',
+            name: 'ther',
+            argumentsRaw: '"Madrid"}',
+            arguments: {'city': 'Madrid'},
+          ),
+        ],
+      );
+
+      final merged = first.concat(second);
+
+      expect(merged.toolCalls.single.name, 'getWeather');
+      expect(
+        merged.toolCalls.single.metadata['thought_signature'],
+        'c2lnbmF0dXJl',
+      );
+    });
+
+    test('later chunks win on conflicting metadata keys', () {
+      const first = AIChatMessage(
+        content: '',
+        toolCalls: [
+          AIChatMessageToolCall(
+            id: 'call_1',
+            name: 'getWeather',
+            argumentsRaw: '{}',
+            arguments: {},
+            metadata: {'thought_signature': 'old'},
+          ),
+        ],
+      );
+      const second = AIChatMessage(
+        content: '',
+        toolCalls: [
+          AIChatMessageToolCall(
+            id: 'call_1',
+            name: '',
+            argumentsRaw: '',
+            arguments: {},
+            metadata: {'thought_signature': 'new'},
+          ),
+        ],
+      );
+
+      final merged = first.concat(second);
+
+      expect(merged.toolCalls.single.metadata['thought_signature'], 'new');
+    });
+  });
+}

--- a/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
@@ -105,8 +105,10 @@ extension ChatMessagesMapper on List<ChatMessage> {
             g.FunctionCall(name: call.name, args: call.arguments),
             // Thinking models require the thought signature captured in
             // toChatResult to be echoed back with the function call.
-            thoughtSignature: switch (call.metadata['thought_signature']) {
-              final String signature => base64Decode(signature),
+            thoughtSignature: switch (call.providerData['google']) {
+              {'thoughtSignature': final String signature} => base64Decode(
+                signature,
+              ),
               _ => null,
             },
           ),
@@ -173,11 +175,13 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
                     name: part.functionCall.name,
                     argumentsRaw: jsonEncode(part.functionCall.args ?? {}),
                     arguments: part.functionCall.args ?? {},
-                    metadata: {
+                    providerData: {
                       if (part.thoughtSignature != null)
-                        'thought_signature': base64Encode(
-                          part.thoughtSignature!,
-                        ),
+                        'google': {
+                          'thoughtSignature': base64Encode(
+                            part.thoughtSignature!,
+                          ),
+                        },
                     },
                   ),
                 )

--- a/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
@@ -103,6 +103,12 @@ extension ChatMessagesMapper on List<ChatMessage> {
         ...msg.toolCalls.map(
           (final call) => g.FunctionCallPart(
             g.FunctionCall(name: call.name, args: call.arguments),
+            // Thinking models require the thought signature captured in
+            // toChatResult to be echoed back with the function call.
+            thoughtSignature: switch (call.metadata['thought_signature']) {
+              final String signature => base64Decode(signature),
+              _ => null,
+            },
           ),
         ),
     ];
@@ -167,6 +173,12 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
                     name: part.functionCall.name,
                     argumentsRaw: jsonEncode(part.functionCall.args ?? {}),
                     arguments: part.functionCall.args ?? {},
+                    metadata: {
+                      if (part.thoughtSignature != null)
+                        'thought_signature': base64Encode(
+                          part.thoughtSignature!,
+                        ),
+                    },
                   ),
                 )
                 .toList(growable: false) ??

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
@@ -105,8 +105,10 @@ extension ChatMessagesMapper on List<ChatMessage> {
             g.FunctionCall(name: call.name, args: call.arguments),
             // Thinking models require the thought signature captured in
             // toChatResult to be echoed back with the function call.
-            thoughtSignature: switch (call.metadata['thought_signature']) {
-              final String signature => base64Decode(signature),
+            thoughtSignature: switch (call.providerData['google']) {
+              {'thoughtSignature': final String signature} => base64Decode(
+                signature,
+              ),
               _ => null,
             },
           ),
@@ -173,11 +175,13 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
                     name: part.functionCall.name,
                     argumentsRaw: jsonEncode(part.functionCall.args ?? {}),
                     arguments: part.functionCall.args ?? {},
-                    metadata: {
+                    providerData: {
                       if (part.thoughtSignature != null)
-                        'thought_signature': base64Encode(
-                          part.thoughtSignature!,
-                        ),
+                        'google': {
+                          'thoughtSignature': base64Encode(
+                            part.thoughtSignature!,
+                          ),
+                        },
                     },
                   ),
                 )

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
@@ -103,6 +103,12 @@ extension ChatMessagesMapper on List<ChatMessage> {
         ...msg.toolCalls.map(
           (final call) => g.FunctionCallPart(
             g.FunctionCall(name: call.name, args: call.arguments),
+            // Thinking models require the thought signature captured in
+            // toChatResult to be echoed back with the function call.
+            thoughtSignature: switch (call.metadata['thought_signature']) {
+              final String signature => base64Decode(signature),
+              _ => null,
+            },
           ),
         ),
     ];
@@ -167,6 +173,12 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
                     name: part.functionCall.name,
                     argumentsRaw: jsonEncode(part.functionCall.args ?? {}),
                     arguments: part.functionCall.args ?? {},
+                    metadata: {
+                      if (part.thoughtSignature != null)
+                        'thought_signature': base64Encode(
+                          part.thoughtSignature!,
+                        ),
+                    },
                   ),
                 )
                 .toList(growable: false) ??

--- a/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+
+import 'package:googleai_dart/googleai_dart.dart' as g;
+import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_google/src/chat_models/google_ai/mappers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GenerateContentResponseMapper thought signatures', () {
+    test(
+      'captures FunctionCallPart.thoughtSignature into tool-call metadata',
+      () {
+        final signature = utf8.encode('signature-bytes');
+        final response = g.GenerateContentResponse(
+          candidates: [
+            g.Candidate(
+              content: g.Content(
+                role: 'model',
+                parts: [
+                  g.FunctionCallPart(
+                    const g.FunctionCall(
+                      name: 'getWeather',
+                      args: {'city': 'Madrid'},
+                    ),
+                    thoughtSignature: signature,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+
+        final result = response.toChatResult('id-1', 'gemini-2.5-flash');
+
+        expect(
+          result.output.toolCalls.single.metadata['thought_signature'],
+          base64Encode(signature),
+        );
+      },
+    );
+
+    test('leaves tool-call metadata empty when there is no signature', () {
+      const response = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              role: 'model',
+              parts: [
+                g.FunctionCallPart(
+                  g.FunctionCall(name: 'getWeather', args: {'city': 'Madrid'}),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+
+      final result = response.toChatResult('id-1', 'gemini-2.5-flash');
+
+      expect(result.output.toolCalls.single.metadata, isEmpty);
+    });
+  });
+
+  group('ChatMessagesMapper thought signatures', () {
+    test('replays tool-call metadata as FunctionCallPart.thoughtSignature', () {
+      final signature = utf8.encode('signature-bytes');
+      final messages = <ChatMessage>[
+        AIChatMessage(
+          content: '',
+          toolCalls: [
+            AIChatMessageToolCall(
+              id: 'getWeather',
+              name: 'getWeather',
+              argumentsRaw: '{"city":"Madrid"}',
+              arguments: const {'city': 'Madrid'},
+              metadata: {'thought_signature': base64Encode(signature)},
+            ),
+          ],
+        ),
+      ];
+
+      final content = messages.toContentList();
+
+      final part = content.single.parts.single as g.FunctionCallPart;
+      expect(part.thoughtSignature, signature);
+    });
+
+    test('maps no thoughtSignature when metadata lacks one', () {
+      final messages = <ChatMessage>[
+        const AIChatMessage(
+          content: '',
+          toolCalls: [
+            AIChatMessageToolCall(
+              id: 'getWeather',
+              name: 'getWeather',
+              argumentsRaw: '{"city":"Madrid"}',
+              arguments: {'city': 'Madrid'},
+            ),
+          ],
+        ),
+      ];
+
+      final content = messages.toContentList();
+
+      final part = content.single.parts.single as g.FunctionCallPart;
+      expect(part.thoughtSignature, isNull);
+    });
+  });
+}

--- a/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   group('GenerateContentResponseMapper thought signatures', () {
     test(
-      'captures FunctionCallPart.thoughtSignature into tool-call metadata',
+      'round-trips FunctionCallPart.thoughtSignature through provider data',
       () {
         final signature = utf8.encode('signature-bytes');
         final response = g.GenerateContentResponse(
@@ -33,13 +33,18 @@ void main() {
         final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
         expect(
-          result.output.toolCalls.single.metadata['thought_signature'],
+          (result.output.toolCalls.single.providerData['google']
+              as Map)['thoughtSignature'],
           base64Encode(signature),
         );
+
+        final replayed = <ChatMessage>[result.output].toContentList();
+        final replayedPart = replayed.single.parts.single as g.FunctionCallPart;
+        expect(replayedPart.thoughtSignature, signature);
       },
     );
 
-    test('leaves tool-call metadata empty when there is no signature', () {
+    test('leaves tool-call provider data empty when there is no signature', () {
       const response = g.GenerateContentResponse(
         candidates: [
           g.Candidate(
@@ -57,35 +62,77 @@ void main() {
 
       final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
-      expect(result.output.toolCalls.single.metadata, isEmpty);
+      expect(result.output.toolCalls.single.providerData, isEmpty);
     });
-  });
 
-  group('ChatMessagesMapper thought signatures', () {
-    test('replays tool-call metadata as FunctionCallPart.thoughtSignature', () {
+    test('preserves thoughtSignature through streamed concatenation', () {
       final signature = utf8.encode('signature-bytes');
-      final messages = <ChatMessage>[
+      final response = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              role: 'model',
+              parts: [
+                g.FunctionCallPart(
+                  const g.FunctionCall(name: 'getWeather', args: {}),
+                  thoughtSignature: signature,
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+      final first = response.toChatResult('id-1', 'gemini-2.5-flash').output;
+      final merged = first.concat(
         AIChatMessage(
           content: '',
           toolCalls: [
             AIChatMessageToolCall(
-              id: 'getWeather',
-              name: 'getWeather',
-              argumentsRaw: '{"city":"Madrid"}',
+              id: first.toolCalls.single.id,
+              name: '',
+              argumentsRaw: '',
               arguments: const {'city': 'Madrid'},
-              metadata: {'thought_signature': base64Encode(signature)},
             ),
           ],
         ),
-      ];
+      );
 
-      final content = messages.toContentList();
-
-      final part = content.single.parts.single as g.FunctionCallPart;
-      expect(part.thoughtSignature, signature);
+      final replayed = <ChatMessage>[merged].toContentList();
+      final replayedPart = replayed.single.parts.single as g.FunctionCallPart;
+      expect(replayedPart.thoughtSignature, signature);
     });
+  });
 
-    test('maps no thoughtSignature when metadata lacks one', () {
+  group('ChatMessagesMapper thought signatures', () {
+    test(
+      'replays tool-call provider data as FunctionCallPart.thoughtSignature',
+      () {
+        final signature = utf8.encode('signature-bytes');
+        final messages = <ChatMessage>[
+          AIChatMessage(
+            content: '',
+            toolCalls: [
+              AIChatMessageToolCall(
+                id: 'getWeather',
+                name: 'getWeather',
+                argumentsRaw: '{"city":"Madrid"}',
+                arguments: const {'city': 'Madrid'},
+                providerData: {
+                  'google': {'thoughtSignature': base64Encode(signature)},
+                },
+              ),
+            ],
+          ),
+        ];
+
+        final content = messages.toContentList();
+
+        final part = content.single.parts.single as g.FunctionCallPart;
+        expect(part.thoughtSignature, signature);
+      },
+    );
+
+    test('maps no thoughtSignature when provider data lacks one', () {
       final messages = <ChatMessage>[
         const AIChatMessage(
           content: '',

--- a/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   group('GenerateContentResponseMapper thought signatures', () {
     test(
-      'captures FunctionCallPart.thoughtSignature into tool-call metadata',
+      'round-trips FunctionCallPart.thoughtSignature through provider data',
       () {
         final signature = utf8.encode('signature-bytes');
         final response = g.GenerateContentResponse(
@@ -33,13 +33,18 @@ void main() {
         final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
         expect(
-          result.output.toolCalls.single.metadata['thought_signature'],
+          (result.output.toolCalls.single.providerData['google']
+              as Map)['thoughtSignature'],
           base64Encode(signature),
         );
+
+        final replayed = <ChatMessage>[result.output].toContentList();
+        final replayedPart = replayed.single.parts.single as g.FunctionCallPart;
+        expect(replayedPart.thoughtSignature, signature);
       },
     );
 
-    test('leaves tool-call metadata empty when there is no signature', () {
+    test('leaves tool-call provider data empty when there is no signature', () {
       const response = g.GenerateContentResponse(
         candidates: [
           g.Candidate(
@@ -57,35 +62,77 @@ void main() {
 
       final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
-      expect(result.output.toolCalls.single.metadata, isEmpty);
+      expect(result.output.toolCalls.single.providerData, isEmpty);
     });
-  });
 
-  group('ChatMessagesMapper thought signatures', () {
-    test('replays tool-call metadata as FunctionCallPart.thoughtSignature', () {
+    test('preserves thoughtSignature through streamed concatenation', () {
       final signature = utf8.encode('signature-bytes');
-      final messages = <ChatMessage>[
+      final response = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              role: 'model',
+              parts: [
+                g.FunctionCallPart(
+                  const g.FunctionCall(name: 'getWeather', args: {}),
+                  thoughtSignature: signature,
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+      final first = response.toChatResult('id-1', 'gemini-2.5-flash').output;
+      final merged = first.concat(
         AIChatMessage(
           content: '',
           toolCalls: [
             AIChatMessageToolCall(
-              id: 'getWeather',
-              name: 'getWeather',
-              argumentsRaw: '{"city":"Madrid"}',
+              id: first.toolCalls.single.id,
+              name: '',
+              argumentsRaw: '',
               arguments: const {'city': 'Madrid'},
-              metadata: {'thought_signature': base64Encode(signature)},
             ),
           ],
         ),
-      ];
+      );
 
-      final content = messages.toContentList();
-
-      final part = content.single.parts.single as g.FunctionCallPart;
-      expect(part.thoughtSignature, signature);
+      final replayed = <ChatMessage>[merged].toContentList();
+      final replayedPart = replayed.single.parts.single as g.FunctionCallPart;
+      expect(replayedPart.thoughtSignature, signature);
     });
+  });
 
-    test('maps no thoughtSignature when metadata lacks one', () {
+  group('ChatMessagesMapper thought signatures', () {
+    test(
+      'replays tool-call provider data as FunctionCallPart.thoughtSignature',
+      () {
+        final signature = utf8.encode('signature-bytes');
+        final messages = <ChatMessage>[
+          AIChatMessage(
+            content: '',
+            toolCalls: [
+              AIChatMessageToolCall(
+                id: 'getWeather',
+                name: 'getWeather',
+                argumentsRaw: '{"city":"Madrid"}',
+                arguments: const {'city': 'Madrid'},
+                providerData: {
+                  'google': {'thoughtSignature': base64Encode(signature)},
+                },
+              ),
+            ],
+          ),
+        ];
+
+        final content = messages.toContentList();
+
+        final part = content.single.parts.single as g.FunctionCallPart;
+        expect(part.thoughtSignature, signature);
+      },
+    );
+
+    test('maps no thoughtSignature when provider data lacks one', () {
       final messages = <ChatMessage>[
         const AIChatMessage(
           content: '',

--- a/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+
+import 'package:googleai_dart/googleai_dart.dart' as g;
+import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_google/src/chat_models/vertex_ai/mappers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GenerateContentResponseMapper thought signatures', () {
+    test(
+      'captures FunctionCallPart.thoughtSignature into tool-call metadata',
+      () {
+        final signature = utf8.encode('signature-bytes');
+        final response = g.GenerateContentResponse(
+          candidates: [
+            g.Candidate(
+              content: g.Content(
+                role: 'model',
+                parts: [
+                  g.FunctionCallPart(
+                    const g.FunctionCall(
+                      name: 'getWeather',
+                      args: {'city': 'Madrid'},
+                    ),
+                    thoughtSignature: signature,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+
+        final result = response.toChatResult('id-1', 'gemini-2.5-flash');
+
+        expect(
+          result.output.toolCalls.single.metadata['thought_signature'],
+          base64Encode(signature),
+        );
+      },
+    );
+
+    test('leaves tool-call metadata empty when there is no signature', () {
+      const response = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              role: 'model',
+              parts: [
+                g.FunctionCallPart(
+                  g.FunctionCall(name: 'getWeather', args: {'city': 'Madrid'}),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+
+      final result = response.toChatResult('id-1', 'gemini-2.5-flash');
+
+      expect(result.output.toolCalls.single.metadata, isEmpty);
+    });
+  });
+
+  group('ChatMessagesMapper thought signatures', () {
+    test('replays tool-call metadata as FunctionCallPart.thoughtSignature', () {
+      final signature = utf8.encode('signature-bytes');
+      final messages = <ChatMessage>[
+        AIChatMessage(
+          content: '',
+          toolCalls: [
+            AIChatMessageToolCall(
+              id: 'getWeather',
+              name: 'getWeather',
+              argumentsRaw: '{"city":"Madrid"}',
+              arguments: const {'city': 'Madrid'},
+              metadata: {'thought_signature': base64Encode(signature)},
+            ),
+          ],
+        ),
+      ];
+
+      final content = messages.toContentList();
+
+      final part = content.single.parts.single as g.FunctionCallPart;
+      expect(part.thoughtSignature, signature);
+    });
+
+    test('maps no thoughtSignature when metadata lacks one', () {
+      final messages = <ChatMessage>[
+        const AIChatMessage(
+          content: '',
+          toolCalls: [
+            AIChatMessageToolCall(
+              id: 'getWeather',
+              name: 'getWeather',
+              argumentsRaw: '{"city":"Madrid"}',
+              arguments: {'city': 'Madrid'},
+            ),
+          ],
+        ),
+      ];
+
+      final content = messages.toContentList();
+
+      final part = content.single.parts.single as g.FunctionCallPart;
+      expect(part.thoughtSignature, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Preserve Gemini function-call `thoughtSignature` values through response mapping, streaming concatenation, serialization, and request replay for both Google AI and Vertex AI.
- Add namespaced `AIChatMessageToolCall.providerData` for opaque provider values that must survive tool-call round trips.
- Fixes #942 as an interim, function-call-specific compatibility patch while the complete ordered content-block model is developed separately.

## Details

Gemini thinking models attach an opaque signature to function-call parts and require the exact signature to be echoed with the call in later conversation turns. The client already exposes that signature, but both `langchain_google` mapper implementations dropped it.

The response mappers now store the base64-encoded signature under:

```dart
providerData: {
  'google': {
    'thoughtSignature': encodedSignature,
  },
}
```

The request mappers decode and replay the value on `FunctionCallPart`. Provider data is included in map serialization, deep equality/hash behavior, and recursive streaming merges, with later chunks winning only for conflicting nested keys.

## Interim limitations

This PR intentionally covers function-call parts only so #942 can ship without waiting for a breaking content-model migration. It does **not** preserve signatures attached to text, media, signature-only, or other non-function-call parts. Google documents signatures as generic Part metadata, so complete Part fidelity and ordered content preservation will follow in separate `googleai_dart` and LangChain content-block changes.

Tool-call ID behavior is also unchanged here. Parallel same-name calls will be addressed with stable provider/part identities in the breaking block-model work.

## Test Plan

- [x] `langchain_core` full suite: 168 tests
- [x] Google AI mapper round trip, absent signature, and streamed concatenation
- [x] Vertex AI mapper round trip, absent signature, and streamed concatenation
- [x] `flutter analyze .` for `langchain_core`
- [x] `flutter analyze .` for `langchain_google`
- [x] Formatting and `git diff --check`

## References

- [Gemini API thought signatures](https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures)
- [Vertex AI thought signatures](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures)

Fixes #942
