### PR TITLE
fix(langchain_google): migrate to googleai_dart 12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          delay_seconds: 5
+          retry_wait_seconds: 5
           command: melos bootstrap
 
       - name: Run linter

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,16 +1,14 @@
 name: Test
 
 on:
-  # pull_request_target is dangerous! Review external PRs code before approving to run the workflow
-  # We need this to be able to access the secrets required by the workflow
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - 'docs/**'
   workflow_dispatch:
 
 # Cancel currently running workflow when a new one is triggered
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -23,7 +21,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: "${{ github.event.pull_request.base.sha }}" # Required for pull_request_target
           fetch-depth: 0
 
       - name: Install Flutter
@@ -39,7 +36,7 @@ jobs:
       - name: Install Melos
         uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
         with:
-          melos-version: '7.0.0-dev.9'
+          melos-version: '7.4.0'
           run-bootstrap: false
 
       - name: Bootstrap
@@ -54,9 +51,4 @@ jobs:
         run: melos lint:diff
 
       - name: Run unit tests
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          VERTEX_AI_PROJECT_ID: ${{ secrets.VERTEX_AI_PROJECT_ID }}
-          VERTEX_AI_SERVICE_ACCOUNT: ${{ secrets.VERTEX_AI_SERVICE_ACCOUNT }}
         run: melos test:diff

--- a/packages/langchain_core/lib/src/tools/base.dart
+++ b/packages/langchain_core/lib/src/tools/base.dart
@@ -206,7 +206,7 @@ abstract base class Tool<
   @override
   Future<Output> invoke(final Input input, {final Options? options}) async {
     try {
-      return invokeInternal(input, options: options);
+      return await invokeInternal(input, options: options);
     } on ToolException catch (e) {
       if (handleToolError != null) {
         return handleToolError!(e);

--- a/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
@@ -153,14 +153,7 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
                     final g.TextPart p => p.text,
                     final g.InlineDataPart p => p.inlineData.data,
                     final g.FileDataPart p => p.fileData.fileUri,
-                    g.FunctionResponsePart() => '',
-                    g.FunctionCallPart() => '',
-                    g.ExecutableCodePart() => '',
-                    g.CodeExecutionResultPart() => '',
-                    g.VideoMetadataPart() => '',
-                    g.ThoughtPart() => '',
-                    g.ThoughtSignaturePart() => '',
-                    g.PartMetadataPart() => '',
+                    g.Part() => '',
                   },
                 )
                 .nonNulls
@@ -241,16 +234,27 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
 
   FinishReason _mapFinishReason(final g.FinishReason? reason) =>
       switch (reason) {
-        g.FinishReason.unspecified => FinishReason.unspecified,
         g.FinishReason.stop => FinishReason.stop,
         g.FinishReason.maxTokens => FinishReason.length,
-        g.FinishReason.safety => FinishReason.contentFilter,
-        g.FinishReason.recitation => FinishReason.recitation,
-        g.FinishReason.other => FinishReason.unspecified,
-        g.FinishReason.blocklist => FinishReason.contentFilter,
-        g.FinishReason.prohibitedContent => FinishReason.contentFilter,
-        g.FinishReason.spii => FinishReason.contentFilter,
-        g.FinishReason.malformedFunctionCall => FinishReason.unspecified,
+        g.FinishReason.safety ||
+        g.FinishReason.blocklist ||
+        g.FinishReason.prohibitedContent ||
+        g.FinishReason.spii ||
+        g.FinishReason.language ||
+        g.FinishReason.imageSafety ||
+        g.FinishReason.imageProhibitedContent => FinishReason.contentFilter,
+        g.FinishReason.recitation ||
+        g.FinishReason.imageRecitation => FinishReason.recitation,
+        g.FinishReason.unspecified ||
+        g.FinishReason.other ||
+        g.FinishReason.malformedFunctionCall ||
+        g.FinishReason.imageOther ||
+        g.FinishReason.noImage ||
+        g.FinishReason.unexpectedToolCall ||
+        g.FinishReason.tooManyToolCalls ||
+        g.FinishReason.missingThoughtSignature ||
+        g.FinishReason.malformedResponse ||
+        g.FinishReason.escalation => FinishReason.unspecified,
         null => FinishReason.unspecified,
       };
 }
@@ -305,7 +309,7 @@ extension ChatToolListMapper on List<ToolSpec>? {
               ),
             )
             .toList(growable: false),
