### PR TITLE
feat(chat-models): add ordered blocks for Google and Anthropic

### DIFF
--- a/packages/langchain/test/agents/content_block_tool_routing_test.dart
+++ b/packages/langchain/test/agents/content_block_tool_routing_test.dart
@@ -1,0 +1,106 @@
+import 'package:langchain/langchain.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('parallel same-name content-block calls route independently', () async {
+    const message = AIChatMessage.withBlocks(
+      contentBlocks: [
+        AIChatMessageToolCall(
+          id: 'call-madrid',
+          index: 0,
+          name: 'weather',
+          argumentsRaw: '{"city":"Madrid"}',
+          arguments: {'city': 'Madrid'},
+        ),
+        AIChatMessageToolCall(
+          id: 'call-paris',
+          index: 1,
+          name: 'weather',
+          argumentsRaw: '{"city":"Paris"}',
+          arguments: {'city': 'Paris'},
+        ),
+      ],
+    );
+    final actions = await const ToolsAgentOutputParser().parseChatMessage(
+      message,
+    );
+
+    expect(actions.map((action) => (action as AgentAction).id), [
+      'call-madrid',
+      'call-paris',
+    ]);
+
+    final tool = _WeatherTool();
+    final agent = _ActionSequenceAgent(
+      tools: [tool],
+      actionSequence: [
+        actions,
+        [
+          const AgentFinish(
+            returnValues: {BaseActionAgent.agentReturnKey: 'done'},
+          ),
+        ],
+      ],
+    );
+    final result = await AgentExecutor(
+      agent: agent,
+      returnIntermediateSteps: true,
+    ).call('weather');
+    final steps =
+        result[AgentExecutor.intermediateStepsOutputKey] as List<AgentStep>;
+
+    expect(steps.map((step) => step.action.id), ['call-madrid', 'call-paris']);
+    expect(steps.map((step) => step.observation), [
+      'weather:Madrid',
+      'weather:Paris',
+    ]);
+    expect(tool.cities, ['Madrid', 'Paris']);
+  });
+}
+
+final class _WeatherTool extends Tool<String, ToolOptions, String> {
+  _WeatherTool()
+    : super(
+        name: 'weather',
+        description: 'Returns weather for a city',
+        inputJsonSchema: const {
+          'type': 'object',
+          'properties': {
+            'city': {'type': 'string'},
+          },
+          'required': ['city'],
+        },
+      );
+
+  final List<String> cities = [];
+
+  @override
+  String getInputFromJson(final Map<String, dynamic> json) =>
+      json['city'] as String;
+
+  @override
+  Future<String> invokeInternal(
+    final String input, {
+    final ToolOptions? options,
+  }) async {
+    cities.add(input);
+    return 'weather:$input';
+  }
+}
+
+final class _ActionSequenceAgent extends BaseMultiActionAgent {
+  _ActionSequenceAgent({required super.tools, required this.actionSequence});
+
+  final List<List<BaseAgentAction>> actionSequence;
+  var _index = 0;
+
+  @override
+  String get agentType => 'content-block-test-agent';
+
+  @override
+  Set<String> get inputKeys => const {'input'};
+
+  @override
+  Future<List<BaseAgentAction>> plan(final AgentPlanInput input) async =>
+      actionSequence[_index++];
+}

--- a/packages/langchain/test/agents/tools_agent_test.dart
+++ b/packages/langchain/test/agents/tools_agent_test.dart
@@ -2,6 +2,7 @@
 
 @TestOn('vm')
 @Timeout(Duration(minutes: 50))
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:async';

