### PR TITLE
feat(langchain_openai): preserve ordered AI content

### DIFF
--- a/packages/langchain_core/lib/src/chat_models/content_blocks.dart
+++ b/packages/langchain_core/lib/src/chat_models/content_blocks.dart
@@ -130,7 +130,7 @@ sealed class AIChatMessageContentBlock {
         ),
       (final AIChatMessageToolCall first, final AIChatMessageToolCall next) =>
         AIChatMessageToolCall(
-          id: _mergedId(first, next),
+          id: _mergedToolCallId(first, next),
           index: next.index ?? first.index,
           name: first.name + next.name,
           argumentsRaw: first.argumentsRaw + next.argumentsRaw,
@@ -734,6 +734,11 @@ String _mergedId(
   final AIChatMessageContentBlock first,
   final AIChatMessageContentBlock second,
 ) => second.id.isNotEmpty ? second.id : first.id;
+
+String _mergedToolCallId(
+  final AIChatMessageToolCall first,
+  final AIChatMessageToolCall second,
+) => first.id.isNotEmpty ? first.id : second.id;
 
 Object? _mergeValues(final Object? first, final Object? second) =>
     first is Map<String, dynamic> && second is Map<String, dynamic>

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai_responses.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai_responses.dart
@@ -192,6 +192,7 @@ class ChatOpenAIResponses extends BaseChatModel<ChatOpenAIResponsesOptions> {
     final PromptValue input, {
     final ChatOpenAIResponsesOptions? options,
   }) {
+    final functionCallIdsByOutputIndex = <int, String>{};
     return _client.responses
         .createStreamWithAccumulator(
           createResponseRequest(
@@ -201,7 +202,9 @@ class ChatOpenAIResponses extends BaseChatModel<ChatOpenAIResponsesOptions> {
           ),
         )
         .expand((final accumulator) {
-          final result = accumulator.toChatResult();
+          final result = accumulator.toChatResult(
+            functionCallIdsByOutputIndex: functionCallIdsByOutputIndex,
+          );
           return result != null ? [result] : const <ChatResult>[];
         });
   }

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
@@ -213,10 +213,11 @@ extension ResponseMapper on oai.Response {
 extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
   /// Maps the latest streaming event to a [ChatResult], or returns `null`
   /// for events that carry no meaningful content (e.g. `response.created`).
-  ChatResult? toChatResult() {
+  ChatResult? toChatResult({
+    final Map<int, String>? functionCallIdsByOutputIndex,
+  }) {
     final event = latestEvent;
-
-    final AIChatMessageContentBlock? block;
+    final blocks = <AIChatMessageContentBlock>[];
 
     switch (event) {
       case oai.OutputTextDeltaEvent(
@@ -225,40 +226,49 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
         :final contentIndex,
         :final delta,
       ):
-        block = AIChatMessageTextBlock(
-          text: delta,
-          id: itemId ?? 'openai-response:$responseId:$outputIndex',
-          index: _responseBlockIndex(outputIndex, contentIndex),
-          providerData: {
-            'openai': {'event': event.toJson()},
-          },
+        blocks.add(
+          AIChatMessageTextBlock(
+            text: delta,
+            id: _responseContentBlockId(
+              itemId: itemId,
+              responseId: responseId,
+              outputIndex: outputIndex,
+              contentIndex: contentIndex,
+            ),
+            index: _responseBlockIndex(outputIndex, contentIndex),
+            providerData: {
+              'openai': {'event': event.toJson()},
+            },
+          ),
         );
-      case oai.OutputItemAddedEvent(:final item)
-          when item is oai.FunctionCallOutputItemResponse:
-        block = AIChatMessageToolCall(
-          id: item.callId,
-          index: event.outputIndex,
-          name: item.name,
-          argumentsRaw: item.arguments,
-          arguments: _decodeArguments(item.arguments),
-          providerData: {
-            'openai': {'outputItem': item.toJson()},
-          },
+      case oai.OutputItemAddedEvent(:final outputIndex, :final item):
+        if (item case final oai.FunctionCallOutputItemResponse functionCall) {
+          functionCallIdsByOutputIndex?[outputIndex] = functionCall.callId;
+        }
+        blocks.addAll(
+          _mapOpenAIOutputItems([item], outputIndexOffset: outputIndex),
         );
+      case oai.OutputItemDoneEvent(:final outputIndex, :final item):
+        blocks.addAll(_mapOutputItemCompletionUpdates(item, outputIndex));
       case oai.FunctionCallArgumentsDeltaEvent(
         :final itemId,
         :final outputIndex,
         :final delta,
       ):
-        block = AIChatMessageToolCall(
-          id: itemId ?? 'openai-response:$responseId:$outputIndex',
-          index: outputIndex,
-          name: '',
-          argumentsRaw: delta,
-          arguments: const {},
-          providerData: {
-            'openai': {'event': event.toJson()},
-          },
+        blocks.add(
+          AIChatMessageToolCall(
+            id:
+                functionCallIdsByOutputIndex?[outputIndex] ??
+                itemId ??
+                'openai-response:$responseId:$outputIndex',
+            index: outputIndex,
+            name: '',
+            argumentsRaw: delta,
+            arguments: const {},
+            providerData: {
+              'openai': {'event': event.toJson()},
+            },
+          ),
         );
       case oai.ReasoningTextDeltaEvent(
         :final itemId,
@@ -266,13 +276,15 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
         :final contentIndex,
         :final delta,
       ):
-        block = AIChatMessageReasoningBlock(
-          reasoning: delta,
-          id: itemId ?? 'openai-response:$responseId:$outputIndex',
-          index: _responseBlockIndex(outputIndex, contentIndex ?? 0),
-          providerData: {
-            'openai': {'event': event.toJson()},
-          },
+        blocks.add(
+          AIChatMessageReasoningBlock(
+            reasoning: delta,
+            id: itemId ?? 'openai-response:$responseId:$outputIndex',
+            index: _responseBlockIndex(outputIndex, contentIndex ?? 0),
+            providerData: {
+              'openai': {'event': event.toJson()},
+            },
+          ),
         );
       case oai.ReasoningSummaryTextDeltaEvent(
         :final itemId,
@@ -280,13 +292,15 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
         :final summaryIndex,
         :final delta,
       ):
-        block = AIChatMessageReasoningBlock(
-          reasoning: delta,
-          id: itemId ?? 'openai-response:$responseId:$outputIndex',
-          index: _responseBlockIndex(outputIndex, summaryIndex),
-          providerData: {
-            'openai': {'event': event.toJson()},
-          },
+        blocks.add(
+          AIChatMessageReasoningBlock(
+            reasoning: delta,
+            id: itemId ?? 'openai-response:$responseId:$outputIndex',
+            index: _responseBlockIndex(outputIndex, summaryIndex),
+            providerData: {
+              'openai': {'event': event.toJson()},
+            },
+          ),
         );
       case oai.RefusalDeltaEvent(:final delta):
         return ChatResult(
@@ -295,9 +309,12 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
             contentBlocks: [
               AIChatMessageNonStandardBlock(
                 value: event.toJson(),
-                id:
-                    event.itemId ??
-                    'openai-response:$responseId:${event.outputIndex}',
+                id: _responseContentBlockId(
+                  itemId: event.itemId,
+                  responseId: responseId,
+                  outputIndex: event.outputIndex,
+                  contentIndex: event.contentIndex,
+                ),
                 index: _responseBlockIndex(
                   event.outputIndex,
                   event.contentIndex,
@@ -328,13 +345,16 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
         return null;
     }
 
+    if (blocks.isEmpty) return null;
+
     return ChatResult(
       id: responseId ?? '',
       output: AIChatMessage.withBlocks(
-        contentBlocks: [block],
-        legacyContent: block is AIChatMessageTextBlock
-            ? block.legacyContent
-            : '',
+        contentBlocks: blocks,
+        legacyContent: blocks
+            .whereType<AIChatMessageTextBlock>()
+            .map((block) => block.legacyContent)
+            .join(),
       ),
       finishReason: _mapStreamFinishReason(status),
       metadata: const {},
@@ -345,10 +365,12 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
 }
 
 List<AIChatMessageContentBlock> _mapOpenAIOutputItems(
-  final List<oai.OutputItem> items,
-) {
+  final List<oai.OutputItem> items, {
+  final int outputIndexOffset = 0,
+}) {
   final blocks = <AIChatMessageContentBlock>[];
-  for (final (outputIndex, item) in items.indexed) {
+  for (final (relativeIndex, item) in items.indexed) {
+    final outputIndex = outputIndexOffset + relativeIndex;
     final rawItem = item.toJson();
     final baseProviderData = <String, dynamic>{
       'openai': {'outputItem': rawItem, 'outputIndex': outputIndex},
@@ -446,6 +468,83 @@ List<AIChatMessageContentBlock> _mapOpenAIOutputItems(
   return blocks;
 }
 
+List<AIChatMessageContentBlock> _mapOutputItemCompletionUpdates(
+  final oai.OutputItem item,
+  final int outputIndex,
+) {
+  final rawItem = item.toJson();
+  final baseProviderData = <String, dynamic>{
+    'openai': {'outputItem': rawItem, 'outputIndex': outputIndex},
+  };
+  return switch (item) {
+    final oai.MessageOutputItem message => [
+      for (final (contentIndex, content) in message.content.indexed)
+        switch (content) {
+          oai.OutputTextContent() => AIChatMessageTextBlock(
+            text: '',
+            id: '${message.id}:$contentIndex',
+            index: _responseBlockIndex(outputIndex, contentIndex),
+            providerData: baseProviderData,
+          ),
+          oai.ReasoningTextContent() ||
+          oai.SummaryTextContent() => AIChatMessageReasoningBlock(
+            reasoning: '',
+            id: '${message.id}:$contentIndex',
+            index: _responseBlockIndex(outputIndex, contentIndex),
+            providerData: baseProviderData,
+          ),
+          final oai.OutputContent other => AIChatMessageNonStandardBlock(
+            value: other.toJson(),
+            id: '${message.id}:$contentIndex',
+            index: _responseBlockIndex(outputIndex, contentIndex),
+            providerData: baseProviderData,
+          ),
+        },
+    ],
+    final oai.FunctionCallOutputItemResponse functionCall => [
+      AIChatMessageToolCall(
+        id: functionCall.callId,
+        index: outputIndex,
+        name: '',
+        argumentsRaw: '',
+        arguments: _decodeArguments(functionCall.arguments),
+        providerData: baseProviderData,
+      ),
+    ],
+    final oai.ReasoningItem reasoning => [
+      AIChatMessageReasoningBlock(
+        reasoning: '',
+        id: reasoning.id,
+        index: outputIndex,
+        providerData: baseProviderData,
+      ),
+    ],
+    oai.OutputItem() => [
+      if ((rawItem['type'] as String? ?? 'unknown').endsWith('_output'))
+        AIChatMessageServerToolResult(
+          id: rawItem['id'] as String? ?? 'openai:$outputIndex',
+          index: outputIndex,
+          toolCallId:
+              rawItem['call_id'] as String? ??
+              rawItem['id'] as String? ??
+              'openai:$outputIndex',
+          name: rawItem['type'] as String?,
+          result: rawItem,
+          providerData: baseProviderData,
+        )
+      else
+        AIChatMessageServerToolCall(
+          id: rawItem['id'] as String? ?? 'openai:$outputIndex',
+          index: outputIndex,
+          name: '',
+          argumentsRaw: '',
+          arguments: rawItem,
+          providerData: baseProviderData,
+        ),
+    ],
+  };
+}
+
 Map<String, dynamic> _decodeArguments(final String raw) {
   try {
     return raw.isEmpty
@@ -466,6 +565,13 @@ Map<String, dynamic>? _openAIOutputItem(
 
 int _responseBlockIndex(final int outputIndex, final int contentIndex) =>
     outputIndex * 100000 + contentIndex;
+
+String _responseContentBlockId({
+  required final String? itemId,
+  required final String? responseId,
+  required final int outputIndex,
+  required final int contentIndex,
+}) => '${itemId ?? 'openai-response:$responseId:$outputIndex'}:$contentIndex';
 
 extension ResponseToolListMapper on List<ToolSpec> {
   List<oai.ResponseTool> toResponseTools() {

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
@@ -60,8 +60,48 @@ oai.CreateResponseRequest createResponseRequest(
 
 extension ChatMessageListResponseMapper on List<ChatMessage> {
   oai.ResponseInput toResponseInput() {
+    final containsResponseOutput = whereType<AIChatMessage>().any(
+      (message) => message.contentBlocks.any(
+        (block) => _openAIOutputItem(block) != null,
+      ),
+    );
+    if (containsResponseOutput) {
+      return oai.ResponseInput.fromOutputItems(
+        expand(_mapMessageToRawItems).toList(growable: false),
+      );
+    }
     final items = expand(_mapMessage).toList(growable: false);
     return oai.ResponseInput.items(items);
+  }
+
+  Iterable<Map<String, dynamic>> _mapMessageToRawItems(
+    final ChatMessage message,
+  ) sync* {
+    if (message is! AIChatMessage) {
+      yield* _mapMessage(message).map((item) => item.toJson());
+      return;
+    }
+    final emittedItems = <String>{};
+    for (final block in message.contentBlocks) {
+      final rawItem = _openAIOutputItem(block);
+      if (rawItem != null) {
+        final key = '${rawItem['type']}:${rawItem['id'] ?? block.index}';
+        if (emittedItems.add(key)) yield rawItem;
+        continue;
+      }
+      switch (block) {
+        case final AIChatMessageTextBlock text:
+          yield oai.MessageItem.assistantText(text.text).toJson();
+        case final AIChatMessageToolCall toolCall:
+          yield oai.FunctionCallItem(
+            callId: toolCall.id,
+            name: toolCall.name,
+            arguments: toolCall.argumentsRaw,
+          ).toJson();
+        case AIChatMessageContentBlock():
+          continue;
+      }
+    }
   }
 
   Iterable<oai.Item> _mapMessage(final ChatMessage msg) {
@@ -126,17 +166,23 @@ extension ChatMessageListResponseMapper on List<ChatMessage> {
   // as separate items (unlike Chat Completions which groups them in one message).
   Iterable<oai.Item> _mapAIMessage(final AIChatMessage msg) {
     final items = <oai.Item>[];
-    if (msg.content.isNotEmpty) {
-      items.add(oai.MessageItem.assistantText(msg.content));
-    }
-    for (final toolCall in msg.toolCalls) {
-      items.add(
-        oai.FunctionCallItem(
-          callId: toolCall.id,
-          name: toolCall.name,
-          arguments: toolCall.argumentsRaw,
-        ),
-      );
+    for (final block in msg.contentBlocks) {
+      switch (block) {
+        case final AIChatMessageTextBlock text:
+          if (text.text.isNotEmpty) {
+            items.add(oai.MessageItem.assistantText(text.text));
+          }
+        case final AIChatMessageToolCall toolCall:
+          items.add(
+            oai.FunctionCallItem(
+              callId: toolCall.id,
+              name: toolCall.name,
+              arguments: toolCall.argumentsRaw,
+            ),
+          );
+        case AIChatMessageContentBlock():
+          continue;
+      }
     }
     return items;
   }
@@ -151,24 +197,12 @@ extension ChatMessageListResponseMapper on List<ChatMessage> {
 
 extension ResponseMapper on oai.Response {
   ChatResult toChatResult() {
-    final toolCalls = functionCalls
-        .map((fc) {
-          var args = <String, dynamic>{};
-          try {
-            args = fc.arguments.isEmpty ? {} : json.decode(fc.arguments);
-          } catch (_) {}
-          return AIChatMessageToolCall(
-            id: fc.callId,
-            name: fc.name,
-            argumentsRaw: fc.arguments,
-            arguments: args,
-          );
-        })
-        .toList(growable: false);
-
     return ChatResult(
       id: id,
-      output: AIChatMessage(content: outputText, toolCalls: toolCalls),
+      output: AIChatMessage.withBlocks(
+        contentBlocks: _mapOpenAIOutputItems(output),
+        legacyContent: outputText,
+      ),
       finishReason: _mapFinishReason(status),
       metadata: {'model': model, 'created_at': createdAt},
       usage: _mapResponseUsage(usage),
@@ -182,42 +216,98 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
   ChatResult? toChatResult() {
     final event = latestEvent;
 
-    final String content;
-    final List<AIChatMessageToolCall> toolCalls;
+    final AIChatMessageContentBlock? block;
 
     switch (event) {
-      case oai.OutputTextDeltaEvent(:final delta):
-        content = delta;
-        toolCalls = const [];
+      case oai.OutputTextDeltaEvent(
+        :final itemId,
+        :final outputIndex,
+        :final contentIndex,
+        :final delta,
+      ):
+        block = AIChatMessageTextBlock(
+          text: delta,
+          id: itemId ?? 'openai-response:$responseId:$outputIndex',
+          index: _responseBlockIndex(outputIndex, contentIndex),
+          providerData: {
+            'openai': {'event': event.toJson()},
+          },
+        );
       case oai.OutputItemAddedEvent(:final item)
           when item is oai.FunctionCallOutputItemResponse:
-        content = '';
-        toolCalls = [
-          AIChatMessageToolCall(
-            id: item.callId,
-            name: item.name,
-            argumentsRaw: '',
-            arguments: const {},
-          ),
-        ];
-      case oai.FunctionCallArgumentsDeltaEvent(:final delta):
-        content = '';
-        // Use empty id so AIChatMessage.concat falls back to the last
-        // tool call's id (set by OutputItemAddedEvent with callId).
-        toolCalls = [
-          AIChatMessageToolCall(
-            id: '',
-            name: '',
-            argumentsRaw: delta,
-            arguments: const {},
-          ),
-        ];
+        block = AIChatMessageToolCall(
+          id: item.callId,
+          index: event.outputIndex,
+          name: item.name,
+          argumentsRaw: item.arguments,
+          arguments: _decodeArguments(item.arguments),
+          providerData: {
+            'openai': {'outputItem': item.toJson()},
+          },
+        );
+      case oai.FunctionCallArgumentsDeltaEvent(
+        :final itemId,
+        :final outputIndex,
+        :final delta,
+      ):
+        block = AIChatMessageToolCall(
+          id: itemId ?? 'openai-response:$responseId:$outputIndex',
+          index: outputIndex,
+          name: '',
+          argumentsRaw: delta,
+          arguments: const {},
+          providerData: {
+            'openai': {'event': event.toJson()},
+          },
+        );
+      case oai.ReasoningTextDeltaEvent(
+        :final itemId,
+        :final outputIndex,
+        :final contentIndex,
+        :final delta,
+      ):
+        block = AIChatMessageReasoningBlock(
+          reasoning: delta,
+          id: itemId ?? 'openai-response:$responseId:$outputIndex',
+          index: _responseBlockIndex(outputIndex, contentIndex ?? 0),
+          providerData: {
+            'openai': {'event': event.toJson()},
+          },
+        );
+      case oai.ReasoningSummaryTextDeltaEvent(
+        :final itemId,
+        :final outputIndex,
+        :final summaryIndex,
+        :final delta,
+      ):
+        block = AIChatMessageReasoningBlock(
+          reasoning: delta,
+          id: itemId ?? 'openai-response:$responseId:$outputIndex',
+          index: _responseBlockIndex(outputIndex, summaryIndex),
+          providerData: {
+            'openai': {'event': event.toJson()},
+          },
+        );
       case oai.RefusalDeltaEvent(:final delta):
-        content = '';
-        toolCalls = const [];
         return ChatResult(
           id: responseId ?? '',
-          output: AIChatMessage(content: content, toolCalls: toolCalls),
+          output: AIChatMessage.withBlocks(
+            contentBlocks: [
+              AIChatMessageNonStandardBlock(
+                value: event.toJson(),
+                id:
+                    event.itemId ??
+                    'openai-response:$responseId:${event.outputIndex}',
+                index: _responseBlockIndex(
+                  event.outputIndex,
+                  event.contentIndex,
+                ),
+                providerData: {
+                  'openai': {'event': event.toJson()},
+                },
+              ),
+            ],
+          ),
           finishReason: FinishReason.unspecified,
           metadata: {'refusal': delta},
           usage: _mapResponseUsage(usage),
@@ -227,7 +317,7 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
         final result = response.toChatResult();
         return ChatResult(
           id: result.id,
-          output: result.output,
+          output: const AIChatMessage.withBlocks(contentBlocks: []),
           finishReason: result.finishReason,
           metadata: result.metadata,
           usage: result.usage,
@@ -240,7 +330,12 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
 
     return ChatResult(
       id: responseId ?? '',
-      output: AIChatMessage(content: content, toolCalls: toolCalls),
+      output: AIChatMessage.withBlocks(
+        contentBlocks: [block],
+        legacyContent: block is AIChatMessageTextBlock
+            ? block.legacyContent
+            : '',
+      ),
       finishReason: _mapStreamFinishReason(status),
       metadata: const {},
       usage: _mapResponseUsage(usage),
@@ -248,6 +343,129 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
     );
   }
 }
+
+List<AIChatMessageContentBlock> _mapOpenAIOutputItems(
+  final List<oai.OutputItem> items,
+) {
+  final blocks = <AIChatMessageContentBlock>[];
+  for (final (outputIndex, item) in items.indexed) {
+    final rawItem = item.toJson();
+    final baseProviderData = <String, dynamic>{
+      'openai': {'outputItem': rawItem, 'outputIndex': outputIndex},
+    };
+    switch (item) {
+      case final oai.MessageOutputItem message:
+        for (final (contentIndex, content) in message.content.indexed) {
+          final providerData = <String, dynamic>{
+            'openai': {
+              'outputItem': rawItem,
+              'outputIndex': outputIndex,
+              'contentIndex': contentIndex,
+            },
+          };
+          final id = '${message.id}:$contentIndex';
+          final index = _responseBlockIndex(outputIndex, contentIndex);
+          blocks.add(switch (content) {
+            final oai.OutputTextContent text => AIChatMessageTextBlock(
+              text: text.text,
+              id: id,
+              index: index,
+              providerData: providerData,
+            ),
+            final oai.ReasoningTextContent reasoning =>
+              AIChatMessageReasoningBlock(
+                reasoning: reasoning.text,
+                id: id,
+                index: index,
+                providerData: providerData,
+              ),
+            final oai.SummaryTextContent summary => AIChatMessageReasoningBlock(
+              reasoning: summary.text,
+              id: id,
+              index: index,
+              providerData: providerData,
+            ),
+            final oai.OutputContent other => AIChatMessageNonStandardBlock(
+              value: other.toJson(),
+              id: id,
+              index: index,
+              providerData: providerData,
+            ),
+          });
+        }
+      case final oai.FunctionCallOutputItemResponse functionCall:
+        blocks.add(
+          AIChatMessageToolCall(
+            id: functionCall.callId,
+            index: outputIndex,
+            name: functionCall.name,
+            argumentsRaw: functionCall.arguments,
+            arguments: _decodeArguments(functionCall.arguments),
+            providerData: baseProviderData,
+          ),
+        );
+      case final oai.ReasoningItem reasoning:
+        final reasoningText = [
+          ...?reasoning.content?.map((content) => content['text']),
+          ...reasoning.summary.map((summary) => summary.text),
+        ].whereType<String>().join();
+        blocks.add(
+          AIChatMessageReasoningBlock(
+            reasoning: reasoningText,
+            id: reasoning.id,
+            index: outputIndex,
+            providerData: baseProviderData,
+          ),
+        );
+      case oai.OutputItem():
+        final type = rawItem['type'] as String? ?? 'unknown';
+        blocks.add(
+          type.endsWith('_output')
+              ? AIChatMessageServerToolResult(
+                  id: rawItem['id'] as String? ?? 'openai:$outputIndex',
+                  index: outputIndex,
+                  toolCallId:
+                      rawItem['call_id'] as String? ??
+                      rawItem['id'] as String? ??
+                      'openai:$outputIndex',
+                  name: type,
+                  result: rawItem,
+                  providerData: baseProviderData,
+                )
+              : AIChatMessageServerToolCall(
+                  id: rawItem['id'] as String? ?? 'openai:$outputIndex',
+                  index: outputIndex,
+                  name: type,
+                  argumentsRaw: jsonEncode(rawItem),
+                  arguments: rawItem,
+                  providerData: baseProviderData,
+                ),
+        );
+    }
+  }
+  return blocks;
+}
+
+Map<String, dynamic> _decodeArguments(final String raw) {
+  try {
+    return raw.isEmpty
+        ? const {}
+        : (jsonDecode(raw) as Map).cast<String, dynamic>();
+  } on Object {
+    return const {};
+  }
+}
+
+Map<String, dynamic>? _openAIOutputItem(
+  final AIChatMessageContentBlock block,
+) => switch (block.providerData['openai']) {
+  {'outputItem': final Map<Object?, Object?> item} =>
+    item.cast<String, dynamic>(),
+  _ => null,
+};
+
+int _responseBlockIndex(final int outputIndex, final int contentIndex) =>
+    outputIndex * 100000 + contentIndex;
 
 extension ResponseToolListMapper on List<ToolSpec> {
   List<oai.ResponseTool> toResponseTools() {

--- a/packages/langchain_openai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/mappers.dart
@@ -155,7 +155,9 @@ extension ChatMessageListMapper on List<ChatMessage> {
       type: 'function',
       function: oai.FunctionCall(
         name: toolCall.name,
-        arguments: json.encode(toolCall.arguments),
+        arguments: toolCall.argumentsRaw.isNotEmpty
+            ? toolCall.argumentsRaw
+            : json.encode(toolCall.arguments),
       ),
     );
   }
@@ -179,11 +181,36 @@ extension CreateChatCompletionResponseMapper on oai.ChatCompletion {
 
     return ChatResult(
       id: id,
-      output: AIChatMessage(
-        content: msg.content ?? '',
-        toolCalls:
-            msg.toolCalls?.map(_mapMessageToolCall).toList(growable: false) ??
-            const [],
+      output: AIChatMessage.withBlocks(
+        contentBlocks: [
+          if (msg.hasReasoningContent)
+            AIChatMessageReasoningBlock(
+              reasoning: msg.reasoningContent ?? msg.reasoning ?? '',
+              id: 'openai-chat:$id:reasoning',
+              index: 0,
+              providerData: {
+                'openai': {
+                  'chatMessage': msg.toJson(),
+                  if (msg.reasoningDetails != null)
+                    'reasoningDetails': msg.reasoningDetails!
+                        .map((detail) => detail.toJson())
+                        .toList(growable: false),
+                },
+              },
+            ),
+          if ((msg.content ?? '').isNotEmpty)
+            AIChatMessageTextBlock(
+              text: msg.content!,
+              id: 'openai-chat:$id:text',
+              index: 1,
+              providerData: {
+                'openai': {'chatMessage': msg.toJson()},
+              },
+            ),
+          for (final (index, toolCall) in (msg.toolCalls ?? const []).indexed)
+            _mapMessageToolCall(toolCall, index: index + 2, responseId: id),
+        ],
+        legacyContent: msg.content ?? '',
       ),
       finishReason: _mapFinishReason(choice.finishReason),
       metadata: {
@@ -196,7 +223,11 @@ extension CreateChatCompletionResponseMapper on oai.ChatCompletion {
     );
   }
 
-  AIChatMessageToolCall _mapMessageToolCall(final oai.ToolCall toolCall) {
+  AIChatMessageToolCall _mapMessageToolCall(
+    final oai.ToolCall toolCall, {
+    required final int index,
+    required final String responseId,
+  }) {
     var args = <String, dynamic>{};
     try {
       args = toolCall.function.arguments.isEmpty
@@ -205,9 +236,13 @@ extension CreateChatCompletionResponseMapper on oai.ChatCompletion {
     } catch (_) {}
     return AIChatMessageToolCall(
       id: toolCall.id,
+      index: index,
       name: toolCall.function.name,
       argumentsRaw: toolCall.function.arguments,
       arguments: args,
+      providerData: {
+        'openai': {'toolCall': toolCall.toJson(), 'responseId': responseId},
+      },
     );
   }
 }
@@ -256,13 +291,31 @@ extension CreateChatCompletionStreamResponseMapper on oai.ChatStreamEvent {
 
     return ChatResult(
       id: id,
-      output: AIChatMessage(
-        content: delta?.content ?? '',
-        toolCalls:
-            delta?.toolCalls
-                ?.map(_mapMessageToolCall)
-                .toList(growable: false) ??
-            const [],
+      output: AIChatMessage.withBlocks(
+        contentBlocks: [
+          if (delta?.hasReasoningContent ?? false)
+            AIChatMessageReasoningBlock(
+              reasoning: delta?.reasoningContent ?? delta?.reasoning ?? '',
+              id: 'openai-chat:$id:reasoning',
+              index: 0,
+              providerData: {
+                'openai': {'delta': delta?.toJson()},
+              },
+            ),
+          if ((delta?.content ?? '').isNotEmpty)
+            AIChatMessageTextBlock(
+              text: delta!.content!,
+              id: 'openai-chat:$id:text',
+              index: 1,
+              providerData: {
+                'openai': {'delta': delta.toJson()},
+              },
+            ),
+          for (final toolCall
+              in delta?.toolCalls ?? const <oai.ToolCallDelta>[])
+            _mapMessageToolCall(toolCall, responseId: id),
+        ],
+        legacyContent: delta?.content ?? '',
       ),
       finishReason: _mapFinishReason(choice?.finishReason),
       metadata: {
@@ -275,16 +328,23 @@ extension CreateChatCompletionStreamResponseMapper on oai.ChatStreamEvent {
     );
   }
 
-  AIChatMessageToolCall _mapMessageToolCall(final oai.ToolCallDelta toolCall) {
+  AIChatMessageToolCall _mapMessageToolCall(
+    final oai.ToolCallDelta toolCall, {
+    required final String responseId,
+  }) {
     var args = <String, dynamic>{};
     try {
       args = json.decode(toolCall.function?.arguments ?? '');
     } catch (_) {}
     return AIChatMessageToolCall(
-      id: toolCall.id ?? '',
+      id: toolCall.id ?? 'openai-chat:$responseId:tool:${toolCall.index}',
+      index: toolCall.index + 2,
       name: toolCall.function?.name ?? '',
       argumentsRaw: toolCall.function?.arguments ?? '',
       arguments: args,
+      providerData: {
+        'openai': {'delta': toolCall.toJson()},
+      },
     );
   }
 }

--- a/packages/langchain_openai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/mappers.dart
@@ -337,7 +337,10 @@ extension CreateChatCompletionStreamResponseMapper on oai.ChatStreamEvent {
       args = json.decode(toolCall.function?.arguments ?? '');
     } catch (_) {}
     return AIChatMessageToolCall(
-      id: toolCall.id ?? 'openai-chat:$responseId:tool:${toolCall.index}',
+      // Continuation deltas commonly omit the provider ID. Keep it empty so
+      // the explicit stream index can associate it with the opening delta;
+      // assigning a synthetic stable ID here would split one call in two.
+      id: toolCall.id ?? '',
       index: toolCall.index + 2,
       name: toolCall.function?.name ?? '',
       argumentsRaw: toolCall.function?.arguments ?? '',

--- a/packages/langchain_openai/test/agents/tools_test.dart
+++ b/packages/langchain_openai/test/agents/tools_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_async
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_openai/test/chains/qa_with_sources_test.dart
+++ b/packages/langchain_openai/test/chains/qa_with_sources_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
@@ -285,11 +285,14 @@ void main() {
 
       test('keeps parallel same-name streamed function calls distinct', () {
         final accumulator = oai.ResponseStreamAccumulator();
+        final functionCallIdsByOutputIndex = <int, String>{};
         final results = <ChatResult>[];
 
         void add(final oai.ResponseStreamEvent event) {
           accumulator.add(event);
-          final result = accumulator.toChatResult();
+          final result = accumulator.toChatResult(
+            functionCallIdsByOutputIndex: functionCallIdsByOutputIndex,
+          );
           if (result != null) results.add(result);
         }
 
@@ -340,6 +343,73 @@ void main() {
           'Madrid',
           'Paris',
         ]);
+      });
+
+      test('keeps content indexes distinct within one output item', () {
+        final accumulator = oai.ResponseStreamAccumulator();
+        final results = <ChatResult>[];
+
+        for (final event in const <oai.ResponseStreamEvent>[
+          oai.OutputTextDeltaEvent(
+            itemId: 'message_1',
+            outputIndex: 0,
+            contentIndex: 0,
+            delta: 'first',
+          ),
+          oai.OutputTextDeltaEvent(
+            itemId: 'message_1',
+            outputIndex: 0,
+            contentIndex: 1,
+            delta: 'second',
+          ),
+        ]) {
+          accumulator.add(event);
+          results.add(accumulator.toChatResult()!);
+        }
+
+        final output = results
+            .map((result) => result.output)
+            .reduce((first, next) => first.concat(next));
+
+        expect(output.contentBlocks, hasLength(2));
+        expect(output.contentAsString, 'firstsecond');
+      });
+
+      test('retains completed server-tool output item data', () {
+        final accumulator = oai.ResponseStreamAccumulator();
+        final results = <ChatResult>[];
+
+        for (final event in const <oai.ResponseStreamEvent>[
+          oai.OutputItemAddedEvent(
+            outputIndex: 0,
+            item: oai.WebSearchCallOutputItem(
+              id: 'search_1',
+              status: oai.ItemStatus.inProgress,
+            ),
+          ),
+          oai.OutputItemDoneEvent(
+            outputIndex: 0,
+            item: oai.WebSearchCallOutputItem(
+              id: 'search_1',
+              status: oai.ItemStatus.completed,
+            ),
+          ),
+        ]) {
+          accumulator.add(event);
+          results.add(accumulator.toChatResult()!);
+        }
+
+        final output = results
+            .map((result) => result.output)
+            .reduce((first, next) => first.concat(next));
+        final block =
+            output.contentBlocks.single as AIChatMessageServerToolCall;
+
+        expect(block.name, 'web_search_call');
+        expect(block.arguments['status'], 'completed');
+        final openAIData = block.providerData['openai'] as Map<String, dynamic>;
+        final outputItem = openAIData['outputItem'] as Map<String, dynamic>;
+        expect(outputItem['status'], 'completed');
       });
     });
   });

--- a/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
@@ -232,5 +232,115 @@ void main() {
         expect(request.metadata, {'key': 'value'});
       });
     });
+
+    group('ordered output blocks', () {
+      test('preserves reasoning, text, function, and server-tool order', () {
+        final output = <Map<String, dynamic>>[
+          {
+            'type': 'reasoning',
+            'id': 'reasoning_1',
+            'summary': [
+              {'type': 'summary_text', 'text': 'Check the weather.'},
+            ],
+            'encrypted_content': 'opaque',
+          },
+          {
+            'type': 'message',
+            'id': 'message_1',
+            'role': 'assistant',
+            'content': [
+              {'type': 'output_text', 'text': 'I will check.'},
+            ],
+          },
+          {
+            'type': 'function_call',
+            'id': 'item_1',
+            'call_id': 'call_1',
+            'name': 'weather',
+            'arguments': '{"city":"Madrid"}',
+          },
+          {'type': 'web_search_call', 'id': 'search_1', 'status': 'completed'},
+        ];
+        final response = oai.Response.fromJson({
+          'id': 'response_1',
+          'object': 'response',
+          'created_at': 1,
+          'status': 'completed',
+          'output': output,
+        });
+
+        final message = response.toChatResult().output;
+        final replayed = <ChatMessage>[message].toResponseInput();
+
+        expect(message.contentBlocks.map((block) => block.runtimeType), [
+          AIChatMessageReasoningBlock,
+          AIChatMessageTextBlock,
+          AIChatMessageToolCall,
+          AIChatMessageServerToolCall,
+        ]);
+        expect(message.content, 'I will check.');
+        expect(message.toolCalls.single.id, 'call_1');
+        expect(replayed.toJson(), output);
+      });
+
+      test('keeps parallel same-name streamed function calls distinct', () {
+        final accumulator = oai.ResponseStreamAccumulator();
+        final results = <ChatResult>[];
+
+        void add(final oai.ResponseStreamEvent event) {
+          accumulator.add(event);
+          final result = accumulator.toChatResult();
+          if (result != null) results.add(result);
+        }
+
+        add(
+          const oai.OutputItemAddedEvent(
+            outputIndex: 0,
+            item: oai.FunctionCallOutputItemResponse(
+              id: 'item_madrid',
+              callId: 'call_madrid',
+              name: 'weather',
+              arguments: '',
+            ),
+          ),
+        );
+        add(
+          const oai.OutputItemAddedEvent(
+            outputIndex: 1,
+            item: oai.FunctionCallOutputItemResponse(
+              id: 'item_paris',
+              callId: 'call_paris',
+              name: 'weather',
+              arguments: '',
+            ),
+          ),
+        );
+        add(
+          const oai.FunctionCallArgumentsDeltaEvent(
+            outputIndex: 0,
+            itemId: 'item_madrid',
+            delta: '{"city":"Madrid"}',
+          ),
+        );
+        add(
+          const oai.FunctionCallArgumentsDeltaEvent(
+            outputIndex: 1,
+            itemId: 'item_paris',
+            delta: '{"city":"Paris"}',
+          ),
+        );
+
+        final calls = results
+            .map((result) => result.output)
+            .reduce((first, next) => first.concat(next))
+            .toolCalls;
+
+        expect(calls.map((call) => call.id), ['call_madrid', 'call_paris']);
+        expect(calls.map((call) => call.arguments['city']), [
+          'Madrid',
+          'Paris',
+        ]);
+      });
+    });
   });
 }

--- a/packages/langchain_openai/test/chat_models/chat_openai_responses_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_responses_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_openai/test/chat_models/chat_openai_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:convert';

--- a/packages/langchain_openai/test/chat_models/github_models_test.dart
+++ b/packages/langchain_openai/test/chat_models/github_models_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_print
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:convert';

--- a/packages/langchain_openai/test/chat_models/mappers_content_blocks_test.dart
+++ b/packages/langchain_openai/test/chat_models/mappers_content_blocks_test.dart
@@ -1,0 +1,79 @@
+import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_openai/src/chat_models/mappers.dart';
+import 'package:openai_dart/openai_dart.dart' as oai;
+import 'package:test/test.dart';
+
+void main() {
+  test('Chat Completions preserves reasoning, text, and tool calls', () {
+    const completion = oai.ChatCompletion(
+      id: 'completion-1',
+      object: 'chat.completion',
+      model: 'gpt-compatible',
+      choices: [
+        oai.ChatChoice(
+          message: oai.AssistantMessage(
+            reasoningContent: 'reasoning',
+            content: 'answer',
+            toolCalls: [
+              oai.ToolCall(
+                id: 'call-1',
+                type: 'function',
+                function: oai.FunctionCall(
+                  name: 'weather',
+                  arguments: '{"city":"Madrid"}',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    final message = completion.toChatResult('completion-1').output;
+
+    expect(message.contentBlocks.map((block) => block.runtimeType), [
+      AIChatMessageReasoningBlock,
+      AIChatMessageTextBlock,
+      AIChatMessageToolCall,
+    ]);
+    expect(message.content, 'answer');
+    expect(message.toolCalls.single.arguments, {'city': 'Madrid'});
+  });
+
+  test('Chat Completions streams parallel same-name calls by index', () {
+    oai.ChatStreamEvent chunk(final List<oai.ToolCallDelta> calls) =>
+        oai.ChatStreamEvent(
+          choices: [
+            oai.ChatStreamChoice(delta: oai.ChatDelta(toolCalls: calls)),
+          ],
+        );
+
+    final starts = chunk(const [
+      oai.ToolCallDelta(
+        index: 0,
+        id: 'call-madrid',
+        function: oai.FunctionCallDelta(name: 'weather'),
+      ),
+      oai.ToolCallDelta(
+        index: 1,
+        id: 'call-paris',
+        function: oai.FunctionCallDelta(name: 'weather'),
+      ),
+    ]).toChatResult('completion-1').output;
+    final arguments = chunk(const [
+      oai.ToolCallDelta(
+        index: 0,
+        function: oai.FunctionCallDelta(arguments: '{"city":"Madrid"}'),
+      ),
+      oai.ToolCallDelta(
+        index: 1,
+        function: oai.FunctionCallDelta(arguments: '{"city":"Paris"}'),
+      ),
+    ]).toChatResult('completion-1').output;
+
+    final calls = starts.concat(arguments).toolCalls;
+
+    expect(calls.map((call) => call.id), ['call-madrid', 'call-paris']);
+    expect(calls.map((call) => call.arguments['city']), ['Madrid', 'Paris']);
+  });
+}

--- a/packages/langchain_openai/test/chat_models/open_router_test.dart
+++ b/packages/langchain_openai/test/chat_models/open_router_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:convert';

--- a/packages/langchain_openai/test/chat_models/together_ai_test.dart
+++ b/packages/langchain_openai/test/chat_models/together_ai_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_openai/test/embeddings/openai_embeddings_test.dart
+++ b/packages/langchain_openai/test/embeddings/openai_embeddings_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_openai/test/embeddings/together_ai_embeddings_test.dart
+++ b/packages/langchain_openai/test/embeddings/together_ai_embeddings_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_openai/test/llms/openai_test.dart
+++ b/packages/langchain_openai/test/llms/openai_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_openai/test/tools/dall_e_test.dart
+++ b/packages/langchain_openai/test/tools/dall_e_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_redundant_argument_values
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';


### PR DESCRIPTION
## Summary

- Migrates OpenAI Chat Completions and Responses API mappers to ordered AI content blocks.
- Preserves reasoning, visible text, function calls, server-tool activity, unsupported output items, and their native order.
- Keeps parallel same-name streamed function calls distinct by provider identity or index.

## Details

Chat Completions maps reasoning, text, and tool-call deltas into independently streamable blocks. Continuation deltas that omit the provider call ID remain correlated by their explicit stream index without inventing a conflicting stable ID.

Responses API output items retain their raw provider representation in namespaced provider data, so server tools and future item types are not silently discarded. Response message content indexes receive distinct identities, function-call argument deltas retain the public call ID, and output-item completion events update the final provider payload without duplicating visible content.

This PR builds on the ordered block model merged in #962.

## Test plan

- [x] Bootstrap the complete workspace using published dependencies only
- [x] Run full-workspace `melos analyze`
- [x] Run all non-live `langchain_openai` tests
- [x] Verify ordered Responses API output and parallel streamed tool calls
- [x] Run live Responses API tests
- [x] Run live Chat Completions tool-call and streamed-function tests