-        codeExecution: enableCodeExecution ? <String, dynamic>{} : null,
+        codeExecution: enableCodeExecution ? const g.CodeExecution() : null,
       ),
     ];
   }
@@ -385,23 +389,22 @@ extension SchemaMapper on Map<String, dynamic> {
 }
 
 extension ChatToolChoiceMapper on ChatToolChoice {
-  Map<String, dynamic> toToolConfig() {
-    return switch (this) {
-      ChatToolChoiceNone _ => {
-        'functionCallingConfig': {'mode': 'NONE'},
-      },
-      ChatToolChoiceAuto _ => {
-        'functionCallingConfig': {'mode': 'AUTO'},
-      },
-      ChatToolChoiceRequired() => {
-        'functionCallingConfig': {'mode': 'ANY'},
-      },
-      final ChatToolChoiceForced t => {
-        'functionCallingConfig': {
-          'mode': 'ANY',
-          'allowedFunctionNames': [t.name],
-        },
-      },
+  g.ToolConfig toToolConfig() {
+    final functionCallingConfig = switch (this) {
+      ChatToolChoiceNone _ => const g.FunctionCallingConfig(
+        mode: g.FunctionCallingMode.none,
+      ),
+      ChatToolChoiceAuto _ => const g.FunctionCallingConfig(
+        mode: g.FunctionCallingMode.auto,
+      ),
+      ChatToolChoiceRequired() => const g.FunctionCallingConfig(
+        mode: g.FunctionCallingMode.any,
+      ),
+      final ChatToolChoiceForced t => g.FunctionCallingConfig(
+        mode: g.FunctionCallingMode.any,
+        allowedFunctionNames: [t.name],
+      ),
     };
+    return g.ToolConfig(functionCallingConfig: functionCallingConfig);
   }
 }

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
@@ -153,14 +153,7 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
                     final g.TextPart p => p.text,
                     final g.InlineDataPart p => p.inlineData.data,
                     final g.FileDataPart p => p.fileData.fileUri,
-                    g.FunctionResponsePart() => '',
-                    g.FunctionCallPart() => '',
-                    g.ExecutableCodePart() => '',
-                    g.CodeExecutionResultPart() => '',
-                    g.VideoMetadataPart() => '',
-                    g.ThoughtPart() => '',
-                    g.ThoughtSignaturePart() => '',
-                    g.PartMetadataPart() => '',
+                    g.Part() => '',
                   },
                 )
                 .nonNulls
@@ -241,16 +234,27 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
 
   FinishReason _mapFinishReason(final g.FinishReason? reason) =>
       switch (reason) {
-        g.FinishReason.unspecified => FinishReason.unspecified,
         g.FinishReason.stop => FinishReason.stop,
         g.FinishReason.maxTokens => FinishReason.length,
-        g.FinishReason.safety => FinishReason.contentFilter,
-        g.FinishReason.recitation => FinishReason.recitation,
-        g.FinishReason.other => FinishReason.unspecified,
-        g.FinishReason.blocklist => FinishReason.contentFilter,
-        g.FinishReason.prohibitedContent => FinishReason.contentFilter,
-        g.FinishReason.spii => FinishReason.contentFilter,
-        g.FinishReason.malformedFunctionCall => FinishReason.unspecified,
+        g.FinishReason.safety ||
+        g.FinishReason.blocklist ||
+        g.FinishReason.prohibitedContent ||
+        g.FinishReason.spii ||
+        g.FinishReason.language ||
+        g.FinishReason.imageSafety ||
+        g.FinishReason.imageProhibitedContent => FinishReason.contentFilter,
+        g.FinishReason.recitation ||
+        g.FinishReason.imageRecitation => FinishReason.recitation,
+        g.FinishReason.unspecified ||
+        g.FinishReason.other ||
+        g.FinishReason.malformedFunctionCall ||
+        g.FinishReason.imageOther ||
+        g.FinishReason.noImage ||
+        g.FinishReason.unexpectedToolCall ||
+        g.FinishReason.tooManyToolCalls ||
+        g.FinishReason.missingThoughtSignature ||
+        g.FinishReason.malformedResponse ||
+        g.FinishReason.escalation => FinishReason.unspecified,
         null => FinishReason.unspecified,
       };
 }
@@ -305,7 +309,7 @@ extension ChatToolListMapper on List<ToolSpec>? {
               ),
             )
             .toList(growable: false),