--- a/packages/langchain_anthropic/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_anthropic/lib/src/chat_models/mappers.dart
@@ -148,20 +148,13 @@ extension ChatMessageListMapper on List<ChatMessage> {
   }
 
   a.InputMessage _mapAIChatMessage(final AIChatMessage msg) {
-    if (msg.toolCalls.isEmpty) {
+    final blocks = msg.contentBlocks;
+    if (blocks.length == 1 && blocks.single is AIChatMessageTextBlock) {
       return a.InputMessage.assistant(msg.content);
-    } else {
-      return a.InputMessage.assistantBlocks([
-        if (msg.content.isNotEmpty) a.InputContentBlock.text(msg.content),
-        ...msg.toolCalls.map(
-          (final toolCall) => a.InputContentBlock.toolUse(
-            id: toolCall.id,
-            name: toolCall.name,
-            input: toolCall.arguments,
-          ),
-        ),
-      ]);
     }
+    return a.InputMessage.assistantBlocks(
+      blocks.map(_mapAIContentBlock).toList(growable: false),
+    );
   }
 
   a.InputMessage _mapToolChatMessages(final List<ToolChatMessage> msgs) {
@@ -180,20 +173,16 @@ extension ChatMessageListMapper on List<ChatMessage> {
 
 extension MessageMapper on a.Message {
   ChatResult toChatResult() {
-    final content = '$thinking$text';
-    final toolCalls = toolUseBlocks
-        .map(
-          (tu) => AIChatMessageToolCall(
-            id: tu.id,
-            name: tu.name,
-            argumentsRaw: tu.input.isNotEmpty ? json.encode(tu.input) : '',
-            arguments: tu.input,
-          ),
-        )
-        .toList(growable: false);
+    final blocks = [
+      for (final (index, block) in content.indexed)
+        _mapContentBlock(block, messageId: id, index: index),
+    ];
     return ChatResult(
       id: id,
-      output: AIChatMessage(content: content, toolCalls: toolCalls),
+      output: AIChatMessage.withBlocks(
+        contentBlocks: blocks,
+        legacyContent: '$thinking$text',
+      ),
       finishReason: _mapFinishReason(stopReason),
       metadata: {'model': model, 'stop_sequence': stopSequence},
       usage: _mapUsage(usage),
@@ -206,7 +195,7 @@ class MessageStreamEventTransformer
   MessageStreamEventTransformer();
 
   String? lastMessageId;
-  String? lastToolCallId;
+  final Map<int, String> toolCallIdsByIndex = {};
 
   @override
   Stream<ChatResult> bind(final Stream<a.MessageStreamEvent> stream) {
@@ -232,18 +221,12 @@ class MessageStreamEventTransformer
 
     return ChatResult(
       id: msg.id,
-      output: AIChatMessage(
-        content: '${msg.thinking}${msg.text}',
-        toolCalls: msg.toolUseBlocks
-            .map(
-              (tu) => AIChatMessageToolCall(
-                id: tu.id,
-                name: tu.name,
-                argumentsRaw: tu.input.isNotEmpty ? json.encode(tu.input) : '',
-                arguments: tu.input,
-              ),
-            )
-            .toList(growable: false),
+      output: AIChatMessage.withBlocks(
+        contentBlocks: [
+          for (final (index, block) in msg.content.indexed)
+            _mapContentBlock(block, messageId: msg.id, index: index),
+        ],
+        legacyContent: '${msg.thinking}${msg.text}',
       ),
       finishReason: _mapFinishReason(msg.stopReason),
       metadata: {
@@ -258,7 +241,7 @@ class MessageStreamEventTransformer
   ChatResult _mapMessageDeltaEvent(final a.MessageDeltaEvent e) {
     return ChatResult(
       id: lastMessageId ?? '',
-      output: const AIChatMessage(content: ''),
+      output: const AIChatMessage.withBlocks(contentBlocks: []),
       finishReason: _mapFinishReason(e.delta.stopReason),
       metadata: {
         if (e.delta.stopSequence != null) 'stop_sequence': e.delta.stopSequence,
@@ -269,16 +252,20 @@ class MessageStreamEventTransformer
   }
 
   ChatResult _mapContentBlockStartEvent(final a.ContentBlockStartEvent e) {
-    final (content, toolCall) = _mapContentBlock(e.contentBlock);
-    if (toolCall != null) {
-      lastToolCallId = toolCall.id;
+    final block = _mapContentBlock(
+      e.contentBlock,
+      messageId: lastMessageId ?? '',
+      index: e.index,
+    );
+    if (block case final AIChatMessageToolCall toolCall) {
+      toolCallIdsByIndex[e.index] = toolCall.id;
     }
 
     return ChatResult(
       id: lastMessageId ?? '',
-      output: AIChatMessage(
-        content: content,
-        toolCalls: [if (toolCall != null) toolCall],
+      output: AIChatMessage.withBlocks(
+        contentBlocks: [block],
+        legacyContent: block.legacyContent,
       ),
       finishReason: FinishReason.unspecified,
       metadata: const {},
@@ -288,10 +275,18 @@ class MessageStreamEventTransformer
   }
 
   ChatResult _mapContentBlockDeltaEvent(final a.ContentBlockDeltaEvent e) {
-    final (content, toolCalls) = _mapContentBlockDelta(lastToolCallId, e.delta);
+    final block = _mapContentBlockDelta(
+      e.delta,
+      messageId: lastMessageId ?? '',
+      index: e.index,
+      toolCallId: toolCallIdsByIndex[e.index],
+    );
     return ChatResult(
       id: lastMessageId ?? '',
-      output: AIChatMessage(content: content, toolCalls: toolCalls),
+      output: AIChatMessage.withBlocks(
+        contentBlocks: [block],
+        legacyContent: block.legacyContent,
+      ),
       finishReason: FinishReason.unspecified,
       metadata: {'index': e.index},
       usage: const LanguageModelUsage(),
@@ -300,59 +295,249 @@ class MessageStreamEventTransformer
   }
 
   ChatResult? _mapContentBlockStopEvent(final a.ContentBlockStopEvent e) {
-    lastToolCallId = null;
+    toolCallIdsByIndex.remove(e.index);
     return null;
   }
 
   ChatResult? _mapMessageStopEvent(final a.MessageStopEvent e) {
     lastMessageId = null;
+    toolCallIdsByIndex.clear();
     return null;
   }
 }
 
-/// Maps a single content block from stream start event.
-(String content, AIChatMessageToolCall? toolCall) _mapContentBlock(
-  final a.ContentBlock contentBlock,
-) => switch (contentBlock) {
-  final a.TextBlock t => (t.text, null),
-  final a.ThinkingBlock t => (t.thinking, null),
-  final a.ToolUseBlock tu => (
-    '',
-    AIChatMessageToolCall(
-      id: tu.id,
-      name: tu.name,
-      argumentsRaw: tu.input.isNotEmpty ? json.encode(tu.input) : '',
-      arguments: tu.input,
+a.InputContentBlock _mapAIContentBlock(final AIChatMessageContentBlock block) {
+  final rawBlock = switch (block.providerData['anthropic']) {
+    {'contentBlock': final Map<Object?, Object?> value} =>
+      value.cast<String, dynamic>(),
+    _ => null,
+  };
+  return switch (block) {
+    final AIChatMessageTextBlock text => a.InputContentBlock.fromJson({
+      ...?rawBlock,
+      'type': 'text',
+      'text': text.text,
+    }),
+    final AIChatMessageReasoningBlock reasoning => _mapAnthropicReasoningBlock(
+      reasoning,
+      rawBlock,
     ),
-  ),
-  a.RedactedThinkingBlock() => ('', null),
-  a.ServerToolUseBlock() => ('', null),
-  a.WebSearchToolResultBlock() => ('', null),
-  _ => ('', null),
-};
+    final AIChatMessageToolCall toolCall => a.InputContentBlock.fromJson({
+      ...?rawBlock,
+      'type': 'tool_use',
+      'id': toolCall.id,
+      'name': toolCall.name,
+      'input': toolCall.arguments,
+    }),
+    AIChatMessageMediaBlock() ||
+    AIChatMessageFileBlock() ||
+    AIChatMessageServerToolCall() ||
+    AIChatMessageServerToolResult() ||
+    AIChatMessageProviderMetadataBlock() => _rawAnthropicInputBlock(
+      block,
+      rawBlock,
+    ),
+    final AIChatMessageNonStandardBlock nonStandard =>
+      rawBlock != null
+          ? a.InputContentBlock.fromJson(rawBlock)
+          : switch (nonStandard.value) {
+              final Map<Object?, Object?> value => a.InputContentBlock.fromJson(
+                value.cast<String, dynamic>(),
+              ),
+              _ => throw UnsupportedError(
+                'Cannot replay ${nonStandard.value.runtimeType} to Anthropic',
+              ),
+            },
+  };
+}
 
-/// Maps a content block delta from streaming events.
-(String content, List<AIChatMessageToolCall> toolCalls) _mapContentBlockDelta(
-  final String? lastToolId,
-  final a.ContentBlockDelta blockDelta,
-) => switch (blockDelta) {
-  final a.TextDelta t => (t.text, const <AIChatMessageToolCall>[]),
-  final a.InputJsonDelta jb => (
-    '',
-    [
-      AIChatMessageToolCall(
-        id: lastToolId ?? '',
-        name: '',
-        argumentsRaw: jb.partialJson,
-        arguments: const {},
-      ),
-    ],
-  ),
-  final a.ThinkingDelta t => (t.thinking, const <AIChatMessageToolCall>[]),
-  a.SignatureDelta() => ('', const <AIChatMessageToolCall>[]),
-  a.CitationsDelta() => ('', const <AIChatMessageToolCall>[]),
-  _ => ('', const <AIChatMessageToolCall>[]),
-};
+a.InputContentBlock _mapAnthropicReasoningBlock(
+  final AIChatMessageReasoningBlock block,
+  final Map<String, dynamic>? rawBlock,
+) {
+  if (rawBlock?['type'] == 'redacted_thinking') {
+    return a.InputContentBlock.fromJson(rawBlock!);
+  }
+  return a.InputContentBlock.fromJson({
+    ...?rawBlock,
+    'type': rawBlock?['type'] ?? 'thinking',
+    'thinking': block.reasoning,
+    if (_anthropicSignature(block) case final String signature)
+      'signature': signature,
+  });
+}
+
+a.InputContentBlock _rawAnthropicInputBlock(
+  final AIChatMessageContentBlock block,
+  final Map<String, dynamic>? rawBlock,
+) {
+  if (rawBlock == null) {
+    throw UnsupportedError(
+      '${block.runtimeType} can only be replayed to Anthropic when it contains '
+      'providerData["anthropic"]["contentBlock"]',
+    );
+  }
+  return a.InputContentBlock.fromJson(rawBlock);
+}
+
+AIChatMessageContentBlock _mapContentBlock(
+  final a.ContentBlock contentBlock, {
+  required final String messageId,
+  required final int index,
+}) {
+  final rawBlock = contentBlock.toJson();
+  final fallbackId = 'anthropic:$messageId:$index';
+  final providerData = <String, dynamic>{
+    'anthropic': {
+      'contentBlock': rawBlock,
+      if (contentBlock case final a.ThinkingBlock thinking)
+        'signature': thinking.signature,
+    },
+  };
+  return switch (contentBlock) {
+    final a.TextBlock text => AIChatMessageTextBlock(
+      text: text.text,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    final a.ThinkingBlock thinking => AIChatMessageReasoningBlock(
+      reasoning: thinking.thinking,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    a.RedactedThinkingBlock() => AIChatMessageReasoningBlock(
+      reasoning: '',
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    final a.ToolUseBlock toolUse => AIChatMessageToolCall(
+      id: toolUse.id,
+      index: index,
+      name: toolUse.name,
+      argumentsRaw: toolUse.input.isNotEmpty ? json.encode(toolUse.input) : '',
+      arguments: toolUse.input,
+      providerData: providerData,
+    ),
+    _ => _mapNonClientAnthropicBlock(
+      rawBlock,
+      fallbackId: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+  };
+}
+
+AIChatMessageContentBlock _mapNonClientAnthropicBlock(
+  final Map<String, dynamic> rawBlock, {
+  required final String fallbackId,
+  required final int index,
+  required final Map<String, dynamic> providerData,
+}) {
+  final type = rawBlock['type'] as String? ?? '';
+  if (type.endsWith('tool_use')) {
+    final input = switch (rawBlock['input']) {
+      final Map<Object?, Object?> value => value.cast<String, dynamic>(),
+      _ => const <String, dynamic>{},
+    };
+    return AIChatMessageServerToolCall(
+      id: rawBlock['id'] as String? ?? fallbackId,
+      index: index,
+      name: rawBlock['name'] as String? ?? type,
+      argumentsRaw: input.isNotEmpty ? json.encode(input) : '',
+      arguments: input,
+      providerData: providerData,
+    );
+  }
+  if (type.endsWith('tool_result')) {
+    final toolCallId = rawBlock['tool_use_id'] as String? ?? fallbackId;
+    return AIChatMessageServerToolResult(
+      id: toolCallId,
+      index: index,
+      toolCallId: toolCallId,
+      result: rawBlock['content'],
+      providerData: providerData,
+    );
+  }
+  return AIChatMessageNonStandardBlock(
+    value: rawBlock,
+    id: fallbackId,
+    index: index,
+    providerData: providerData,
+  );
+}
+
+AIChatMessageContentBlock _mapContentBlockDelta(
+  final a.ContentBlockDelta blockDelta, {
+  required final String messageId,
+  required final int index,
+  required final String? toolCallId,
+}) {
+  final fallbackId = 'anthropic:$messageId:$index';
+  return switch (blockDelta) {
+    final a.TextDelta text => AIChatMessageTextBlock(
+      text: text.text,
+      id: fallbackId,
+      index: index,
+      providerData: {
+        'anthropic': {'delta': text.toJson()},
+      },
+    ),
+    final a.InputJsonDelta jsonDelta => AIChatMessageToolCall(
+      id: toolCallId ?? fallbackId,
+      index: index,
+      name: '',
+      argumentsRaw: jsonDelta.partialJson,
+      arguments: const {},
+      providerData: {
+        'anthropic': {'delta': jsonDelta.toJson()},
+      },
+    ),
+    final a.ThinkingDelta thinking => AIChatMessageReasoningBlock(
+      reasoning: thinking.thinking,
+      id: fallbackId,
+      index: index,
+      providerData: {
+        'anthropic': {'delta': thinking.toJson()},
+      },
+    ),
+    final a.SignatureDelta signature => AIChatMessageReasoningBlock(
+      reasoning: '',
+      id: fallbackId,
+      index: index,
+      providerData: {
+        'anthropic': {
+          'delta': signature.toJson(),
+          'signature': signature.signature,
+        },
+      },
+    ),
+    final a.CitationsDelta citations => AIChatMessageTextBlock(
+      text: '',
+      id: fallbackId,
+      index: index,
+      providerData: {
+        'anthropic': {'delta': citations.toJson()},
+      },
+    ),
+    final a.ContentBlockDelta unknown => AIChatMessageNonStandardBlock(
+      value: unknown.toJson(),
+      id: fallbackId,
+      index: index,
+      providerData: {
+        'anthropic': {'delta': unknown.toJson()},
+      },
+    ),
+  };
+}
+
+String? _anthropicSignature(final AIChatMessageContentBlock block) =>
+    switch (block.providerData['anthropic']) {
+      {'signature': final String signature} => signature,
+      _ => null,
+    };
 
 extension ToolSpecListMapper on List<ToolSpec> {
   /// Converts tool specs to typed ToolDefinition list for the request.

--- a/packages/langchain_anthropic/pubspec.yaml
+++ b/packages/langchain_anthropic/pubspec.yaml
@@ -20,7 +20,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  anthropic_sdk_dart: ^1.3.0
+  anthropic_sdk_dart: ^7.0.0
   collection: ^1.19.1
   http: ^1.5.0
   langchain_core: 0.4.1

--- a/packages/langchain_anthropic/test/chat_models/chat_anthropic_test.dart
+++ b/packages/langchain_anthropic/test/chat_models/chat_anthropic_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_redundant_argument_values, avoid_print
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:convert';

--- a/packages/langchain_anthropic/test/chat_models/mappers_test.dart
+++ b/packages/langchain_anthropic/test/chat_models/mappers_test.dart
@@ -1,0 +1,214 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart' as a;
+import 'package:langchain_anthropic/src/chat_models/mappers.dart';
+import 'package:langchain_core/chat_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Anthropic ordered content blocks', () {
+    test('preserves thinking, tool-use order, signature, and replay', () {
+      const responseBlocks = <a.ContentBlock>[
+        a.ThinkingBlock(thinking: 'reasoning', signature: 'opaque-signature'),
+        a.ToolUseBlock(
+          id: 'call-1',
+          name: 'weather',
+          input: {'city': 'Madrid'},
+        ),
+        a.TextBlock(text: 'It is sunny.'),
+        a.ServerToolUseBlock(
+          id: 'server-1',
+          name: 'web_search',
+          input: {'query': 'weather'},
+        ),
+      ];
+      const message = a.Message(
+        id: 'message-1',
+        content: responseBlocks,
+        model: 'claude-sonnet-4-5',
+        usage: a.Usage(inputTokens: 10, outputTokens: 20),
+      );
+
+      final output = message.toChatResult().output;
+      final replayed = <ChatMessage>[output].toInputMessages().single;
+
+      expect(output.contentBlocks.map((block) => block.runtimeType), [
+        AIChatMessageReasoningBlock,
+        AIChatMessageToolCall,
+        AIChatMessageTextBlock,
+        AIChatMessageServerToolCall,
+      ]);
+      expect(output.content, 'reasoningIt is sunny.');
+      expect(
+        (output.contentBlocks.first.providerData['anthropic']
+            as Map<String, dynamic>)['signature'],
+        'opaque-signature',
+      );
+      expect(
+        replayed.toJson()['content'],
+        responseBlocks.map((block) => block.toJson()).toList(),
+      );
+    });
+
+    test('preserves redacted and future content blocks', () {
+      final responseBlocks = <a.ContentBlock>[
+        const a.RedactedThinkingBlock(data: 'encrypted'),
+        a.ContentBlock.fromJson({
+          'type': 'future_block',
+          'payload': {'value': 1},
+        }),
+      ];
+      final message = a.Message(
+        id: 'message-1',
+        content: responseBlocks,
+        model: 'claude-sonnet-4-5',
+        usage: const a.Usage(inputTokens: 1, outputTokens: 1),
+      );
+
+      final output = message.toChatResult().output;
+      final replayed = <ChatMessage>[output].toInputMessages().single;
+
+      expect(output.contentBlocks.first, isA<AIChatMessageReasoningBlock>());
+      expect(output.contentBlocks.last, isA<AIChatMessageNonStandardBlock>());
+      expect(
+        replayed.toJson()['content'],
+        responseBlocks.map((block) => block.toJson()).toList(),
+      );
+    });
+  });
+
+  group('Anthropic streaming content blocks', () {
+    test(
+      'applies signature delta to its reasoning block and replays it',
+      () async {
+        final events = <a.MessageStreamEvent>[
+          const a.MessageStartEvent(
+            message: a.Message(
+              id: 'message-1',
+              content: [],
+              model: 'claude-sonnet-4-5',
+              usage: a.Usage(inputTokens: 10, outputTokens: 0),
+            ),
+          ),
+          const a.ContentBlockStartEvent(
+            index: 0,
+            contentBlock: a.ThinkingBlock(thinking: '', signature: ''),
+          ),
+          const a.ContentBlockDeltaEvent(
+            index: 0,
+            delta: a.ThinkingDelta('reasoning'),
+          ),
+          const a.ContentBlockDeltaEvent(
+            index: 0,
+            delta: a.SignatureDelta('opaque-signature'),
+          ),
+          const a.ContentBlockStartEvent(
+            index: 1,
+            contentBlock: a.ToolUseBlock(
+              id: 'call-1',
+              name: 'weather',
+              input: {},
+            ),
+          ),
+          const a.ContentBlockDeltaEvent(
+            index: 1,
+            delta: a.InputJsonDelta('{"city":'),
+          ),
+          const a.ContentBlockDeltaEvent(
+            index: 1,
+            delta: a.InputJsonDelta('"Madrid"}'),
+          ),
+          const a.ContentBlockStartEvent(
+            index: 2,
+            contentBlock: a.TextBlock(text: ''),
+          ),
+          const a.ContentBlockDeltaEvent(
+            index: 2,
+            delta: a.TextDelta('It is sunny.'),
+          ),
+        ];
+
+        final results = await MessageStreamEventTransformer()
+            .bind(Stream.fromIterable(events))
+            .toList();
+        final output = results
+            .map((result) => result.output)
+            .reduce((first, next) => first.concat(next));
+        final reasoning =
+            output.contentBlocks[0] as AIChatMessageReasoningBlock;
+        final toolCall = output.contentBlocks[1] as AIChatMessageToolCall;
+        final replayed = <ChatMessage>[output].toInputMessages().single;
+
+        expect(reasoning.reasoning, 'reasoning');
+        expect(
+          (reasoning.providerData['anthropic']
+              as Map<String, dynamic>)['signature'],
+          'opaque-signature',
+        );
+        expect(toolCall.arguments, {'city': 'Madrid'});
+        expect(output.content, 'reasoningIt is sunny.');
+        expect(replayed.toJson()['content'], [
+          {
+            'type': 'thinking',
+            'thinking': 'reasoning',
+            'signature': 'opaque-signature',
+          },
+          {
+            'type': 'tool_use',
+            'id': 'call-1',
+            'name': 'weather',
+            'input': {'city': 'Madrid'},
+          },
+          {'type': 'text', 'text': 'It is sunny.'},
+        ]);
+      },
+    );
+
+    test('keeps parallel same-name calls correlated by index', () async {
+      final transformer = MessageStreamEventTransformer();
+      final events = <a.MessageStreamEvent>[
+        const a.MessageStartEvent(
+          message: a.Message(
+            id: 'message-1',
+            content: [],
+            model: 'claude-sonnet-4-5',
+            usage: a.Usage(inputTokens: 1, outputTokens: 0),
+          ),
+        ),
+        const a.ContentBlockStartEvent(
+          index: 0,
+          contentBlock: a.ToolUseBlock(
+            id: 'call-madrid',
+            name: 'weather',
+            input: {},
+          ),
+        ),
+        const a.ContentBlockStartEvent(
+          index: 1,
+          contentBlock: a.ToolUseBlock(
+            id: 'call-paris',
+            name: 'weather',
+            input: {},
+          ),
+        ),
+        const a.ContentBlockDeltaEvent(
+          index: 0,
+          delta: a.InputJsonDelta('{"city":"Madrid"}'),
+        ),
+        const a.ContentBlockDeltaEvent(
+          index: 1,
+          delta: a.InputJsonDelta('{"city":"Paris"}'),
+        ),
+      ];
+
+      final results = await transformer
+          .bind(Stream.fromIterable(events))
+          .toList();
+      final calls = results
+          .map((result) => result.output)
+          .reduce((first, next) => first.concat(next))
+          .toolCalls;
+
+      expect(calls.map((call) => call.id), ['call-madrid', 'call-paris']);
+      expect(calls.map((call) => call.arguments['city']), ['Madrid', 'Paris']);
+    });
+  });
+}

--- a/packages/langchain_core/lib/src/chat_models/chat_models.dart
+++ b/packages/langchain_core/lib/src/chat_models/chat_models.dart
@@ -1,4 +1,5 @@
 export 'base.dart';
+export 'content_blocks.dart';
 export 'fake.dart';
 export 'types.dart';
 export 'utils.dart';

--- a/packages/langchain_core/lib/src/chat_models/content_blocks.dart
+++ b/packages/langchain_core/lib/src/chat_models/content_blocks.dart
@@ -16,6 +16,7 @@ sealed class AIChatMessageContentBlock {
   const AIChatMessageContentBlock({
     this.id = '',
     this.index,
+    this.isMergeable = true,
     this.providerData = const {},
   });
 
@@ -24,6 +25,12 @@ sealed class AIChatMessageContentBlock {
 
   /// Position assigned to this block by the provider's streaming protocol.
   final int? index;
+
+  /// Whether later streaming chunks may be merged into this block.
+  ///
+  /// Set this to `false` when the provider requires the exact boundary of a
+  /// completed content part to be retained.
+  final bool isMergeable;
 
   /// Provider-specific data, nested under a provider namespace.
   final Map<String, dynamic> providerData;
@@ -58,6 +65,7 @@ sealed class AIChatMessageContentBlock {
 
   /// Whether [other] is a chunk of the same logical streaming block.
   bool canMerge(final AIChatMessageContentBlock other) {
+    if (!isMergeable || !other.isMergeable) return false;
     if (runtimeType != other.runtimeType) return false;
     if (id.isNotEmpty && other.id.isNotEmpty) {
       return id == other.id;
@@ -202,6 +210,7 @@ final class AIChatMessageTextBlock extends AIChatMessageContentBlock {
     required this.text,
     super.id,
     super.index,
+    super.isMergeable,
     super.providerData,
   });
 
@@ -214,6 +223,7 @@ final class AIChatMessageTextBlock extends AIChatMessageContentBlock {
         text: map['text'] as String,
         id: _readId(map),
         index: map['index'] as int?,
+        isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
 
@@ -244,6 +254,7 @@ final class AIChatMessageReasoningBlock extends AIChatMessageContentBlock {
     required this.reasoning,
     super.id,
     super.index,
+    super.isMergeable,
     super.providerData,
   });
 
@@ -256,6 +267,7 @@ final class AIChatMessageReasoningBlock extends AIChatMessageContentBlock {
         reasoning: map['reasoning'] as String,
         id: _readId(map),
         index: map['index'] as int?,
+        isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
 
@@ -287,6 +299,7 @@ final class AIChatMessageMediaBlock extends AIChatMessageContentBlock {
     this.mimeType,
     super.id,
     super.index,
+    super.isMergeable,
     super.providerData,
   });
 
@@ -303,6 +316,7 @@ final class AIChatMessageMediaBlock extends AIChatMessageContentBlock {
         mimeType: map['mimeType'] as String?,
         id: _readId(map),
         index: map['index'] as int?,
+        isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
 
@@ -338,6 +352,7 @@ final class AIChatMessageFileBlock extends AIChatMessageContentBlock {
     this.mimeType,
     super.id,
     super.index,
+    super.isMergeable,
     super.providerData,
   });
 
@@ -358,6 +373,7 @@ final class AIChatMessageFileBlock extends AIChatMessageContentBlock {
         mimeType: map['mimeType'] as String?,
         id: _readId(map),
         index: map['index'] as int?,
+        isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
 
@@ -397,6 +413,7 @@ final class AIChatMessageToolCall extends AIChatMessageContentBlock {
     required this.argumentsRaw,
     required this.arguments,
     super.index,
+    super.isMergeable,
     super.providerData,
   });
 
@@ -417,6 +434,7 @@ final class AIChatMessageToolCall extends AIChatMessageContentBlock {
         argumentsRaw: map['argumentsRaw'] as String,
         arguments: _readMap(map['arguments']),
         index: map['index'] as int?,
+        isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
 
@@ -432,6 +450,7 @@ final class AIChatMessageToolCall extends AIChatMessageContentBlock {
     'arguments': arguments,
     'providerData': providerData,
     if (index != null) 'index': index,
+    if (!isMergeable) 'isMergeable': false,
   };
 
   @override
@@ -440,6 +459,7 @@ final class AIChatMessageToolCall extends AIChatMessageContentBlock {
     return identical(this, other) ||
         id == other.id &&
             index == other.index &&
+            isMergeable == other.isMergeable &&
             name == other.name &&
             argumentsRaw == other.argumentsRaw &&
             deepEquals.equals(arguments, other.arguments) &&
@@ -452,6 +472,7 @@ final class AIChatMessageToolCall extends AIChatMessageContentBlock {
     return Object.hash(
       id,
       index,
+      isMergeable,
       name,
       argumentsRaw,
       deepEquals.hash(arguments),
@@ -476,6 +497,7 @@ final class AIChatMessageServerToolCall extends AIChatMessageContentBlock {
     required this.argumentsRaw,
     required this.arguments,
     super.index,
+    super.isMergeable,
     super.providerData,
   });
 
@@ -496,6 +518,7 @@ final class AIChatMessageServerToolCall extends AIChatMessageContentBlock {
         argumentsRaw: map['argumentsRaw'] as String,
         arguments: _readMap(map['arguments']),
         index: map['index'] as int?,
+        isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
 
@@ -543,6 +566,7 @@ final class AIChatMessageServerToolResult extends AIChatMessageContentBlock {
     this.name,
     super.id,
     super.index,
+    super.isMergeable,
     super.providerData,
   });
 
@@ -563,6 +587,7 @@ final class AIChatMessageServerToolResult extends AIChatMessageContentBlock {
         result: map['result'],
         id: _readId(map),
         index: map['index'] as int?,
+        isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
 
@@ -608,6 +633,7 @@ final class AIChatMessageProviderMetadataBlock
   const AIChatMessageProviderMetadataBlock({
     super.id,
     super.index,
+    super.isMergeable,
     required super.providerData,
   });
 
@@ -617,6 +643,7 @@ final class AIChatMessageProviderMetadataBlock
   ) => AIChatMessageProviderMetadataBlock(
     id: _readId(map),
     index: map['index'] as int?,
+    isMergeable: _readIsMergeable(map),
     providerData: _readProviderData(map),
   );
 
@@ -645,6 +672,7 @@ final class AIChatMessageNonStandardBlock extends AIChatMessageContentBlock {
     required this.value,
     super.id,
     super.index,
+    super.isMergeable,
     super.providerData,
   });
 
@@ -657,6 +685,7 @@ final class AIChatMessageNonStandardBlock extends AIChatMessageContentBlock {
         value: map['value'],
         id: _readId(map),
         index: map['index'] as int?,
+        isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
 
@@ -745,6 +774,9 @@ Map<String, dynamic> _mergeArguments(
 
 String _readId(final Map<String, dynamic> map) => map['id'] as String? ?? '';
 
+bool _readIsMergeable(final Map<String, dynamic> map) =>
+    map['isMergeable'] as bool? ?? true;
+
 Map<String, dynamic> _readMap(final Object? value) =>
     (value as Map?)?.cast<String, dynamic>() ?? const {};
 
@@ -754,6 +786,7 @@ Map<String, dynamic> _readProviderData(final Map<String, dynamic> map) =>
 Map<String, dynamic> _metadataMap(final AIChatMessageContentBlock block) => {
   if (block.id.isNotEmpty) 'id': block.id,
   if (block.index != null) 'index': block.index,
+  if (!block.isMergeable) 'isMergeable': false,
   if (block.providerData.isNotEmpty) 'providerData': block.providerData,
 };
 
@@ -764,6 +797,7 @@ bool _metadataEquals(
   const deepEquals = DeepCollectionEquality();
   return first.id == second.id &&
       first.index == second.index &&
+      first.isMergeable == second.isMergeable &&
       deepEquals.equals(first.providerData, second.providerData);
 }
 
@@ -772,6 +806,7 @@ int _metadataHash(final AIChatMessageContentBlock block) {
   return Object.hash(
     block.id,
     block.index,
+    block.isMergeable,
     deepEquals.hash(block.providerData),
   );
 }

--- a/packages/langchain_core/lib/src/chat_models/content_blocks.dart
+++ b/packages/langchain_core/lib/src/chat_models/content_blocks.dart
@@ -59,8 +59,10 @@ sealed class AIChatMessageContentBlock {
   /// Whether [other] is a chunk of the same logical streaming block.
   bool canMerge(final AIChatMessageContentBlock other) {
     if (runtimeType != other.runtimeType) return false;
-    final identity = streamIdentity;
-    return identity != null && identity == other.streamIdentity;
+    if (id.isNotEmpty && other.id.isNotEmpty) {
+      return id == other.id;
+    }
+    return index != null && index == other.index;
   }
 
   /// Merges a later streaming chunk into this block.

--- a/packages/langchain_core/lib/src/chat_models/content_blocks.dart
+++ b/packages/langchain_core/lib/src/chat_models/content_blocks.dart
@@ -1,0 +1,775 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+
+/// {@template ai_chat_message_content_block}
+/// An ordered content block produced by a chat model.
+///
+/// A block can be correlated across streaming chunks through either a stable
+/// provider [id] or an explicit provider [index]. Provider-specific values must
+/// be nested under a provider namespace in [providerData].
+/// {@endtemplate}
+@immutable
+sealed class AIChatMessageContentBlock {
+  /// {@macro ai_chat_message_content_block}
+  const AIChatMessageContentBlock({
+    this.id = '',
+    this.index,
+    this.providerData = const {},
+  });
+
+  /// Stable provider identifier for this block, when available.
+  final String id;
+
+  /// Position assigned to this block by the provider's streaming protocol.
+  final int? index;
+
+  /// Provider-specific data, nested under a provider namespace.
+  final Map<String, dynamic> providerData;
+
+  /// A stable identity that can be used to merge streamed chunks.
+  String? get streamIdentity => id.isNotEmpty
+      ? 'id:$id'
+      : index != null
+      ? 'index:$index'
+      : null;
+
+  /// Legacy string projection of this block.
+  String get legacyContent;
+
+  /// Converts this block to a map.
+  Map<String, dynamic> toMap();
+
+  /// Converts a map to a content block.
+  factory AIChatMessageContentBlock.fromMap(Map<String, dynamic> map) =>
+      switch (map['type']) {
+        'text' => AIChatMessageTextBlock.fromMap(map),
+        'reasoning' => AIChatMessageReasoningBlock.fromMap(map),
+        'media' => AIChatMessageMediaBlock.fromMap(map),
+        'file' => AIChatMessageFileBlock.fromMap(map),
+        'toolCall' => AIChatMessageToolCall.fromMap(map),
+        'serverToolCall' => AIChatMessageServerToolCall.fromMap(map),
+        'serverToolResult' => AIChatMessageServerToolResult.fromMap(map),
+        'providerMetadata' => AIChatMessageProviderMetadataBlock.fromMap(map),
+        'nonStandard' => AIChatMessageNonStandardBlock.fromMap(map),
+        _ => throw ArgumentError('Unknown AI content block: ${map['type']}'),
+      };
+
+  /// Whether [other] is a chunk of the same logical streaming block.
+  bool canMerge(final AIChatMessageContentBlock other) {
+    if (runtimeType != other.runtimeType) return false;
+    final identity = streamIdentity;
+    return identity != null && identity == other.streamIdentity;
+  }
+
+  /// Merges a later streaming chunk into this block.
+  AIChatMessageContentBlock concat(final AIChatMessageContentBlock other) {
+    if (!canMerge(other)) {
+      throw ArgumentError('Cannot merge unrelated content blocks');
+    }
+    return switch ((this, other)) {
+      (final AIChatMessageTextBlock first, final AIChatMessageTextBlock next) =>
+        AIChatMessageTextBlock(
+          text: first.text + next.text,
+          id: _mergedId(first, next),
+          index: next.index ?? first.index,
+          providerData: mergeProviderData(
+            first.providerData,
+            next.providerData,
+          ),
+        ),
+      (
+        final AIChatMessageReasoningBlock first,
+        final AIChatMessageReasoningBlock next,
+      ) =>
+        AIChatMessageReasoningBlock(
+          reasoning: first.reasoning + next.reasoning,
+          id: _mergedId(first, next),
+          index: next.index ?? first.index,
+          providerData: mergeProviderData(
+            first.providerData,
+            next.providerData,
+          ),
+        ),
+      (
+        final AIChatMessageMediaBlock first,
+        final AIChatMessageMediaBlock next,
+      ) =>
+        AIChatMessageMediaBlock(
+          data: first.data + next.data,
+          mimeType: next.mimeType ?? first.mimeType,
+          id: _mergedId(first, next),
+          index: next.index ?? first.index,
+          providerData: mergeProviderData(
+            first.providerData,
+            next.providerData,
+          ),
+        ),
+      (final AIChatMessageFileBlock first, final AIChatMessageFileBlock next) =>
+        AIChatMessageFileBlock(
+          uri: next.uri.isNotEmpty ? next.uri : first.uri,
+          name: next.name ?? first.name,
+          mimeType: next.mimeType ?? first.mimeType,
+          id: _mergedId(first, next),
+          index: next.index ?? first.index,
+          providerData: mergeProviderData(
+            first.providerData,
+            next.providerData,
+          ),
+        ),
+      (final AIChatMessageToolCall first, final AIChatMessageToolCall next) =>
+        AIChatMessageToolCall(
+          id: _mergedId(first, next),
+          index: next.index ?? first.index,
+          name: first.name + next.name,
+          argumentsRaw: first.argumentsRaw + next.argumentsRaw,
+          arguments: _mergeToolArguments(first, next),
+          providerData: mergeProviderData(
+            first.providerData,
+            next.providerData,
+          ),
+        ),
+      (
+        final AIChatMessageServerToolCall first,
+        final AIChatMessageServerToolCall next,
+      ) =>
+        AIChatMessageServerToolCall(
+          id: _mergedId(first, next),
+          index: next.index ?? first.index,
+          name: first.name + next.name,
+          argumentsRaw: first.argumentsRaw + next.argumentsRaw,
+          arguments: _mergeServerToolArguments(first, next),
+          providerData: mergeProviderData(
+            first.providerData,
+            next.providerData,
+          ),
+        ),
+      (
+        final AIChatMessageServerToolResult first,
+        final AIChatMessageServerToolResult next,
+      ) =>
+        AIChatMessageServerToolResult(
+          id: _mergedId(first, next),
+          index: next.index ?? first.index,
+          toolCallId: next.toolCallId.isNotEmpty
+              ? next.toolCallId
+              : first.toolCallId,
+          name: next.name ?? first.name,
+          result: _mergeValues(first.result, next.result),
+          providerData: mergeProviderData(
+            first.providerData,
+            next.providerData,
+          ),
+        ),
+      (
+        final AIChatMessageProviderMetadataBlock first,
+        final AIChatMessageProviderMetadataBlock next,
+      ) =>
+        AIChatMessageProviderMetadataBlock(
+          id: _mergedId(first, next),
+          index: next.index ?? first.index,
+          providerData: mergeProviderData(
+            first.providerData,
+            next.providerData,
+          ),
+        ),
+      (
+        final AIChatMessageNonStandardBlock first,
+        final AIChatMessageNonStandardBlock next,
+      ) =>
+        AIChatMessageNonStandardBlock(
+          value: _mergeValues(first.value, next.value),
+          id: _mergedId(first, next),
+          index: next.index ?? first.index,
+          providerData: mergeProviderData(
+            first.providerData,
+            next.providerData,
+          ),
+        ),
+      _ => throw StateError('Unreachable content-block merge'),
+    };
+  }
+}
+
+/// A visible text block.
+@immutable
+final class AIChatMessageTextBlock extends AIChatMessageContentBlock {
+  /// Creates a visible text block.
+  const AIChatMessageTextBlock({
+    required this.text,
+    super.id,
+    super.index,
+    super.providerData,
+  });
+
+  /// The visible text.
+  final String text;
+
+  /// Converts a map to a text block.
+  factory AIChatMessageTextBlock.fromMap(Map<String, dynamic> map) =>
+      AIChatMessageTextBlock(
+        text: map['text'] as String,
+        id: _readId(map),
+        index: map['index'] as int?,
+        providerData: _readProviderData(map),
+      );
+
+  @override
+  String get legacyContent => text;
+
+  @override
+  Map<String, dynamic> toMap() => {
+    'type': 'text',
+    'text': text,
+    ..._metadataMap(this),
+  };
+
+  @override
+  bool operator ==(covariant AIChatMessageTextBlock other) =>
+      identical(this, other) ||
+      text == other.text && _metadataEquals(this, other);
+
+  @override
+  int get hashCode => Object.hash(text, _metadataHash(this));
+}
+
+/// A reasoning or thinking block that is not visible model output.
+@immutable
+final class AIChatMessageReasoningBlock extends AIChatMessageContentBlock {
+  /// Creates a reasoning block.
+  const AIChatMessageReasoningBlock({
+    required this.reasoning,
+    super.id,
+    super.index,
+    super.providerData,
+  });
+
+  /// The reasoning text.
+  final String reasoning;
+
+  /// Converts a map to a reasoning block.
+  factory AIChatMessageReasoningBlock.fromMap(Map<String, dynamic> map) =>
+      AIChatMessageReasoningBlock(
+        reasoning: map['reasoning'] as String,
+        id: _readId(map),
+        index: map['index'] as int?,
+        providerData: _readProviderData(map),
+      );
+
+  @override
+  String get legacyContent => reasoning;
+
+  @override
+  Map<String, dynamic> toMap() => {
+    'type': 'reasoning',
+    'reasoning': reasoning,
+    ..._metadataMap(this),
+  };
+
+  @override
+  bool operator ==(covariant AIChatMessageReasoningBlock other) =>
+      identical(this, other) ||
+      reasoning == other.reasoning && _metadataEquals(this, other);
+
+  @override
+  int get hashCode => Object.hash(reasoning, _metadataHash(this));
+}
+
+/// An inline media block.
+@immutable
+final class AIChatMessageMediaBlock extends AIChatMessageContentBlock {
+  /// Creates an inline media block.
+  const AIChatMessageMediaBlock({
+    required this.data,
+    this.mimeType,
+    super.id,
+    super.index,
+    super.providerData,
+  });
+
+  /// The inline media data.
+  final String data;
+
+  /// The media MIME type, when known.
+  final String? mimeType;
+
+  /// Converts a map to a media block.
+  factory AIChatMessageMediaBlock.fromMap(Map<String, dynamic> map) =>
+      AIChatMessageMediaBlock(
+        data: map['data'] as String,
+        mimeType: map['mimeType'] as String?,
+        id: _readId(map),
+        index: map['index'] as int?,
+        providerData: _readProviderData(map),
+      );
+
+  @override
+  String get legacyContent => data;
+
+  @override
+  Map<String, dynamic> toMap() => {
+    'type': 'media',
+    'data': data,
+    if (mimeType != null) 'mimeType': mimeType,
+    ..._metadataMap(this),
+  };
+
+  @override
+  bool operator ==(covariant AIChatMessageMediaBlock other) =>
+      identical(this, other) ||
+      data == other.data &&
+          mimeType == other.mimeType &&
+          _metadataEquals(this, other);
+
+  @override
+  int get hashCode => Object.hash(data, mimeType, _metadataHash(this));
+}
+
+/// A provider-hosted file block.
+@immutable
+final class AIChatMessageFileBlock extends AIChatMessageContentBlock {
+  /// Creates a file block.
+  const AIChatMessageFileBlock({
+    required this.uri,
+    this.name,
+    this.mimeType,
+    super.id,
+    super.index,
+    super.providerData,
+  });
+
+  /// URI that identifies the file.
+  final String uri;
+
+  /// Optional file name.
+  final String? name;
+
+  /// Optional file MIME type.
+  final String? mimeType;
+
+  /// Converts a map to a file block.
+  factory AIChatMessageFileBlock.fromMap(Map<String, dynamic> map) =>
+      AIChatMessageFileBlock(
+        uri: map['uri'] as String,
+        name: map['name'] as String?,
+        mimeType: map['mimeType'] as String?,
+        id: _readId(map),
+        index: map['index'] as int?,
+        providerData: _readProviderData(map),
+      );
+
+  @override
+  String get legacyContent => uri;
+
+  @override
+  Map<String, dynamic> toMap() => {
+    'type': 'file',
+    'uri': uri,
+    if (name != null) 'name': name,
+    if (mimeType != null) 'mimeType': mimeType,
+    ..._metadataMap(this),
+  };
+
+  @override
+  bool operator ==(covariant AIChatMessageFileBlock other) =>
+      identical(this, other) ||
+      uri == other.uri &&
+          name == other.name &&
+          mimeType == other.mimeType &&
+          _metadataEquals(this, other);
+
+  @override
+  int get hashCode => Object.hash(uri, name, mimeType, _metadataHash(this));
+}
+
+/// {@template ai_chat_message_tool_call}
+/// A client-defined tool that the model wants to call.
+/// {@endtemplate}
+@immutable
+final class AIChatMessageToolCall extends AIChatMessageContentBlock {
+  /// {@macro ai_chat_message_tool_call}
+  const AIChatMessageToolCall({
+    required super.id,
+    required this.name,
+    required this.argumentsRaw,
+    required this.arguments,
+    super.index,
+    super.providerData,
+  });
+
+  /// The name of the tool to call.
+  final String name;
+
+  /// The raw arguments JSON string (needed to parse streaming responses).
+  final String argumentsRaw;
+
+  /// The arguments to pass to the tool in JSON Map format.
+  final Map<String, dynamic> arguments;
+
+  /// Converts a map to a tool-call block.
+  factory AIChatMessageToolCall.fromMap(Map<String, dynamic> map) =>
+      AIChatMessageToolCall(
+        id: _readId(map),
+        name: map['name'] as String,
+        argumentsRaw: map['argumentsRaw'] as String,
+        arguments: _readMap(map['arguments']),
+        index: map['index'] as int?,
+        providerData: _readProviderData(map),
+      );
+
+  @override
+  String get legacyContent => '';
+
+  @override
+  Map<String, dynamic> toMap() => {
+    'type': 'toolCall',
+    'id': id,
+    'name': name,
+    'argumentsRaw': argumentsRaw,
+    'arguments': arguments,
+    'providerData': providerData,
+    if (index != null) 'index': index,
+  };
+
+  @override
+  bool operator ==(covariant AIChatMessageToolCall other) {
+    const deepEquals = DeepCollectionEquality();
+    return identical(this, other) ||
+        id == other.id &&
+            index == other.index &&
+            name == other.name &&
+            argumentsRaw == other.argumentsRaw &&
+            deepEquals.equals(arguments, other.arguments) &&
+            deepEquals.equals(providerData, other.providerData);
+  }
+
+  @override
+  int get hashCode {
+    const deepEquals = DeepCollectionEquality();
+    return Object.hash(
+      id,
+      index,
+      name,
+      argumentsRaw,
+      deepEquals.hash(arguments),
+      deepEquals.hash(providerData),
+    );
+  }
+
+  @override
+  String toString() =>
+      'AIChatMessageToolCall(id: $id, index: $index, name: $name, '
+      'argumentsRaw: $argumentsRaw, arguments: $arguments, '
+      'providerData: $providerData)';
+}
+
+/// A provider-owned server tool invocation.
+@immutable
+final class AIChatMessageServerToolCall extends AIChatMessageContentBlock {
+  /// Creates a server tool-call block.
+  const AIChatMessageServerToolCall({
+    required super.id,
+    required this.name,
+    required this.argumentsRaw,
+    required this.arguments,
+    super.index,
+    super.providerData,
+  });
+
+  /// The server tool name.
+  final String name;
+
+  /// The raw arguments JSON string.
+  final String argumentsRaw;
+
+  /// The parsed arguments.
+  final Map<String, dynamic> arguments;
+
+  /// Converts a map to a server tool-call block.
+  factory AIChatMessageServerToolCall.fromMap(Map<String, dynamic> map) =>
+      AIChatMessageServerToolCall(
+        id: _readId(map),
+        name: map['name'] as String,
+        argumentsRaw: map['argumentsRaw'] as String,
+        arguments: _readMap(map['arguments']),
+        index: map['index'] as int?,
+        providerData: _readProviderData(map),
+      );
+
+  @override
+  String get legacyContent => '';
+
+  @override
+  Map<String, dynamic> toMap() => {
+    'type': 'serverToolCall',
+    'name': name,
+    'argumentsRaw': argumentsRaw,
+    'arguments': arguments,
+    ..._metadataMap(this),
+  };
+
+  @override
+  bool operator ==(covariant AIChatMessageServerToolCall other) {
+    const deepEquals = DeepCollectionEquality();
+    return identical(this, other) ||
+        name == other.name &&
+            argumentsRaw == other.argumentsRaw &&
+            deepEquals.equals(arguments, other.arguments) &&
+            _metadataEquals(this, other);
+  }
+
+  @override
+  int get hashCode {
+    const deepEquals = DeepCollectionEquality();
+    return Object.hash(
+      name,
+      argumentsRaw,
+      deepEquals.hash(arguments),
+      _metadataHash(this),
+    );
+  }
+}
+
+/// The result of a provider-owned server tool invocation.
+@immutable
+final class AIChatMessageServerToolResult extends AIChatMessageContentBlock {
+  /// Creates a server tool-result block.
+  const AIChatMessageServerToolResult({
+    required this.toolCallId,
+    required this.result,
+    this.name,
+    super.id,
+    super.index,
+    super.providerData,
+  });
+
+  /// Identifier of the corresponding server tool call.
+  final String toolCallId;
+
+  /// Optional server tool name.
+  final String? name;
+
+  /// Provider-native result payload.
+  final Object? result;
+
+  /// Converts a map to a server tool-result block.
+  factory AIChatMessageServerToolResult.fromMap(Map<String, dynamic> map) =>
+      AIChatMessageServerToolResult(
+        toolCallId: map['toolCallId'] as String,
+        name: map['name'] as String?,
+        result: map['result'],
+        id: _readId(map),
+        index: map['index'] as int?,
+        providerData: _readProviderData(map),
+      );
+
+  @override
+  String get legacyContent => '';
+
+  @override
+  Map<String, dynamic> toMap() => {
+    'type': 'serverToolResult',
+    'toolCallId': toolCallId,
+    if (name != null) 'name': name,
+    'result': result,
+    ..._metadataMap(this),
+  };
+
+  @override
+  bool operator ==(covariant AIChatMessageServerToolResult other) {
+    const deepEquals = DeepCollectionEquality();
+    return identical(this, other) ||
+        toolCallId == other.toolCallId &&
+            name == other.name &&
+            deepEquals.equals(result, other.result) &&
+            _metadataEquals(this, other);
+  }
+
+  @override
+  int get hashCode {
+    const deepEquals = DeepCollectionEquality();
+    return Object.hash(
+      toolCallId,
+      name,
+      deepEquals.hash(result),
+      _metadataHash(this),
+    );
+  }
+}
+
+/// A metadata-only provider content block.
+@immutable
+final class AIChatMessageProviderMetadataBlock
+    extends AIChatMessageContentBlock {
+  /// Creates a provider metadata block.
+  const AIChatMessageProviderMetadataBlock({
+    super.id,
+    super.index,
+    required super.providerData,
+  });
+
+  /// Converts a map to a provider metadata block.
+  factory AIChatMessageProviderMetadataBlock.fromMap(
+    Map<String, dynamic> map,
+  ) => AIChatMessageProviderMetadataBlock(
+    id: _readId(map),
+    index: map['index'] as int?,
+    providerData: _readProviderData(map),
+  );
+
+  @override
+  String get legacyContent => '';
+
+  @override
+  Map<String, dynamic> toMap() => {
+    'type': 'providerMetadata',
+    ..._metadataMap(this),
+  };
+
+  @override
+  bool operator ==(covariant AIChatMessageProviderMetadataBlock other) =>
+      identical(this, other) || _metadataEquals(this, other);
+
+  @override
+  int get hashCode => _metadataHash(this);
+}
+
+/// A provider payload not represented by a standard content block.
+@immutable
+final class AIChatMessageNonStandardBlock extends AIChatMessageContentBlock {
+  /// Creates a non-standard provider payload block.
+  const AIChatMessageNonStandardBlock({
+    required this.value,
+    super.id,
+    super.index,
+    super.providerData,
+  });
+
+  /// The preserved provider-native payload.
+  final Object? value;
+
+  /// Converts a map to a non-standard block.
+  factory AIChatMessageNonStandardBlock.fromMap(Map<String, dynamic> map) =>
+      AIChatMessageNonStandardBlock(
+        value: map['value'],
+        id: _readId(map),
+        index: map['index'] as int?,
+        providerData: _readProviderData(map),
+      );
+
+  @override
+  String get legacyContent => '';
+
+  @override
+  Map<String, dynamic> toMap() => {
+    'type': 'nonStandard',
+    'value': value,
+    ..._metadataMap(this),
+  };
+
+  @override
+  bool operator ==(covariant AIChatMessageNonStandardBlock other) {
+    const deepEquals = DeepCollectionEquality();
+    return identical(this, other) ||
+        deepEquals.equals(value, other.value) && _metadataEquals(this, other);
+  }
+
+  @override
+  int get hashCode {
+    const deepEquals = DeepCollectionEquality();
+    return Object.hash(deepEquals.hash(value), _metadataHash(this));
+  }
+}
+
+/// Deeply merges namespaced provider data, with later values taking priority.
+Map<String, dynamic> mergeProviderData(
+  final Map<String, dynamic> first,
+  final Map<String, dynamic> second,
+) {
+  final merged = <String, dynamic>{...first};
+  for (final entry in second.entries) {
+    final previous = merged[entry.key];
+    final next = entry.value;
+    merged[entry.key] =
+        previous is Map<String, dynamic> && next is Map<String, dynamic>
+        ? mergeProviderData(previous, next)
+        : next;
+  }
+  return merged;
+}
+
+String _mergedId(
+  final AIChatMessageContentBlock first,
+  final AIChatMessageContentBlock second,
+) => second.id.isNotEmpty ? second.id : first.id;
+
+Object? _mergeValues(final Object? first, final Object? second) =>
+    first is Map<String, dynamic> && second is Map<String, dynamic>
+    ? mergeProviderData(first, second)
+    : second ?? first;
+
+Map<String, dynamic> _mergeToolArguments(
+  final AIChatMessageToolCall first,
+  final AIChatMessageToolCall second,
+) => _mergeArguments(
+  first.arguments,
+  second.arguments,
+  first.argumentsRaw + second.argumentsRaw,
+);
+
+Map<String, dynamic> _mergeServerToolArguments(
+  final AIChatMessageServerToolCall first,
+  final AIChatMessageServerToolCall second,
+) => _mergeArguments(
+  first.arguments,
+  second.arguments,
+  first.argumentsRaw + second.argumentsRaw,
+);
+
+Map<String, dynamic> _mergeArguments(
+  final Map<String, dynamic> first,
+  final Map<String, dynamic> second,
+  final String raw,
+) {
+  final merged = {...first, ...second};
+  if (merged.isNotEmpty || raw.isEmpty) return merged;
+  try {
+    return (jsonDecode(raw) as Map).cast<String, dynamic>();
+  } on Object {
+    return merged;
+  }
+}
+
+String _readId(final Map<String, dynamic> map) => map['id'] as String? ?? '';
+
+Map<String, dynamic> _readMap(final Object? value) =>
+    (value as Map?)?.cast<String, dynamic>() ?? const {};
+
+Map<String, dynamic> _readProviderData(final Map<String, dynamic> map) =>
+    _readMap(map['providerData']);
+
+Map<String, dynamic> _metadataMap(final AIChatMessageContentBlock block) => {
+  if (block.id.isNotEmpty) 'id': block.id,
+  if (block.index != null) 'index': block.index,
+  if (block.providerData.isNotEmpty) 'providerData': block.providerData,
+};
+
+bool _metadataEquals(
+  final AIChatMessageContentBlock first,
+  final AIChatMessageContentBlock second,
+) {
+  const deepEquals = DeepCollectionEquality();
+  return first.id == second.id &&
+      first.index == second.index &&
+      deepEquals.equals(first.providerData, second.providerData);
+}
+
+int _metadataHash(final AIChatMessageContentBlock block) {
+  const deepEquals = DeepCollectionEquality();
+  return Object.hash(
+    block.id,
+    block.index,
+    deepEquals.hash(block.providerData),
+  );
+}

--- a/packages/langchain_core/lib/src/chat_models/types.dart
+++ b/packages/langchain_core/lib/src/chat_models/types.dart
@@ -3,6 +3,9 @@ import 'package:meta/meta.dart';
 
 import '../language_models/language_models.dart';
 import '../tools/base.dart';
+import 'content_blocks.dart';
+
+export 'content_blocks.dart';
 
 /// {@template chat_model_options}
 /// Generation options to pass into the Chat Model.
@@ -317,16 +320,41 @@ HumanChatMessage{
 @immutable
 class AIChatMessage extends ChatMessage {
   /// {@macro ai_chat_message}
-  const AIChatMessage({required this.content, this.toolCalls = const []});
+  const AIChatMessage({
+    required String content,
+    List<AIChatMessageToolCall> toolCalls = const [],
+  }) : _legacyContent = content,
+       _legacyToolCalls = toolCalls,
+       _contentBlocks = null;
+
+  /// Creates an AI message from its canonical ordered content blocks.
+  const AIChatMessage.withBlocks({
+    required List<AIChatMessageContentBlock> contentBlocks,
+    String? legacyContent,
+  }) : _contentBlocks = contentBlocks,
+       _legacyContent = legacyContent,
+       _legacyToolCalls = const [];
 
   /// Converts a map to a [AIChatMessage].
-  factory AIChatMessage.fromMap(Map<String, dynamic> map) => AIChatMessage(
-    content: map['content'] as String,
-    toolCalls: (map['toolCalls'] as List<dynamic>)
-        .map((i) => i as Map<String, dynamic>)
-        .map(AIChatMessageToolCall.fromMap)
-        .toList(growable: false),
-  );
+  factory AIChatMessage.fromMap(Map<String, dynamic> map) {
+    final blocks = map['contentBlocks'] as List<dynamic>?;
+    if (blocks != null) {
+      return AIChatMessage.withBlocks(
+        contentBlocks: blocks
+            .map((item) => (item as Map).cast<String, dynamic>())
+            .map(AIChatMessageContentBlock.fromMap)
+            .toList(growable: false),
+        legacyContent: map['content'] as String?,
+      );
+    }
+    return AIChatMessage(
+      content: map['content'] as String? ?? '',
+      toolCalls: (map['toolCalls'] as List<dynamic>? ?? const [])
+          .map((item) => (item as Map).cast<String, dynamic>())
+          .map(AIChatMessageToolCall.fromMap)
+          .toList(growable: false),
+    );
+  }
 
   /// Converts this ChatMessage to a map along with a type hint for deserialization.
   @override
@@ -334,33 +362,78 @@ class AIChatMessage extends ChatMessage {
     ...super.toMap(),
     'content': content,
     'toolCalls': toolCalls.map((t) => t.toMap()).toList(growable: false),
+    'contentBlocks': contentBlocks
+        .map((block) => block.toMap())
+        .toList(growable: false),
     'type': 'ai',
   };
 
-  /// The content of the message.
-  final String content;
+  final String? _legacyContent;
+  final List<AIChatMessageToolCall> _legacyToolCalls;
+  final List<AIChatMessageContentBlock>? _contentBlocks;
+
+  /// The legacy string projection of the message.
+  String get content =>
+      _legacyContent ?? contentBlocks.map((b) => b.legacyContent).join();
+
+  /// The canonical ordered content blocks.
+  List<AIChatMessageContentBlock> get contentBlocks =>
+      _contentBlocks ??
+      [
+        if ((_legacyContent ?? '').isNotEmpty)
+          AIChatMessageTextBlock(text: _legacyContent!),
+        ..._legacyToolCalls,
+      ];
 
   /// The list of tool that the model wants to call.
   /// If the model does not want to call any tool, this list will be empty.
-  final List<AIChatMessageToolCall> toolCalls;
+  List<AIChatMessageToolCall> get toolCalls =>
+      _contentBlocks?.whereType<AIChatMessageToolCall>().toList(
+        growable: false,
+      ) ??
+      _legacyToolCalls;
 
   /// Default prefix for [AIChatMessage].
   static const defaultPrefix = 'AI';
 
   @override
   bool operator ==(covariant final AIChatMessage other) {
-    final listEquals = const DeepCollectionEquality().equals;
+    const listEquals = DeepCollectionEquality();
     return identical(this, other) ||
-        content == other.content && listEquals(toolCalls, other.toolCalls);
+        content == other.content &&
+            listEquals.equals(contentBlocks, other.contentBlocks);
   }
 
   @override
-  int get hashCode => content.hashCode ^ toolCalls.hashCode;
+  int get hashCode {
+    const listEquals = DeepCollectionEquality();
+    return Object.hash(content, listEquals.hash(contentBlocks));
+  }
 
   @override
   AIChatMessage concat(final ChatMessage other) {
     if (other is! AIChatMessage) {
       return this;
+    }
+
+    if (_contentBlocks != null || other._contentBlocks != null) {
+      final mergedBlocks = [...contentBlocks];
+      for (final otherBlock in other.contentBlocks) {
+        final matchingIndex = mergedBlocks.indexWhere(
+          (block) => block.canMerge(otherBlock),
+        );
+        if (matchingIndex == -1) {
+          mergedBlocks.add(otherBlock);
+        } else {
+          mergedBlocks[matchingIndex] = mergedBlocks[matchingIndex].concat(
+            otherBlock,
+          );
+        }
+      }
+      return AIChatMessage.withBlocks(
+        contentBlocks: mergedBlocks,
+        legacyContent: content + other.content,
+      );
     }
 
     final toolCalls = <AIChatMessageToolCall>[];
@@ -394,7 +467,7 @@ class AIChatMessage extends ChatMessage {
               ...?thisToolCall?.arguments,
               ...?otherToolCall?.arguments,
             },
-            providerData: _mergeProviderData(
+            providerData: mergeProviderData(
               thisToolCall?.providerData ?? const {},
               otherToolCall?.providerData ?? const {},
             ),
@@ -417,121 +490,6 @@ AIChatMessage{
   toolCalls: $toolCalls,
 }''';
   }
-}
-
-/// {@template ai_chat_message_tool_call}
-/// A tool that the model wants to call.
-/// {@endtemplate}
-@immutable
-class AIChatMessageToolCall {
-  /// {@macro ai_chat_message_tool_call}
-  const AIChatMessageToolCall({
-    required this.id,
-    required this.name,
-    required this.argumentsRaw,
-    required this.arguments,
-    this.providerData = const {},
-  });
-
-  /// The id of the tool to call.
-  ///
-  /// This is used to match up the tool results later.
-  final String id;
-
-  /// The name of the tool to call.
-  final String name;
-
-  /// The raw arguments JSON string (needed to parse streaming responses).
-  final String argumentsRaw;
-
-  /// The arguments to pass to the tool in JSON Map format.
-  ///
-  /// Note that the model does not always generate a valid JSON, in that case,
-  /// [arguments] will be empty but you can still see the raw response in
-  /// [argumentsRaw].
-  ///
-  /// The model may also hallucinate parameters not defined by your tool schema.
-  /// Validate the arguments in your code before calling your tool.
-  final Map<String, dynamic> arguments;
-
-  /// Provider-specific data attached to this tool call.
-  ///
-  /// Data must be nested under a provider namespace to avoid collisions. For
-  /// example, Google's `thoughtSignature` is stored under the `google` key so
-  /// it can survive a tool-call round trip.
-  final Map<String, dynamic> providerData;
-
-  /// Converts the [AIChatMessageToolCall] to a [Map].
-  Map<String, dynamic> toMap() {
-    return {
-      'id': id,
-      'name': name,
-      'argumentsRaw': argumentsRaw,
-      'arguments': arguments,
-      'providerData': providerData,
-    };
-  }
-
-  /// Converts a map to a [AIChatMessageToolCall].
-  factory AIChatMessageToolCall.fromMap(Map<String, dynamic> map) =>
-      AIChatMessageToolCall(
-        id: map['id'] as String,
-        name: map['name'] as String,
-        argumentsRaw: map['argumentsRaw'] as String,
-        arguments: (map['arguments'] as Map<String, dynamic>?) ?? {},
-        providerData: (map['providerData'] as Map<String, dynamic>?) ?? {},
-      );
-
-  @override
-  bool operator ==(covariant final AIChatMessageToolCall other) {
-    final mapEquals = const DeepCollectionEquality().equals;
-    return identical(this, other) ||
-        id == other.id &&
-            name == other.name &&
-            argumentsRaw == other.argumentsRaw &&
-            mapEquals(arguments, other.arguments) &&
-            mapEquals(providerData, other.providerData);
-  }
-
-  @override
-  int get hashCode {
-    const deepCollectionEquality = DeepCollectionEquality();
-    return Object.hash(
-      id,
-      name,
-      argumentsRaw,
-      deepCollectionEquality.hash(arguments),
-      deepCollectionEquality.hash(providerData),
-    );
-  }
-
-  @override
-  String toString() {
-    return '''
-AIChatMessageToolCall{
-  id: $id,
-  name: $name,
-  argumentsRaw: $argumentsRaw,
-  arguments: $arguments,
-  providerData: $providerData,
-}''';
-  }
-}
-
-Map<String, dynamic> _mergeProviderData(
-  final Map<String, dynamic> first,
-  final Map<String, dynamic> second,
-) {
-  final merged = <String, dynamic>{...first};
-  for (final entry in second.entries) {
-    final previous = merged[entry.key];
-    final next = entry.value;
-    merged[entry.key] =
-        previous is Map<String, dynamic> && next is Map<String, dynamic>
-        ? _mergeProviderData(previous, next)
-        : next;
-  }
-  return merged;
 }
 
 /// {@template tool_chat_message}

--- a/packages/langchain_core/test/chat_models/ai_chat_message_content_blocks_test.dart
+++ b/packages/langchain_core/test/chat_models/ai_chat_message_content_blocks_test.dart
@@ -152,5 +152,20 @@ void main() {
 
       expect(first.concat(second).contentBlocks, hasLength(2));
     });
+
+    test('does not let a matching index override different stable ids', () {
+      const first = AIChatMessage.withBlocks(
+        contentBlocks: [
+          AIChatMessageTextBlock(text: 'one', id: 'block-1', index: 0),
+        ],
+      );
+      const second = AIChatMessage.withBlocks(
+        contentBlocks: [
+          AIChatMessageTextBlock(text: 'two', id: 'block-2', index: 0),
+        ],
+      );
+
+      expect(first.concat(second).contentBlocks, hasLength(2));
+    });
   });
 }

--- a/packages/langchain_core/test/chat_models/ai_chat_message_content_blocks_test.dart
+++ b/packages/langchain_core/test/chat_models/ai_chat_message_content_blocks_test.dart
@@ -34,6 +34,7 @@ void main() {
           AIChatMessageReasoningBlock(
             reasoning: 'hidden',
             id: 'reasoning-1',
+            isMergeable: false,
             providerData: {
               'anthropic': {'signature': 'opaque'},
             },
@@ -55,6 +56,10 @@ void main() {
       expect(map['content'], 'legacy projection');
       expect(map['toolCalls'], hasLength(1));
       expect(map['contentBlocks'], hasLength(3));
+      expect(
+        (map['contentBlocks'] as List).first,
+        containsPair('isMergeable', false),
+      );
       expect(restored, message);
       expect(restored.content, 'legacy projection');
     });
@@ -166,6 +171,36 @@ void main() {
       );
 
       expect(first.concat(second).contentBlocks, hasLength(2));
+    });
+
+    test('retains completed provider part boundaries', () {
+      const first = AIChatMessage.withBlocks(
+        contentBlocks: [
+          AIChatMessageTextBlock(text: 'answer', id: 'part-0', index: 0),
+        ],
+      );
+      const signedBoundary = AIChatMessage.withBlocks(
+        contentBlocks: [
+          AIChatMessageTextBlock(
+            text: '',
+            id: 'part-0',
+            index: 0,
+            isMergeable: false,
+          ),
+        ],
+      );
+
+      final result = first.concat(signedBoundary);
+
+      expect(result.contentBlocks, hasLength(2));
+      expect(
+        result.contentBlocks.last,
+        isA<AIChatMessageTextBlock>().having(
+          (block) => block.isMergeable,
+          'isMergeable',
+          isFalse,
+        ),
+      );
     });
   });
 }

--- a/packages/langchain_core/test/chat_models/ai_chat_message_content_blocks_test.dart
+++ b/packages/langchain_core/test/chat_models/ai_chat_message_content_blocks_test.dart
@@ -1,0 +1,156 @@
+import 'package:langchain_core/chat_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AIChatMessage ordered content blocks', () {
+    test('preserves order and derives tool calls', () {
+      const firstCall = AIChatMessageToolCall(
+        id: 'call-1',
+        name: 'weather',
+        argumentsRaw: '{}',
+        arguments: {},
+      );
+      const message = AIChatMessage.withBlocks(
+        contentBlocks: [
+          AIChatMessageReasoningBlock(reasoning: 'check', index: 0),
+          firstCall,
+          AIChatMessageTextBlock(text: 'sunny', index: 2),
+        ],
+      );
+
+      expect(message.contentBlocks, [
+        isA<AIChatMessageReasoningBlock>(),
+        same(firstCall),
+        isA<AIChatMessageTextBlock>(),
+      ]);
+      expect(message.toolCalls, [firstCall]);
+      expect(message.content, 'checksunny');
+    });
+
+    test('round-trips canonical and legacy serialization', () {
+      const message = AIChatMessage.withBlocks(
+        legacyContent: 'legacy projection',
+        contentBlocks: [
+          AIChatMessageReasoningBlock(
+            reasoning: 'hidden',
+            id: 'reasoning-1',
+            providerData: {
+              'anthropic': {'signature': 'opaque'},
+            },
+          ),
+          AIChatMessageTextBlock(text: 'visible', id: 'text-1'),
+          AIChatMessageToolCall(
+            id: 'call-1',
+            index: 2,
+            name: 'weather',
+            argumentsRaw: '{"city":"Madrid"}',
+            arguments: {'city': 'Madrid'},
+          ),
+        ],
+      );
+
+      final map = message.toMap();
+      final restored = AIChatMessage.fromMap(map);
+
+      expect(map['content'], 'legacy projection');
+      expect(map['toolCalls'], hasLength(1));
+      expect(map['contentBlocks'], hasLength(3));
+      expect(restored, message);
+      expect(restored.content, 'legacy projection');
+    });
+
+    test('reads legacy maps without tool calls', () {
+      final message = AIChatMessage.fromMap(const {
+        'type': 'ai',
+        'content': 'hello',
+      });
+
+      expect(message.content, 'hello');
+      expect(message.contentBlocks.single, isA<AIChatMessageTextBlock>());
+      expect(message.toolCalls, isEmpty);
+    });
+  });
+
+  group('AIChatMessage block streaming', () {
+    test('merges only matching stable stream identities', () {
+      const first = AIChatMessage.withBlocks(
+        contentBlocks: [
+          AIChatMessageTextBlock(text: 'hel', index: 0),
+          AIChatMessageReasoningBlock(reasoning: 'rea', index: 1),
+        ],
+      );
+      const second = AIChatMessage.withBlocks(
+        contentBlocks: [
+          AIChatMessageTextBlock(text: 'lo', index: 0),
+          AIChatMessageReasoningBlock(reasoning: 'son', index: 1),
+        ],
+      );
+
+      final result = first.concat(second);
+
+      expect((result.contentBlocks[0] as AIChatMessageTextBlock).text, 'hello');
+      expect(
+        (result.contentBlocks[1] as AIChatMessageReasoningBlock).reasoning,
+        'reason',
+      );
+    });
+
+    test('keeps parallel same-name calls separate by stream index', () {
+      const starts = AIChatMessage.withBlocks(
+        contentBlocks: [
+          AIChatMessageToolCall(
+            id: '',
+            index: 0,
+            name: 'weather',
+            argumentsRaw: '{"city":',
+            arguments: {},
+          ),
+          AIChatMessageToolCall(
+            id: '',
+            index: 1,
+            name: 'weather',
+            argumentsRaw: '{"city":',
+            arguments: {},
+          ),
+        ],
+      );
+      const finishes = AIChatMessage.withBlocks(
+        contentBlocks: [
+          AIChatMessageToolCall(
+            id: '',
+            index: 0,
+            name: '',
+            argumentsRaw: '"Madrid"}',
+            arguments: {'city': 'Madrid'},
+          ),
+          AIChatMessageToolCall(
+            id: '',
+            index: 1,
+            name: '',
+            argumentsRaw: '"Paris"}',
+            arguments: {'city': 'Paris'},
+          ),
+        ],
+      );
+
+      final calls = starts.concat(finishes).toolCalls;
+
+      expect(calls, hasLength(2));
+      expect(calls[0].arguments, {'city': 'Madrid'});
+      expect(calls[1].arguments, {'city': 'Paris'});
+      expect(calls[0].argumentsRaw, '{"city":"Madrid"}');
+      expect(calls[1].argumentsRaw, '{"city":"Paris"}');
+    });
+
+    test('does not merge blocks without an id or index', () {
+      const first = AIChatMessage.withBlocks(
+        contentBlocks: [AIChatMessageTextBlock(text: 'one')],
+      );
+      const second = AIChatMessage.withBlocks(
+        contentBlocks: [AIChatMessageTextBlock(text: 'two')],
+      );
+
+      expect(first.concat(second).contentBlocks, hasLength(2));
+    });
+  });
+}

--- a/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
@@ -6,6 +6,7 @@ import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/tools.dart';
 
+import '../google_parts_mapper.dart';
 import 'types.dart';
 
 extension ChatMessagesMapper on List<ChatMessage> {
@@ -97,24 +98,7 @@ extension ChatMessagesMapper on List<ChatMessage> {
   }
 
   g.Content _mapAIChatMessage(final AIChatMessage msg) {
-    final contentParts = [
-      if (msg.content.isNotEmpty) g.TextPart(msg.content),
-      if (msg.toolCalls.isNotEmpty)
-        ...msg.toolCalls.map(
-          (final call) => g.FunctionCallPart(
-            g.FunctionCall(name: call.name, args: call.arguments),
-            // Thinking models require the thought signature captured in
-            // toChatResult to be echoed back with the function call.
-            thoughtSignature: switch (call.providerData['google']) {
-              {'thoughtSignature': final String signature} => base64Decode(
-                signature,
-              ),
-              _ => null,
-            },
-          ),
-        ),
-    ];
-    return g.Content(role: 'model', parts: contentParts);
+    return g.Content(role: 'model', parts: aiMessageToGoogleParts(msg));
   }
 
   g.FunctionResponsePart _toolMsgToFunctionResponsePart(
@@ -145,41 +129,14 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
 
     return ChatResult(
       id: id,
-      output: AIChatMessage(
-        content:
-            candidate.content?.parts
-                .map(
-                  (p) => switch (p) {
-                    final g.TextPart p => p.text,
-                    final g.InlineDataPart p => p.inlineData.data,
-                    final g.FileDataPart p => p.fileData.fileUri,
-                    g.Part() => '',
-                  },
-                )
-                .nonNulls
-                .join('\n') ??
-            '',
-        toolCalls:
-            candidate.content?.parts
-                .whereType<g.FunctionCallPart>()
-                .map(
-                  (final part) => AIChatMessageToolCall(
-                    id: part.functionCall.name,
-                    name: part.functionCall.name,
-                    argumentsRaw: jsonEncode(part.functionCall.args ?? {}),
-                    arguments: part.functionCall.args ?? {},
-                    providerData: {
-                      if (part.thoughtSignature != null)
-                        'google': {
-                          'thoughtSignature': base64Encode(
-                            part.thoughtSignature!,
-                          ),
-                        },
-                    },
-                  ),
-                )
-                .toList(growable: false) ??
-            [],
+      output: AIChatMessage.withBlocks(
+        contentBlocks: googlePartsToContentBlocks(
+          candidate.content?.parts ?? const [],
+          responseId: id,
+        ),
+        legacyContent: googlePartsToLegacyContent(
+          candidate.content?.parts ?? const [],
+        ),
       ),
       finishReason: _mapFinishReason(candidate.finishReason),
       metadata: {

--- a/packages/langchain_google/lib/src/chat_models/google_parts_mapper.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_parts_mapper.dart
@@ -39,18 +39,22 @@ AIChatMessageContentBlock _googlePartToContentBlock(
   required final int index,
 }) {
   final providerData = _googleProviderData(part);
+  final isMergeable =
+      part is g.FunctionCallPart || part.thoughtSignature == null;
   return switch (part) {
     final g.TextPart text when text.thought ?? false =>
       AIChatMessageReasoningBlock(
         reasoning: text.text,
         id: fallbackId,
         index: index,
+        isMergeable: isMergeable,
         providerData: providerData,
       ),
     final g.TextPart text => AIChatMessageTextBlock(
       text: text.text,
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
     final g.InlineDataPart media => AIChatMessageMediaBlock(
@@ -58,6 +62,7 @@ AIChatMessageContentBlock _googlePartToContentBlock(
       mimeType: media.inlineData.mimeType,
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
     final g.FileDataPart file => AIChatMessageFileBlock(
@@ -65,11 +70,13 @@ AIChatMessageContentBlock _googlePartToContentBlock(
       mimeType: file.fileData.mimeType,
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
     final g.FunctionCallPart call => AIChatMessageToolCall(
       id: call.functionCall.id ?? fallbackId,
       index: index,
+      isMergeable: isMergeable,
       name: call.functionCall.name,
       argumentsRaw: jsonEncode(call.functionCall.args ?? const {}),
       arguments: call.functionCall.args ?? const {},
@@ -78,6 +85,7 @@ AIChatMessageContentBlock _googlePartToContentBlock(
     final g.FunctionResponsePart result => AIChatMessageServerToolResult(
       id: result.functionResponse.id ?? fallbackId,
       index: index,
+      isMergeable: isMergeable,
       toolCallId: result.functionResponse.id ?? fallbackId,
       name: result.functionResponse.name,
       result: result.functionResponse.response,
@@ -86,6 +94,7 @@ AIChatMessageContentBlock _googlePartToContentBlock(
     final g.ExecutableCodePart code => AIChatMessageServerToolCall(
       id: code.executableCode.id ?? fallbackId,
       index: index,
+      isMergeable: isMergeable,
       name: 'codeExecution',
       argumentsRaw: jsonEncode(code.executableCode.toJson()),
       arguments: code.executableCode.toJson(),
@@ -94,6 +103,7 @@ AIChatMessageContentBlock _googlePartToContentBlock(
     final g.CodeExecutionResultPart result => AIChatMessageServerToolResult(
       id: result.codeExecutionResult.id ?? fallbackId,
       index: index,
+      isMergeable: isMergeable,
       toolCallId: result.codeExecutionResult.id ?? fallbackId,
       name: 'codeExecution',
       result: result.codeExecutionResult.toJson(),
@@ -102,6 +112,7 @@ AIChatMessageContentBlock _googlePartToContentBlock(
     final g.ToolCallPart call => AIChatMessageServerToolCall(
       id: call.toolCall.id ?? fallbackId,
       index: index,
+      isMergeable: isMergeable,
       name: call.toolCall.toolName ?? call.toolCall.toolType.name,
       argumentsRaw: jsonEncode(call.toolCall.args ?? const {}),
       arguments: call.toolCall.args ?? const {},
@@ -110,6 +121,7 @@ AIChatMessageContentBlock _googlePartToContentBlock(
     final g.ToolResponsePart result => AIChatMessageServerToolResult(
       id: result.toolResponse.id ?? fallbackId,
       index: index,
+      isMergeable: isMergeable,
       toolCallId: result.toolResponse.id ?? fallbackId,
       result: result.toolResponse.response,
       providerData: providerData,
@@ -117,12 +129,14 @@ AIChatMessageContentBlock _googlePartToContentBlock(
     g.MetadataPart() => AIChatMessageProviderMetadataBlock(
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
     final g.UnknownPart unknown => AIChatMessageNonStandardBlock(
       value: unknown.rawJson,
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
     // Deprecated metadata-only Parts are accepted for source compatibility.
@@ -132,6 +146,7 @@ AIChatMessageContentBlock _googlePartToContentBlock(
     g.PartMetadataPart() => AIChatMessageProviderMetadataBlock(
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
   };

--- a/packages/langchain_google/lib/src/chat_models/google_parts_mapper.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_parts_mapper.dart
@@ -1,0 +1,227 @@
+// ignore_for_file: deprecated_member_use, public_member_api_docs
+import 'dart:convert';
+
+import 'package:googleai_dart/googleai_dart.dart' as g;
+import 'package:langchain_core/chat_models.dart';
+
+List<AIChatMessageContentBlock> googlePartsToContentBlocks(
+  final List<g.Part> parts, {
+  required final String responseId,
+  final int candidateIndex = 0,
+}) => [
+  for (final (partIndex, part) in parts.indexed)
+    _googlePartToContentBlock(
+      part,
+      fallbackId: 'google:$responseId:$candidateIndex:$partIndex',
+      index: partIndex,
+    ),
+];
+
+String googlePartsToLegacyContent(final List<g.Part> parts) => parts
+    .map(
+      (part) => switch (part) {
+        final g.TextPart part => part.text,
+        final g.InlineDataPart part => part.inlineData.data,
+        final g.FileDataPart part => part.fileData.fileUri,
+        g.Part() => '',
+      },
+    )
+    .join('\n');
+
+List<g.Part> aiMessageToGoogleParts(final AIChatMessage message) => message
+    .contentBlocks
+    .map(_contentBlockToGooglePart)
+    .toList(growable: false);
+
+AIChatMessageContentBlock _googlePartToContentBlock(
+  final g.Part part, {
+  required final String fallbackId,
+  required final int index,
+}) {
+  final providerData = _googleProviderData(part);
+  return switch (part) {
+    final g.TextPart text when text.thought ?? false =>
+      AIChatMessageReasoningBlock(
+        reasoning: text.text,
+        id: fallbackId,
+        index: index,
+        providerData: providerData,
+      ),
+    final g.TextPart text => AIChatMessageTextBlock(
+      text: text.text,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    final g.InlineDataPart media => AIChatMessageMediaBlock(
+      data: media.inlineData.data,
+      mimeType: media.inlineData.mimeType,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    final g.FileDataPart file => AIChatMessageFileBlock(
+      uri: file.fileData.fileUri,
+      mimeType: file.fileData.mimeType,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    final g.FunctionCallPart call => AIChatMessageToolCall(
+      id: call.functionCall.id ?? fallbackId,
+      index: index,
+      name: call.functionCall.name,
+      argumentsRaw: jsonEncode(call.functionCall.args ?? const {}),
+      arguments: call.functionCall.args ?? const {},
+      providerData: providerData,
+    ),
+    final g.FunctionResponsePart result => AIChatMessageServerToolResult(
+      id: result.functionResponse.id ?? fallbackId,
+      index: index,
+      toolCallId: result.functionResponse.id ?? fallbackId,
+      name: result.functionResponse.name,
+      result: result.functionResponse.response,
+      providerData: providerData,
+    ),
+    final g.ExecutableCodePart code => AIChatMessageServerToolCall(
+      id: code.executableCode.id ?? fallbackId,
+      index: index,
+      name: 'codeExecution',
+      argumentsRaw: jsonEncode(code.executableCode.toJson()),
+      arguments: code.executableCode.toJson(),
+      providerData: providerData,
+    ),
+    final g.CodeExecutionResultPart result => AIChatMessageServerToolResult(
+      id: result.codeExecutionResult.id ?? fallbackId,
+      index: index,
+      toolCallId: result.codeExecutionResult.id ?? fallbackId,
+      name: 'codeExecution',
+      result: result.codeExecutionResult.toJson(),
+      providerData: providerData,
+    ),
+    final g.ToolCallPart call => AIChatMessageServerToolCall(
+      id: call.toolCall.id ?? fallbackId,
+      index: index,
+      name: call.toolCall.toolName ?? call.toolCall.toolType.name,
+      argumentsRaw: jsonEncode(call.toolCall.args ?? const {}),
+      arguments: call.toolCall.args ?? const {},
+      providerData: providerData,
+    ),
+    final g.ToolResponsePart result => AIChatMessageServerToolResult(
+      id: result.toolResponse.id ?? fallbackId,
+      index: index,
+      toolCallId: result.toolResponse.id ?? fallbackId,
+      result: result.toolResponse.response,
+      providerData: providerData,
+    ),
+    g.MetadataPart() => AIChatMessageProviderMetadataBlock(
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    final g.UnknownPart unknown => AIChatMessageNonStandardBlock(
+      value: unknown.rawJson,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    // Deprecated metadata-only Parts are accepted for source compatibility.
+    g.VideoMetadataPart() ||
+    g.ThoughtPart() ||
+    g.ThoughtSignaturePart() ||
+    g.PartMetadataPart() => AIChatMessageProviderMetadataBlock(
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+  };
+}
+
+Map<String, dynamic> _googleProviderData(final g.Part part) => {
+  'google': {
+    'part': part.toJson(),
+    if (part.thoughtSignature != null)
+      'thoughtSignature': base64Encode(part.thoughtSignature!),
+  },
+};
+
+g.Part _contentBlockToGooglePart(final AIChatMessageContentBlock block) {
+  final rawPart = switch (block.providerData['google']) {
+    {'part': final Map<Object?, Object?> part} => part.cast<String, dynamic>(),
+    _ => null,
+  };
+  return switch (block) {
+    final AIChatMessageTextBlock text => g.Part.fromJson({
+      ...?rawPart,
+      'text': text.text,
+    }),
+    final AIChatMessageReasoningBlock reasoning => g.Part.fromJson({
+      ...?rawPart,
+      'text': reasoning.reasoning,
+      'thought': true,
+    }),
+    final AIChatMessageMediaBlock media => g.Part.fromJson({
+      ...?rawPart,
+      'inlineData': {
+        ...?_nestedMap(rawPart?['inlineData']),
+        if (media.mimeType != null) 'mimeType': media.mimeType,
+        'data': media.data,
+      },
+    }),
+    final AIChatMessageFileBlock file => g.Part.fromJson({
+      ...?rawPart,
+      'fileData': {
+        ...?_nestedMap(rawPart?['fileData']),
+        if (file.mimeType != null) 'mimeType': file.mimeType,
+        'fileUri': file.uri,
+      },
+    }),
+    final AIChatMessageToolCall call => g.Part.fromJson({
+      ...?rawPart,
+      'functionCall': {
+        ...?_nestedMap(rawPart?['functionCall']),
+        if (call.id.isNotEmpty) 'id': call.id,
+        'name': call.name,
+        'args': call.arguments,
+      },
+      if (rawPart == null) ..._legacyThoughtSignature(call.providerData),
+    }),
+    AIChatMessageServerToolCall() ||
+    AIChatMessageServerToolResult() ||
+    AIChatMessageProviderMetadataBlock() => _rawGooglePart(block, rawPart),
+    final AIChatMessageNonStandardBlock nonStandard =>
+      rawPart != null
+          ? g.Part.fromJson(rawPart)
+          : switch (nonStandard.value) {
+              final Map<Object?, Object?> value => g.Part.fromJson(
+                value.cast<String, dynamic>(),
+              ),
+              _ => g.UnknownPart({'value': nonStandard.value}),
+            },
+  };
+}
+
+g.Part _rawGooglePart(
+  final AIChatMessageContentBlock block,
+  final Map<String, dynamic>? rawPart,
+) {
+  if (rawPart == null) {
+    throw UnsupportedError(
+      '${block.runtimeType} can only be replayed to Google when it contains '
+      'providerData["google"]["part"]',
+    );
+  }
+  return g.Part.fromJson(rawPart);
+}
+
+Map<String, dynamic>? _nestedMap(final Object? value) =>
+    value is Map ? value.cast<String, dynamic>() : null;
+
+Map<String, dynamic> _legacyThoughtSignature(
+  final Map<String, dynamic> providerData,
+) => switch (providerData['google']) {
+  {'thoughtSignature': final String signature} => {
+    'thoughtSignature': signature,
+  },
+  _ => const {},
+};

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
@@ -6,6 +6,7 @@ import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/tools.dart';
 
+import '../google_parts_mapper.dart';
 import 'types.dart';
 
 extension ChatMessagesMapper on List<ChatMessage> {
@@ -97,24 +98,7 @@ extension ChatMessagesMapper on List<ChatMessage> {
   }
 
   g.Content _mapAIChatMessage(final AIChatMessage msg) {
-    final contentParts = [
-      if (msg.content.isNotEmpty) g.TextPart(msg.content),
-      if (msg.toolCalls.isNotEmpty)
-        ...msg.toolCalls.map(
-          (final call) => g.FunctionCallPart(
-            g.FunctionCall(name: call.name, args: call.arguments),
-            // Thinking models require the thought signature captured in
-            // toChatResult to be echoed back with the function call.
-            thoughtSignature: switch (call.providerData['google']) {
-              {'thoughtSignature': final String signature} => base64Decode(
-                signature,
-              ),
-              _ => null,
-            },
-          ),
-        ),
-    ];
-    return g.Content(role: 'model', parts: contentParts);
+    return g.Content(role: 'model', parts: aiMessageToGoogleParts(msg));
   }
 
   g.FunctionResponsePart _toolMsgToFunctionResponsePart(
@@ -145,41 +129,14 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
 
     return ChatResult(
       id: id,
-      output: AIChatMessage(
-        content:
-            candidate.content?.parts
-                .map(
-                  (p) => switch (p) {
-                    final g.TextPart p => p.text,
-                    final g.InlineDataPart p => p.inlineData.data,
-                    final g.FileDataPart p => p.fileData.fileUri,
-                    g.Part() => '',
-                  },
-                )
-                .nonNulls
-                .join('\n') ??
-            '',
-        toolCalls:
-            candidate.content?.parts
-                .whereType<g.FunctionCallPart>()
-                .map(
-                  (final part) => AIChatMessageToolCall(
-                    id: part.functionCall.name,
-                    name: part.functionCall.name,
-                    argumentsRaw: jsonEncode(part.functionCall.args ?? {}),
-                    arguments: part.functionCall.args ?? {},
-                    providerData: {
-                      if (part.thoughtSignature != null)
-                        'google': {
-                          'thoughtSignature': base64Encode(
-                            part.thoughtSignature!,
-                          ),
-                        },
-                    },
-                  ),
-                )
-                .toList(growable: false) ??
-            [],
+      output: AIChatMessage.withBlocks(
+        contentBlocks: googlePartsToContentBlocks(
+          candidate.content?.parts ?? const [],
+          responseId: id,
+        ),
+        legacyContent: googlePartsToLegacyContent(
+          candidate.content?.parts ?? const [],
+        ),
       ),
       finishReason: _mapFinishReason(candidate.finishReason),
       metadata: {

--- a/packages/langchain_google/test/chat_models/google_ai/chat_google_generative_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/chat_google_generative_ai_test.dart
@@ -6,11 +6,13 @@ library; // Uses dart:io
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:googleai_dart/googleai_dart.dart' as g;
 import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_core/tools.dart';
 import 'package:langchain_google/langchain_google.dart';
+import 'package:langchain_google/src/chat_models/google_ai/mappers.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -157,6 +159,58 @@ void main() {
       expect(count, greaterThan(1));
       expect(content, contains('123456789'));
     });
+
+    test(
+      'Streaming preserves thought-signature part boundaries',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        final chunks = await chatModel
+            .stream(
+              PromptValue.string(
+                'Solve this carefully, then answer with only the final integer: '
+                'A shop discounts a 240 euro item by 15%, then applies 21% VAT. '
+                'What is the final price rounded to the nearest euro?',
+              ),
+              options: const ChatGoogleGenerativeAIOptions(
+                model: 'gemini-3.1-pro-preview',
+                temperature: 0,
+              ),
+            )
+            .toList();
+
+        expect(chunks, hasLength(greaterThan(1)));
+        final merged = chunks.reduce((first, next) => first.concat(next));
+        final signedBlocks = merged.output.contentBlocks
+            .where((block) {
+              final googleData = block.providerData['google'];
+              final rawPart = googleData is Map ? googleData['part'] : null;
+              return rawPart is Map && rawPart['thoughtSignature'] != null;
+            })
+            .toList(growable: false);
+
+        expect(merged.output.content, isNotEmpty);
+        expect(signedBlocks, isNotEmpty);
+        expect(
+          signedBlocks,
+          everyElement(
+            isA<AIChatMessageContentBlock>().having(
+              (block) => block.isMergeable,
+              'isMergeable',
+              isFalse,
+            ),
+          ),
+        );
+
+        final replayedParts = <ChatMessage>[
+          merged.output,
+        ].toContentList().single.parts;
+        expect(
+          replayedParts.where((part) => part.thoughtSignature != null),
+          hasLength(signedBlocks.length),
+        );
+        expect(replayedParts.whereType<g.TextPart>(), isNotEmpty);
+      },
+    );
 
     test(
       'Test tool calling',

--- a/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
@@ -107,6 +107,49 @@ void main() {
       final replayedPart = replayed.single.parts.single as g.FunctionCallPart;
       expect(replayedPart.thoughtSignature, signature);
     });
+
+    test('keeps a final signed text part separate while streaming', () {
+      final signature = utf8.encode('final-text-signature');
+      const firstResponse = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(parts: [g.TextPart('visible answer')]),
+          ),
+        ],
+      );
+      final finalResponse = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              parts: [g.TextPart('', thoughtSignature: signature)],
+            ),
+          ),
+        ],
+      );
+
+      final first = firstResponse
+          .toChatResult('stream-id', 'gemini-3.1-pro-preview')
+          .output;
+      final signedBoundary = finalResponse
+          .toChatResult('stream-id', 'gemini-3.1-pro-preview')
+          .output;
+      final merged = first.concat(signedBoundary);
+
+      expect(merged.contentBlocks, hasLength(2));
+      expect(
+        merged.contentBlocks.last,
+        isA<AIChatMessageTextBlock>()
+            .having((block) => block.text, 'text', isEmpty)
+            .having((block) => block.isMergeable, 'isMergeable', isFalse),
+      );
+
+      final replayed = <ChatMessage>[merged].toContentList().single.parts;
+      expect(replayed, hasLength(2));
+      expect(replayed.first.thoughtSignature, isNull);
+      expect(replayed.last, isA<g.TextPart>());
+      expect((replayed.last as g.TextPart).text, isEmpty);
+      expect(replayed.last.thoughtSignature, signature);
+    });
   });
 
   group('ChatMessagesMapper thought signatures', () {

--- a/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
@@ -46,7 +46,7 @@ void main() {
       },
     );
 
-    test('leaves tool-call provider data empty when there is no signature', () {
+    test('retains the raw part without inventing a signature', () {
       const response = g.GenerateContentResponse(
         candidates: [
           g.Candidate(
@@ -64,7 +64,11 @@ void main() {
 
       final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
-      expect(result.output.toolCalls.single.providerData, isEmpty);
+      final googleData =
+          result.output.toolCalls.single.providerData['google']
+              as Map<String, dynamic>;
+      expect(googleData, contains('part'));
+      expect(googleData, isNot(contains('thoughtSignature')));
     });
 
     test('preserves thoughtSignature through streamed concatenation', () {
@@ -205,6 +209,129 @@ void main() {
       final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
       expect(result.output.content, startsWith('visible'));
+    });
+
+    test('preserves ordered parts and common metadata through replay', () {
+      final signature = utf8.encode('reasoning-signature');
+      final parts = <g.Part>[
+        g.TextPart(
+          'reasoning',
+          thought: true,
+          thoughtSignature: signature,
+          partMetadata: const {'phase': 'analysis'},
+        ),
+        const g.TextPart('answer', additionalProperties: {'future': 1}),
+        const g.InlineDataPart(g.Blob(mimeType: 'image/png', data: 'aW1n')),
+        const g.FileDataPart(
+          g.FileData(fileUri: 'files/one', mimeType: 'text/plain'),
+        ),
+        const g.FunctionCallPart(
+          g.FunctionCall(id: 'call-1', name: 'weather', args: {'city': 'A'}),
+        ),
+        const g.FunctionResponsePart(
+          g.FunctionResponse(
+            id: 'call-1',
+            name: 'weather',
+            response: {'temperature': 20},
+          ),
+        ),
+        const g.ExecutableCodePart(
+          g.ExecutableCode(
+            id: 'code-1',
+            language: g.Language.python,
+            code: '1 + 1',
+          ),
+        ),
+        const g.CodeExecutionResultPart(
+          g.CodeExecutionResult(
+            id: 'code-1',
+            outcome: g.Outcome.ok,
+            output: '2',
+          ),
+        ),
+        const g.ToolCallPart(
+          g.ToolCall(
+            id: 'server-1',
+            toolType: g.ToolType.googleSearchWeb,
+            args: {'q': 'weather'},
+          ),
+        ),
+        const g.ToolResponsePart(
+          g.ToolResponse(
+            id: 'server-1',
+            toolType: g.ToolType.googleSearchWeb,
+            response: {'result': 'sunny'},
+          ),
+        ),
+        g.MetadataPart(thoughtSignature: signature),
+        g.UnknownPart({
+          'futurePart': {'value': 1},
+        }),
+      ];
+      final response = g.GenerateContentResponse(
+        candidates: [g.Candidate(content: g.Content(parts: parts))],
+      );
+
+      final message = response.toChatResult('response-1', 'gemini').output;
+      final replayed = <ChatMessage>[message].toContentList().single.parts;
+
+      expect(message.contentBlocks.map((block) => block.runtimeType), [
+        AIChatMessageReasoningBlock,
+        AIChatMessageTextBlock,
+        AIChatMessageMediaBlock,
+        AIChatMessageFileBlock,
+        AIChatMessageToolCall,
+        AIChatMessageServerToolResult,
+        AIChatMessageServerToolCall,
+        AIChatMessageServerToolResult,
+        AIChatMessageServerToolCall,
+        AIChatMessageServerToolResult,
+        AIChatMessageProviderMetadataBlock,
+        AIChatMessageNonStandardBlock,
+      ]);
+      expect(
+        replayed.map((part) => part.toJson()),
+        parts.map((p) => p.toJson()),
+      );
+    });
+
+    test('keeps parallel same-name streamed calls separate', () {
+      g.GenerateContentResponse chunk(
+        Map<String, dynamic> first,
+        Map<String, dynamic> second,
+      ) => g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              parts: [
+                g.FunctionCallPart(
+                  g.FunctionCall(name: 'weather', args: first),
+                ),
+                g.FunctionCallPart(
+                  g.FunctionCall(name: 'weather', args: second),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+
+      final starts = chunk(
+        const {},
+        const {},
+      ).toChatResult('response-1', 'gemini').output;
+      final finishes = chunk(
+        const {'city': 'Madrid'},
+        const {'city': 'Paris'},
+      ).toChatResult('response-1', 'gemini').output;
+      final calls = starts.concat(finishes).toolCalls;
+
+      expect(calls, hasLength(2));
+      expect(calls.map((call) => call.id), [
+        'google:response-1:0:0',
+        'google:response-1:0:1',
+      ]);
+      expect(calls.map((call) => call.arguments['city']), ['Madrid', 'Paris']);
     });
 
     test('maps every finish reason introduced through v12', () {

--- a/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
@@ -107,6 +107,49 @@ void main() {
       final replayedPart = replayed.single.parts.single as g.FunctionCallPart;
       expect(replayedPart.thoughtSignature, signature);
     });
+
+    test('keeps a final signed text part separate while streaming', () {
+      final signature = utf8.encode('final-text-signature');
+      const firstResponse = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(parts: [g.TextPart('visible answer')]),
+          ),
+        ],
+      );
+      final finalResponse = g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              parts: [g.TextPart('', thoughtSignature: signature)],
+            ),
+          ),
+        ],
+      );
+
+      final first = firstResponse
+          .toChatResult('stream-id', 'gemini-3.1-pro-preview')
+          .output;
+      final signedBoundary = finalResponse
+          .toChatResult('stream-id', 'gemini-3.1-pro-preview')
+          .output;
+      final merged = first.concat(signedBoundary);
+
+      expect(merged.contentBlocks, hasLength(2));
+      expect(
+        merged.contentBlocks.last,
+        isA<AIChatMessageTextBlock>()
+            .having((block) => block.text, 'text', isEmpty)
+            .having((block) => block.isMergeable, 'isMergeable', isFalse),
+      );
+
+      final replayed = <ChatMessage>[merged].toContentList().single.parts;
+      expect(replayed, hasLength(2));
+      expect(replayed.first.thoughtSignature, isNull);
+      expect(replayed.last, isA<g.TextPart>());
+      expect((replayed.last as g.TextPart).text, isEmpty);
+      expect(replayed.last.thoughtSignature, signature);
+    });
   });
 
   group('ChatMessagesMapper thought signatures', () {

--- a/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
@@ -46,7 +46,7 @@ void main() {
       },
     );
 
-    test('leaves tool-call provider data empty when there is no signature', () {
+    test('retains the raw part without inventing a signature', () {
       const response = g.GenerateContentResponse(
         candidates: [
           g.Candidate(
@@ -64,7 +64,11 @@ void main() {
 
       final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
-      expect(result.output.toolCalls.single.providerData, isEmpty);
+      final googleData =
+          result.output.toolCalls.single.providerData['google']
+              as Map<String, dynamic>;
+      expect(googleData, contains('part'));
+      expect(googleData, isNot(contains('thoughtSignature')));
     });
 
     test('preserves thoughtSignature through streamed concatenation', () {
@@ -205,6 +209,129 @@ void main() {
       final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
       expect(result.output.content, startsWith('visible'));
+    });
+
+    test('preserves ordered parts and common metadata through replay', () {
+      final signature = utf8.encode('reasoning-signature');
+      final parts = <g.Part>[
+        g.TextPart(
+          'reasoning',
+          thought: true,
+          thoughtSignature: signature,
+          partMetadata: const {'phase': 'analysis'},
+        ),
+        const g.TextPart('answer', additionalProperties: {'future': 1}),
+        const g.InlineDataPart(g.Blob(mimeType: 'image/png', data: 'aW1n')),
+        const g.FileDataPart(
+          g.FileData(fileUri: 'files/one', mimeType: 'text/plain'),
+        ),
+        const g.FunctionCallPart(
+          g.FunctionCall(id: 'call-1', name: 'weather', args: {'city': 'A'}),
+        ),
+        const g.FunctionResponsePart(
+          g.FunctionResponse(
+            id: 'call-1',
+            name: 'weather',
+            response: {'temperature': 20},
+          ),
+        ),
+        const g.ExecutableCodePart(
+          g.ExecutableCode(
+            id: 'code-1',
+            language: g.Language.python,
+            code: '1 + 1',
+          ),
+        ),
+        const g.CodeExecutionResultPart(
+          g.CodeExecutionResult(
+            id: 'code-1',
+            outcome: g.Outcome.ok,
+            output: '2',
+          ),
+        ),
+        const g.ToolCallPart(
+          g.ToolCall(
+            id: 'server-1',
+            toolType: g.ToolType.googleSearchWeb,
+            args: {'q': 'weather'},
+          ),
+        ),
+        const g.ToolResponsePart(
+          g.ToolResponse(
+            id: 'server-1',
+            toolType: g.ToolType.googleSearchWeb,
+            response: {'result': 'sunny'},
+          ),
+        ),
+        g.MetadataPart(thoughtSignature: signature),
+        g.UnknownPart({
+          'futurePart': {'value': 1},
+        }),
+      ];
+      final response = g.GenerateContentResponse(
+        candidates: [g.Candidate(content: g.Content(parts: parts))],
+      );
+
+      final message = response.toChatResult('response-1', 'gemini').output;
+      final replayed = <ChatMessage>[message].toContentList().single.parts;
+
+      expect(message.contentBlocks.map((block) => block.runtimeType), [
+        AIChatMessageReasoningBlock,
+        AIChatMessageTextBlock,
+        AIChatMessageMediaBlock,
+        AIChatMessageFileBlock,
+        AIChatMessageToolCall,
+        AIChatMessageServerToolResult,
+        AIChatMessageServerToolCall,
+        AIChatMessageServerToolResult,
+        AIChatMessageServerToolCall,
+        AIChatMessageServerToolResult,
+        AIChatMessageProviderMetadataBlock,
+        AIChatMessageNonStandardBlock,
+      ]);
+      expect(
+        replayed.map((part) => part.toJson()),
+        parts.map((p) => p.toJson()),
+      );
+    });
+
+    test('keeps parallel same-name streamed calls separate', () {
+      g.GenerateContentResponse chunk(
+        Map<String, dynamic> first,
+        Map<String, dynamic> second,
+      ) => g.GenerateContentResponse(
+        candidates: [
+          g.Candidate(
+            content: g.Content(
+              parts: [
+                g.FunctionCallPart(
+                  g.FunctionCall(name: 'weather', args: first),
+                ),
+                g.FunctionCallPart(
+                  g.FunctionCall(name: 'weather', args: second),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+
+      final starts = chunk(
+        const {},
+        const {},
+      ).toChatResult('response-1', 'gemini').output;
+      final finishes = chunk(
+        const {'city': 'Madrid'},
+        const {'city': 'Paris'},
+      ).toChatResult('response-1', 'gemini').output;
+      final calls = starts.concat(finishes).toolCalls;
+
+      expect(calls, hasLength(2));
+      expect(calls.map((call) => call.id), [
+        'google:response-1:0:0',
+        'google:response-1:0:1',
+      ]);
+      expect(calls.map((call) => call.arguments['city']), ['Madrid', 'Paris']);
     });
 
     test('maps every finish reason introduced through v12', () {

--- a/packages/langchain_google/test/embeddings/google_ai/google_ai_embeddings_mapper_test.dart
+++ b/packages/langchain_google/test/embeddings/google_ai/google_ai_embeddings_mapper_test.dart
@@ -51,18 +51,16 @@ void main() {
       [0.1, 0.2],
     ]);
     final queryBody = jsonDecode(requests.first.body) as Map<String, dynamic>;
-    expect(queryBody['embedContentConfig'], {
-      'taskType': 'RETRIEVAL_QUERY',
-      'outputDimensionality': 64,
-    });
+    expect(queryBody['taskType'], 'RETRIEVAL_QUERY');
+    expect(queryBody['outputDimensionality'], 64);
+    expect(queryBody.containsKey('embedContentConfig'), isFalse);
     final batchBody = jsonDecode(requests.last.body) as Map<String, dynamic>;
     final documentRequest =
         (batchBody['requests'] as List<dynamic>).single as Map<String, dynamic>;
-    expect(documentRequest['embedContentConfig'], {
-      'taskType': 'RETRIEVAL_DOCUMENT',
-      'title': 'Document title',
-      'outputDimensionality': 64,
-    });
+    expect(documentRequest['taskType'], 'RETRIEVAL_DOCUMENT');
+    expect(documentRequest['title'], 'Document title');
+    expect(documentRequest['outputDimensionality'], 64);
+    expect(documentRequest.containsKey('embedContentConfig'), isFalse);
 
     embeddings.close();
   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ melos:
         cross_file: ^0.3.4+2
         crypto: ^3.0.6
         csv: ^7.1.0
-        anthropic_sdk_dart: ^1.3.0
+        anthropic_sdk_dart: ^7.0.0
         equatable: ^2.0.7
         firebase_ai: ^3.4.0
         firebase_app_check: ^0.4.1+1


### PR DESCRIPTION
## Summary

- Introduces the canonical ordered `AIChatMessageContentBlock` hierarchy with stable stream identity and namespaced provider data.
- Uses Google and Anthropic as proving providers, preserving reasoning, signatures, tool ordering, metadata-only parts, and unknown provider payloads through mapping, serialization, concatenation, and replay.
- Keeps the existing string/tool-call APIs as a temporary compatibility layer while making ordered blocks canonical internally.

## Details

`AIChatMessageToolCall` becomes a content block, and `AIChatMessage.toolCalls` is derived from the ordered content. Streaming concatenation only combines blocks identified by stable provider IDs or explicit indexes; function names are never used as identity. When two chunks both carry stable IDs, those IDs take precedence over a coincidentally matching index.

Google retains original `Part` order and every placement of common metadata, including `thoughtSignature`, `MetadataPart`, and `UnknownPart`. Anthropic retains `ThinkingBlock`, applies `SignatureBlockDelta` to its reasoning block, and replays thinking/tool-use order.

The agent regression suite verifies that two parallel same-name calls remain distinct and route observations to the correct call.

This PR builds on the `googleai_dart` 12 migration merged in #961.

## References

- #942
- #945
- #960
- davidmigloz/ai_clients_dart#292

## Test plan

- [x] Bootstrap the complete workspace using published dependencies only
- [x] Run full-workspace `melos analyze`
- [x] Run all non-live unit tests
- [x] Verify Google and Anthropic reasoning/tool replay regressions
- [x] Verify parallel same-name streamed calls remain distinct through the agent loop
- [x] Verify different stable IDs never merge solely because their indexes match
- [x] Run the live Gemini streaming thought-signature regression