-        codeExecution: enableCodeExecution ? <String, dynamic>{} : null,
+        codeExecution: enableCodeExecution ? const g.CodeExecution() : null,
       ),
     ];
   }
@@ -385,23 +389,22 @@ extension SchemaMapper on Map<String, dynamic> {
 }
 
 extension ChatToolChoiceMapper on ChatToolChoice {
-  Map<String, dynamic> toToolConfig() {
-    return switch (this) {
-      ChatToolChoiceNone _ => {
-        'functionCallingConfig': {'mode': 'NONE'},
-      },
-      ChatToolChoiceAuto _ => {
-        'functionCallingConfig': {'mode': 'AUTO'},
-      },
-      ChatToolChoiceRequired() => {
-        'functionCallingConfig': {'mode': 'ANY'},
-      },
-      final ChatToolChoiceForced t => {
-        'functionCallingConfig': {
-          'mode': 'ANY',
-          'allowedFunctionNames': [t.name],
-        },
-      },
+  g.ToolConfig toToolConfig() {
+    final functionCallingConfig = switch (this) {
+      ChatToolChoiceNone _ => const g.FunctionCallingConfig(
+        mode: g.FunctionCallingMode.none,
+      ),
+      ChatToolChoiceAuto _ => const g.FunctionCallingConfig(
+        mode: g.FunctionCallingMode.auto,
+      ),
+      ChatToolChoiceRequired() => const g.FunctionCallingConfig(
+        mode: g.FunctionCallingMode.any,
+      ),
+      final ChatToolChoiceForced t => g.FunctionCallingConfig(
+        mode: g.FunctionCallingMode.any,
+        allowedFunctionNames: [t.name],
+      ),
     };
+    return g.ToolConfig(functionCallingConfig: functionCallingConfig);
   }
 }

--- a/packages/langchain_google/lib/src/embeddings/google_ai/google_ai_embeddings.dart
+++ b/packages/langchain_google/lib/src/embeddings/google_ai/google_ai_embeddings.dart
@@ -154,9 +154,11 @@ class GoogleGenerativeAIEmbeddings extends Embeddings {
                   .map(
                     (final doc) => g.EmbedContentRequest(
                       content: g.Content(parts: [g.TextPart(doc.pageContent)]),
-                      taskType: g.TaskType.retrievalDocument,
-                      title: doc.metadata[docTitleKey] as String?,
-                      outputDimensionality: dimensions,
+                      embedContentConfig: g.EmbedContentConfig(
+                        taskType: g.TaskType.retrievalDocument,
+                        title: doc.metadata[docTitleKey] as String?,
+                        outputDimensionality: dimensions,
+                      ),
                     ),
                   )
                   .toList(),
@@ -177,9 +179,11 @@ class GoogleGenerativeAIEmbeddings extends Embeddings {
                   model: model,
                   request: g.EmbedContentRequest(
                     content: g.Content(parts: [g.TextPart(doc.pageContent)]),
-                    taskType: g.TaskType.retrievalDocument,
-                    title: doc.metadata[docTitleKey] as String?,
-                    outputDimensionality: dimensions,
+                    embedContentConfig: g.EmbedContentConfig(
+                      taskType: g.TaskType.retrievalDocument,
+                      title: doc.metadata[docTitleKey] as String?,
+                      outputDimensionality: dimensions,
+                    ),
                   ),
                 );
                 return response.embedding.values;
@@ -203,8 +207,10 @@ class GoogleGenerativeAIEmbeddings extends Embeddings {
       model: model,
       request: g.EmbedContentRequest(
         content: g.Content(parts: [g.TextPart(query)]),
-        taskType: g.TaskType.retrievalQuery,
-        outputDimensionality: dimensions,
+        embedContentConfig: g.EmbedContentConfig(
+          taskType: g.TaskType.retrievalQuery,
+          outputDimensionality: dimensions,
+        ),
       ),
     );
     return response.embedding.values;

--- a/packages/langchain_google/lib/src/embeddings/vertex_ai/vertex_ai_embeddings.dart
+++ b/packages/langchain_google/lib/src/embeddings/vertex_ai/vertex_ai_embeddings.dart
@@ -193,9 +193,11 @@ class VertexAIEmbeddings extends Embeddings {
                   .map(
                     (final doc) => g.EmbedContentRequest(
                       content: g.Content(parts: [g.TextPart(doc.pageContent)]),
-                      taskType: g.TaskType.retrievalDocument,
-                      title: doc.metadata[docTitleKey] as String?,
-                      outputDimensionality: dimensions,
+                      embedContentConfig: g.EmbedContentConfig(
+                        taskType: g.TaskType.retrievalDocument,
+                        title: doc.metadata[docTitleKey] as String?,
+                        outputDimensionality: dimensions,
+                      ),
                     ),
                   )
                   .toList(),
@@ -213,9 +215,11 @@ class VertexAIEmbeddings extends Embeddings {
                   model: model,
                   request: g.EmbedContentRequest(
                     content: g.Content(parts: [g.TextPart(doc.pageContent)]),
-                    taskType: g.TaskType.retrievalDocument,
-                    title: doc.metadata[docTitleKey] as String?,
-                    outputDimensionality: dimensions,
+                    embedContentConfig: g.EmbedContentConfig(
+                      taskType: g.TaskType.retrievalDocument,
+                      title: doc.metadata[docTitleKey] as String?,
+                      outputDimensionality: dimensions,
+                    ),
                   ),
                 );
                 return response.embedding.values;
@@ -238,8 +242,10 @@ class VertexAIEmbeddings extends Embeddings {
       model: model,
       request: g.EmbedContentRequest(
         content: g.Content(parts: [g.TextPart(query)]),
-        taskType: g.TaskType.retrievalQuery,
-        outputDimensionality: dimensions,
+        embedContentConfig: g.EmbedContentConfig(
+          taskType: g.TaskType.retrievalQuery,
+          outputDimensionality: dimensions,
+        ),
       ),
     );
     return response.embedding.values;

--- a/packages/langchain_google/lib/src/llms/vertex_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/llms/vertex_ai/mappers.dart
@@ -56,16 +56,27 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
 
   FinishReason _mapFinishReason(final g.FinishReason? reason) =>
       switch (reason) {
-        g.FinishReason.unspecified => FinishReason.unspecified,
         g.FinishReason.stop => FinishReason.stop,
         g.FinishReason.maxTokens => FinishReason.length,
-        g.FinishReason.safety => FinishReason.contentFilter,
-        g.FinishReason.recitation => FinishReason.recitation,
-        g.FinishReason.other => FinishReason.unspecified,
-        g.FinishReason.blocklist => FinishReason.contentFilter,
-        g.FinishReason.prohibitedContent => FinishReason.contentFilter,
-        g.FinishReason.spii => FinishReason.contentFilter,
-        g.FinishReason.malformedFunctionCall => FinishReason.unspecified,
+        g.FinishReason.safety ||
+        g.FinishReason.blocklist ||
+        g.FinishReason.prohibitedContent ||
+        g.FinishReason.spii ||
+        g.FinishReason.language ||
+        g.FinishReason.imageSafety ||
+        g.FinishReason.imageProhibitedContent => FinishReason.contentFilter,
+        g.FinishReason.recitation ||
+        g.FinishReason.imageRecitation => FinishReason.recitation,
+        g.FinishReason.unspecified ||
+        g.FinishReason.other ||
+        g.FinishReason.malformedFunctionCall ||
+        g.FinishReason.imageOther ||
+        g.FinishReason.noImage ||
+        g.FinishReason.unexpectedToolCall ||
+        g.FinishReason.tooManyToolCalls ||
+        g.FinishReason.missingThoughtSignature ||
+        g.FinishReason.malformedResponse ||
+        g.FinishReason.escalation => FinishReason.unspecified,
         null => FinishReason.unspecified,
       };
 }

--- a/packages/langchain_google/pubspec.yaml
+++ b/packages/langchain_google/pubspec.yaml
@@ -23,7 +23,7 @@ resolution: workspace
 dependencies:
   collection: ^1.19.1
   gcloud: ^0.9.0
-  googleai_dart: ^3.5.0
+  googleai_dart: ^12.0.0
   googleapis: ^15.0.0
   googleapis_auth: ^2.0.0
   http: ^1.5.0

--- a/packages/langchain_google/test/chat_models/google_ai/chat_google_generative_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/chat_google_generative_ai_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_redundant_argument_values
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:convert';

--- a/packages/langchain_google/test/chat_models/google_ai/chat_google_generative_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/chat_google_generative_ai_test.dart
@@ -33,9 +33,9 @@ void main() {
 
     test('Test Text-only input', () async {
       const models = [
-        'gemini-2.5-pro',
+        'gemini-3.1-pro-preview',
         'gemini-2.5-flash',
-        'gemini-2.5-flash-lite',
+        'gemini-3.5-flash-lite',
       ];
       for (final model in models) {
         final res = await chatModel.invoke(

--- a/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:googleai_dart/googleai_dart.dart' as g;
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
+import 'package:langchain_core/tools.dart';
 import 'package:langchain_google/src/chat_models/google_ai/mappers.dart';
 import 'package:test/test.dart';
 
@@ -151,6 +153,88 @@ void main() {
 
       final part = content.single.parts.single as g.FunctionCallPart;
       expect(part.thoughtSignature, isNull);
+    });
+  });
+
+  group('googleai_dart 12 typed APIs', () {
+    test('maps every tool choice to typed ToolConfig', () {
+      expect(ChatToolChoice.none.toToolConfig().toJson(), {
+        'functionCallingConfig': {'mode': 'NONE'},
+      });
+      expect(ChatToolChoice.auto.toToolConfig().toJson(), {
+        'functionCallingConfig': {'mode': 'AUTO'},
+      });
+      expect(ChatToolChoice.required.toToolConfig().toJson(), {
+        'functionCallingConfig': {'mode': 'ANY'},
+      });
+      expect(
+        ChatToolChoice.forced(name: 'getWeather').toToolConfig().toJson(),
+        {
+          'functionCallingConfig': {
+            'mode': 'ANY',
+            'allowedFunctionNames': ['getWeather'],
+          },
+        },
+      );
+    });
+
+    test('maps code execution to the typed marker', () {
+      final tools = const <ToolSpec>[].toToolList(enableCodeExecution: true);
+
+      expect(tools, hasLength(1));
+      expect(tools!.single.codeExecution, isA<g.CodeExecution>());
+    });
+
+    test('accepts metadata-only and unknown parts', () {
+      final response = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              parts: [
+                const g.TextPart('visible'),
+                const g.MetadataPart(thought: true),
+                g.UnknownPart({
+                  'futurePart': {'value': 1},
+                }),
+              ],
+            ),
+          ),
+        ],
+      );
+
+      final result = response.toChatResult('id-1', 'gemini-2.5-flash');
+
+      expect(result.output.content, startsWith('visible'));
+    });
+
+    test('maps every finish reason introduced through v12', () {
+      const expected = <g.FinishReason, FinishReason>{
+        g.FinishReason.language: FinishReason.contentFilter,
+        g.FinishReason.imageSafety: FinishReason.contentFilter,
+        g.FinishReason.imageProhibitedContent: FinishReason.contentFilter,
+        g.FinishReason.imageOther: FinishReason.unspecified,
+        g.FinishReason.noImage: FinishReason.unspecified,
+        g.FinishReason.imageRecitation: FinishReason.recitation,
+        g.FinishReason.unexpectedToolCall: FinishReason.unspecified,
+        g.FinishReason.tooManyToolCalls: FinishReason.unspecified,
+        g.FinishReason.missingThoughtSignature: FinishReason.unspecified,
+        g.FinishReason.malformedResponse: FinishReason.unspecified,
+        g.FinishReason.escalation: FinishReason.unspecified,
+      };
+
+      for (final MapEntry(key: reason, value: finishReason)
+          in expected.entries) {
+        final result = g.GenerateContentResponse(
+          candidates: [
+            g.Candidate(
+              content: const g.Content(parts: [g.TextPart('result')]),
+              finishReason: reason,
+            ),
+          ],
+        ).toChatResult('id-1', 'gemini-2.5-flash');
+
+        expect(result.finishReason, finishReason, reason: reason.name);
+      }
     });
   });
 }

--- a/packages/langchain_google/test/chat_models/vertex_ai/chat_vertex_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai/chat_vertex_ai_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_redundant_argument_values
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:googleai_dart/googleai_dart.dart' as g;
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
+import 'package:langchain_core/tools.dart';
 import 'package:langchain_google/src/chat_models/vertex_ai/mappers.dart';
 import 'package:test/test.dart';
 
@@ -151,6 +153,88 @@ void main() {
 
       final part = content.single.parts.single as g.FunctionCallPart;
       expect(part.thoughtSignature, isNull);
+    });
+  });
+
+  group('googleai_dart 12 typed APIs', () {
+    test('maps every tool choice to typed ToolConfig', () {
+      expect(ChatToolChoice.none.toToolConfig().toJson(), {
+        'functionCallingConfig': {'mode': 'NONE'},
+      });
+      expect(ChatToolChoice.auto.toToolConfig().toJson(), {
+        'functionCallingConfig': {'mode': 'AUTO'},
+      });
+      expect(ChatToolChoice.required.toToolConfig().toJson(), {
+        'functionCallingConfig': {'mode': 'ANY'},
+      });
+      expect(
+        ChatToolChoice.forced(name: 'getWeather').toToolConfig().toJson(),
+        {
+          'functionCallingConfig': {
+            'mode': 'ANY',
+            'allowedFunctionNames': ['getWeather'],
+          },
+        },
+      );
+    });
+
+    test('maps code execution to the typed marker', () {
+      final tools = const <ToolSpec>[].toToolList(enableCodeExecution: true);
+
+      expect(tools, hasLength(1));
+      expect(tools!.single.codeExecution, isA<g.CodeExecution>());
+    });
+
+    test('accepts metadata-only and unknown parts', () {
+      final response = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              parts: [
+                const g.TextPart('visible'),
+                const g.MetadataPart(thought: true),
+                g.UnknownPart({
+                  'futurePart': {'value': 1},
+                }),
+              ],
+            ),
+          ),
+        ],
+      );
+
+      final result = response.toChatResult('id-1', 'gemini-2.5-flash');
+
+      expect(result.output.content, startsWith('visible'));
+    });
+
+    test('maps every finish reason introduced through v12', () {
+      const expected = <g.FinishReason, FinishReason>{
+        g.FinishReason.language: FinishReason.contentFilter,
+        g.FinishReason.imageSafety: FinishReason.contentFilter,
+        g.FinishReason.imageProhibitedContent: FinishReason.contentFilter,
+        g.FinishReason.imageOther: FinishReason.unspecified,
+        g.FinishReason.noImage: FinishReason.unspecified,
+        g.FinishReason.imageRecitation: FinishReason.recitation,
+        g.FinishReason.unexpectedToolCall: FinishReason.unspecified,
+        g.FinishReason.tooManyToolCalls: FinishReason.unspecified,
+        g.FinishReason.missingThoughtSignature: FinishReason.unspecified,
+        g.FinishReason.malformedResponse: FinishReason.unspecified,
+        g.FinishReason.escalation: FinishReason.unspecified,
+      };
+
+      for (final MapEntry(key: reason, value: finishReason)
+          in expected.entries) {
+        final result = g.GenerateContentResponse(
+          candidates: [
+            g.Candidate(
+              content: const g.Content(parts: [g.TextPart('result')]),
+              finishReason: reason,
+            ),
+          ],
+        ).toChatResult('id-1', 'gemini-2.5-flash');
+
+        expect(result.finishReason, finishReason, reason: reason.name);
+      }
     });
   });
 }

--- a/packages/langchain_google/test/embeddings/google_ai/google_ai_embeddings_mapper_test.dart
+++ b/packages/langchain_google/test/embeddings/google_ai/google_ai_embeddings_mapper_test.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:langchain_core/documents.dart';
+import 'package:langchain_google/langchain_google.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('uses typed embedding config for queries and documents', () async {
+    final requests = <http.Request>[];
+    final client = MockClient((request) async {
+      requests.add(request);
+      if (request.url.path.endsWith(':batchEmbedContents')) {
+        return http.Response(
+          jsonEncode({
+            'embeddings': [
+              {
+                'values': [0.1, 0.2],
+              },
+            ],
+          }),
+          200,
+        );
+      }
+      return http.Response(
+        jsonEncode({
+          'embedding': {
+            'values': [0.3, 0.4],
+          },
+        }),
+        200,
+      );
+    });
+    final embeddings = GoogleGenerativeAIEmbeddings(
+      apiKey: 'test-key',
+      client: client,
+      dimensions: 64,
+    );
+
+    final queryEmbedding = await embeddings.embedQuery('query');
+    final documentEmbeddings = await embeddings.embedDocuments([
+      const Document(
+        pageContent: 'document',
+        metadata: {'title': 'Document title'},
+      ),
+    ]);
+
+    expect(queryEmbedding, [0.3, 0.4]);
+    expect(documentEmbeddings, [
+      [0.1, 0.2],
+    ]);
+    final queryBody = jsonDecode(requests.first.body) as Map<String, dynamic>;
+    expect(queryBody['embedContentConfig'], {
+      'taskType': 'RETRIEVAL_QUERY',
+      'outputDimensionality': 64,
+    });
+    final batchBody = jsonDecode(requests.last.body) as Map<String, dynamic>;
+    final documentRequest =
+        (batchBody['requests'] as List<dynamic>).single as Map<String, dynamic>;
+    expect(documentRequest['embedContentConfig'], {
+      'taskType': 'RETRIEVAL_DOCUMENT',
+      'title': 'Document title',
+      'outputDimensionality': 64,
+    });
+
+    embeddings.close();
+  });
+}

--- a/packages/langchain_google/test/embeddings/google_ai/google_ai_embeddings_test.dart
+++ b/packages/langchain_google/test/embeddings/google_ai/google_ai_embeddings_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_google/test/embeddings/vertex_ai/vertex_ai_test.dart
+++ b/packages/langchain_google/test/embeddings/vertex_ai/vertex_ai_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_google/test/llms/vertex_ai_test.dart
+++ b/packages/langchain_google/test/llms/vertex_ai_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_redundant_argument_values
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_google/test/vector_stores/matching_engine_test.dart
+++ b/packages/langchain_google/test/vector_stores/matching_engine_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:convert';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,7 +75,7 @@ melos:
         freezed_annotation: ^3.1.0
         gcloud: ^0.9.0
         glob: ^2.1.3
-        googleai_dart: ^3.5.0
+        googleai_dart: ^12.0.0
         googleapis: ^15.0.0
         googleapis_auth: ^2.0.0
         http: ^1.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -136,7 +136,7 @@ melos:
 
     analyze:diff:
       description: Run Flutter static analyzer
-      run: melos exec -- "flutter analyze ."
+      run: melos exec -c 1 -- "flutter analyze --no-pub ."
       packageFilters:
         diff: origin/main...HEAD
 
@@ -159,11 +159,26 @@ melos:
         dirExists: test
 
     test:diff:
-      exec: dart test test
-      description: Run all Dart tests for changed packages in this project.
+      run: melos run test:diff:dart --no-select && melos run test:diff:firebase --no-select
+      description: Run non-live tests for changed packages in this project.
+
+    test:diff:dart:
+      exec: dart test test --exclude-tags=integration
+      description: Run non-live Dart tests for changed packages.
       packageFilters:
         diff: origin/main...HEAD
         flutter: false
+        dirExists: test
+        ignore:
+          - langchain_chroma
+          - langchain_firebase
+          - langchain_supabase
+
+    test:diff:firebase:
+      exec: flutter test test --exclude-tags=integration
+      description: Run non-live Firebase tests when the package changed.
+      packageFilters:
+        scope: langchain_firebase
         dirExists: test
 
     dep-outdated:


### PR DESCRIPTION
## Summary

- Migrates `langchain_google` from `googleai_dart` 3.5 to the published 12.x API.
- Keeps Google AI and Vertex AI behavior symmetrical while retaining the interim function-call thought-signature round trip from #960.
- Adopts the typed tool, code-execution, embedding, authentication-error, and finish-reason APIs required by the new client.

## Details

This is intentionally a dependency/API migration only. It does not introduce the LangChain ordered content-block model; that is delivered by the next PR in this stack.

The centralized Melos constraint and package constraint both require `googleai_dart: ^12.0.0`, so CI and reviewers resolve the published package without local overrides.

Live testing identified the Gemini Developer API embedding-config serialization issue fixed by davidmigloz/ai_clients_dart#298. `googleai_dart` 12.0.1 is now published, resolves through the existing caret constraint, and the reduced-dimensionality embedding integration passes against it.

## References

- Fixes the client-migration prerequisite for #942.
- Builds on the interim fix merged in #960.
- `googleai_dart` structural `Part` support: davidmigloz/ai_clients_dart#292.
- Gemini embedding-config serialization fix: davidmigloz/ai_clients_dart#298.

## Test plan

- [x] Bootstrap the complete workspace using published dependencies only
- [x] Run full-workspace `melos analyze`
- [x] Run all non-live `langchain_google` tests
- [x] Verify Google AI and Vertex AI mapper tests
- [x] Run Google AI and Vertex AI chat integrations, including the #942 tool round trip
- [x] Run Vertex AI embedding integrations
- [x] Resolve `googleai_dart` 12.0.1 and rerun Google AI reduced-dimensionality embeddings
