### PR TITLE
feat(langchain_firebase): preserve ordered AI content

### DIFF
--- a/packages/langchain_firebase/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/langchain_firebase/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,14 @@
 import FlutterMacOS
 import Foundation
 
+import firebase_ai
 import firebase_app_check
 import firebase_auth
 import firebase_core
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  FLTFirebaseAppCheckPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAppCheckPlugin"))
+  FirebaseAIPlugin.register(with: registry.registrar(forPlugin: "FirebaseAIPlugin"))
+  FirebaseAppCheckPlugin.register(with: registry.registrar(forPlugin: "FirebaseAppCheckPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
 }

--- a/packages/langchain_firebase/lib/src/chat_models/firebase_parts_mapper.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/firebase_parts_mapper.dart
@@ -1,0 +1,201 @@
+// ignore_for_file: public_member_api_docs
+import 'dart:convert';
+
+import 'package:firebase_ai/firebase_ai.dart' as f;
+import 'package:langchain_core/chat_models.dart';
+
+List<AIChatMessageContentBlock> firebasePartsToContentBlocks(
+  final List<f.Part> parts, {
+  required final String responseId,
+}) => [
+  for (final (index, part) in parts.indexed)
+    _firebasePartToContentBlock(
+      part,
+      fallbackId: 'firebase:$responseId:0:$index',
+      index: index,
+    ),
+];
+
+String firebasePartsToLegacyContent(final List<f.Part> parts) => parts
+    .map(
+      (part) => switch (part) {
+        final f.TextPart part => part.text,
+        final f.InlineDataPart part => base64Encode(part.bytes),
+        final f.FileData part => part.fileUri,
+        f.Part() => '',
+      },
+    )
+    .join('\n');
+
+List<f.Part> aiMessageToFirebaseParts(final AIChatMessage message) => message
+    .contentBlocks
+    .map(_contentBlockToFirebasePart)
+    .toList(growable: false);
+
+AIChatMessageContentBlock _firebasePartToContentBlock(
+  final f.Part part, {
+  required final String fallbackId,
+  required final int index,
+}) {
+  final rawPart = (part.toJson() as Map).cast<String, dynamic>();
+  final providerData = <String, dynamic>{
+    'firebase': {'part': rawPart},
+  };
+  return switch (part) {
+    final f.TextPart text when text.isThought ?? false =>
+      AIChatMessageReasoningBlock(
+        reasoning: text.text,
+        id: fallbackId,
+        index: index,
+        providerData: providerData,
+      ),
+    final f.TextPart text => AIChatMessageTextBlock(
+      text: text.text,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    final f.InlineDataPart media => AIChatMessageMediaBlock(
+      data: base64Encode(media.bytes),
+      mimeType: media.mimeType,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    final f.FileData file => AIChatMessageFileBlock(
+      uri: file.fileUri,
+      mimeType: file.mimeType,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+    final f.FunctionCall call => AIChatMessageToolCall(
+      id: call.id ?? fallbackId,
+      index: index,
+      name: call.name,
+      argumentsRaw: jsonEncode(call.args),
+      arguments: call.args.cast<String, dynamic>(),
+      providerData: providerData,
+    ),
+    final f.FunctionResponse result => AIChatMessageServerToolResult(
+      id: result.id ?? fallbackId,
+      index: index,
+      toolCallId: result.id ?? fallbackId,
+      name: result.name,
+      result: result.response,
+      providerData: providerData,
+    ),
+    f.ExecutableCodePart() => AIChatMessageServerToolCall(
+      id: fallbackId,
+      index: index,
+      name: 'codeExecution',
+      argumentsRaw: jsonEncode(rawPart['executableCode']),
+      arguments: _readMap(rawPart['executableCode']),
+      providerData: providerData,
+    ),
+    f.CodeExecutionResultPart() => AIChatMessageServerToolResult(
+      id: fallbackId,
+      index: index,
+      toolCallId: fallbackId,
+      name: 'codeExecution',
+      result: rawPart['codeExecutionResult'],
+      providerData: providerData,
+    ),
+    final f.UnknownPart unknown => AIChatMessageNonStandardBlock(
+      value: unknown.data,
+      id: fallbackId,
+      index: index,
+      providerData: providerData,
+    ),
+  };
+}
+
+f.Part _contentBlockToFirebasePart(final AIChatMessageContentBlock block) {
+  final rawPart = switch (block.providerData['firebase']) {
+    {'part': final Map<Object?, Object?> value} =>
+      value.cast<String, dynamic>(),
+    _ => null,
+  };
+  return switch (block) {
+    final AIChatMessageTextBlock text =>
+      rawPart == null
+          ? f.TextPart(text.text)
+          : _firebaseRawPart({...rawPart, 'text': text.text}),
+    final AIChatMessageReasoningBlock reasoning =>
+      rawPart == null
+          ? f.TextPart(reasoning.reasoning, isThought: true)
+          : _firebaseRawPart({
+              ...rawPart,
+              'text': reasoning.reasoning,
+              'thought': true,
+            }),
+    final AIChatMessageMediaBlock media =>
+      rawPart == null
+          ? f.InlineDataPart(media.mimeType ?? '', base64Decode(media.data))
+          : _firebaseRawPart({
+              ...rawPart,
+              'inlineData': {
+                ...?_readNullableMap(rawPart['inlineData']),
+                if (media.mimeType != null) 'mimeType': media.mimeType,
+                'data': media.data,
+              },
+            }),
+    final AIChatMessageFileBlock file =>
+      rawPart == null
+          ? f.FileData(file.mimeType ?? '', file.uri)
+          : _firebaseRawPart({
+              ...rawPart,
+              'file_data': {
+                ...?_readNullableMap(rawPart['file_data']),
+                if (file.mimeType != null) 'mime_type': file.mimeType,
+                'file_uri': file.uri,
+              },
+            }),
+    final AIChatMessageToolCall call =>
+      rawPart == null
+          ? f.FunctionCall(call.name, call.arguments, id: call.id)
+          : _firebaseRawPart({
+              ...rawPart,
+              'functionCall': {
+                ...?_readNullableMap(rawPart['functionCall']),
+                'id': call.id,
+                'name': call.name,
+                'args': call.arguments,
+              },
+            }),
+    AIChatMessageServerToolCall() ||
+    AIChatMessageServerToolResult() ||
+    AIChatMessageProviderMetadataBlock() => _rawFirebasePart(block, rawPart),
+    final AIChatMessageNonStandardBlock nonStandard =>
+      rawPart != null
+          ? _firebaseRawPart(rawPart)
+          : switch (nonStandard.value) {
+              final Map<Object?, Object?> value => _firebaseRawPart(
+                value.cast<String, dynamic>(),
+              ),
+              _ => f.UnknownPart({'value': nonStandard.value}),
+            },
+  };
+}
+
+f.Part _rawFirebasePart(
+  final AIChatMessageContentBlock block,
+  final Map<String, dynamic>? rawPart,
+) {
+  if (rawPart == null) {
+    throw UnsupportedError(
+      '${block.runtimeType} can only be replayed to Firebase when it contains '
+      'providerData["firebase"]["part"]',
+    );
+  }
+  return _firebaseRawPart(rawPart);
+}
+
+f.Part _firebaseRawPart(final Map<String, dynamic> rawPart) =>
+    f.UnknownPart(rawPart.cast<String, Object?>());
+
+Map<String, dynamic> _readMap(final Object? value) =>
+    _readNullableMap(value) ?? const {};
+
+Map<String, dynamic>? _readNullableMap(final Object? value) =>
+    value is Map ? value.cast<String, dynamic>() : null;

--- a/packages/langchain_firebase/lib/src/chat_models/firebase_parts_mapper.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/firebase_parts_mapper.dart
@@ -41,18 +41,22 @@ AIChatMessageContentBlock _firebasePartToContentBlock(
   final providerData = <String, dynamic>{
     'firebase': {'part': rawPart},
   };
+  final isMergeable =
+      part is f.FunctionCall || rawPart['thoughtSignature'] == null;
   return switch (part) {
     final f.TextPart text when text.isThought ?? false =>
       AIChatMessageReasoningBlock(
         reasoning: text.text,
         id: fallbackId,
         index: index,
+        isMergeable: isMergeable,
         providerData: providerData,
       ),
     final f.TextPart text => AIChatMessageTextBlock(
       text: text.text,
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
     final f.InlineDataPart media => AIChatMessageMediaBlock(
@@ -60,6 +64,7 @@ AIChatMessageContentBlock _firebasePartToContentBlock(
       mimeType: media.mimeType,
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
     final f.FileData file => AIChatMessageFileBlock(
@@ -67,11 +72,13 @@ AIChatMessageContentBlock _firebasePartToContentBlock(
       mimeType: file.mimeType,
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
     final f.FunctionCall call => AIChatMessageToolCall(
       id: call.id ?? fallbackId,
       index: index,
+      isMergeable: isMergeable,
       name: call.name,
       argumentsRaw: jsonEncode(call.args),
       arguments: call.args.cast<String, dynamic>(),
@@ -80,6 +87,7 @@ AIChatMessageContentBlock _firebasePartToContentBlock(
     final f.FunctionResponse result => AIChatMessageServerToolResult(
       id: result.id ?? fallbackId,
       index: index,
+      isMergeable: isMergeable,
       toolCallId: result.id ?? fallbackId,
       name: result.name,
       result: result.response,
@@ -88,6 +96,7 @@ AIChatMessageContentBlock _firebasePartToContentBlock(
     f.ExecutableCodePart() => AIChatMessageServerToolCall(
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       name: 'codeExecution',
       argumentsRaw: jsonEncode(rawPart['executableCode']),
       arguments: _readMap(rawPart['executableCode']),
@@ -96,6 +105,7 @@ AIChatMessageContentBlock _firebasePartToContentBlock(
     f.CodeExecutionResultPart() => AIChatMessageServerToolResult(
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       toolCallId: fallbackId,
       name: 'codeExecution',
       result: rawPart['codeExecutionResult'],
@@ -105,6 +115,7 @@ AIChatMessageContentBlock _firebasePartToContentBlock(
       value: unknown.data,
       id: fallbackId,
       index: index,
+      isMergeable: isMergeable,
       providerData: providerData,
     ),
   };

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/chat_firebase_vertex_ai.dart
@@ -318,9 +318,14 @@ class ChatFirebaseVertexAI extends BaseChatModel<ChatFirebaseVertexAIOptions> {
     final effectiveBackend = backend ?? defaultBackend;
 
     final firebaseAI = switch (effectiveBackend) {
+      // Keep supporting explicitly injected Auth and App Check instances while
+      // Firebase transitions callers to FirebaseAI.agentPlatform().
+      // ignore: deprecated_member_use
       FirebaseAIBackend.vertexAI => FirebaseAI.vertexAI(
         app: app,
+        // ignore: deprecated_member_use
         appCheck: appCheck,
+        // ignore: deprecated_member_use
         auth: auth,
         location: location,
       ),

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
@@ -6,6 +6,7 @@ import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/tools.dart';
 
+import '../firebase_parts_mapper.dart';
 import 'types.dart';
 
 extension ChatMessagesMapper on List<ChatMessage> {
@@ -92,14 +93,7 @@ extension ChatMessagesMapper on List<ChatMessage> {
   }
 
   f.Content _mapAIChatMessage(final AIChatMessage msg) {
-    final contentParts = [
-      if (msg.content.isNotEmpty) f.TextPart(msg.content),
-      if (msg.toolCalls.isNotEmpty)
-        ...msg.toolCalls.map(
-          (final call) => f.FunctionCall(call.name, call.arguments),
-        ),
-    ];
-    return f.Content.model(contentParts);
+    return f.Content.model(aiMessageToFirebaseParts(msg));
   }
 
   f.FunctionResponse _toolMsgToFunctionResponse(final ToolChatMessage msg) {
@@ -122,32 +116,12 @@ extension GenerateContentResponseMapper on f.GenerateContentResponse {
     final candidate = candidates.first;
     return ChatResult(
       id: id,
-      output: AIChatMessage(
-        content: candidate.content.parts
-            .map(
-              (p) => switch (p) {
-                final f.TextPart p => p.text,
-                final f.InlineDataPart p => base64Encode(p.bytes),
-                final f.FileData p => p.fileUri,
-                f.FunctionResponse() || f.FunctionCall() => '',
-                f.ExecutableCodePart() => '',
-                f.CodeExecutionResultPart() => '',
-                f.UnknownPart() => '',
-              },
-            )
-            .nonNulls
-            .join('\n'),
-        toolCalls: candidate.content.parts
-            .whereType<f.FunctionCall>()
-            .map(
-              (final call) => AIChatMessageToolCall(
-                id: call.name,
-                name: call.name,
-                argumentsRaw: jsonEncode(call.args),
-                arguments: call.args,
-              ),
-            )
-            .toList(growable: false),
+      output: AIChatMessage.withBlocks(
+        contentBlocks: firebasePartsToContentBlocks(
+          candidate.content.parts,
+          responseId: id,
+        ),
+        legacyContent: firebasePartsToLegacyContent(candidate.content.parts),
       ),
       finishReason: _mapFinishReason(candidate.finishReason),
       metadata: {

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
@@ -161,10 +161,23 @@ extension GenerateContentResponseMapper on f.GenerateContentResponse {
         f.FinishReason.unknown => FinishReason.unspecified,
         f.FinishReason.stop => FinishReason.stop,
         f.FinishReason.maxTokens => FinishReason.length,
-        f.FinishReason.safety => FinishReason.contentFilter,
-        f.FinishReason.recitation => FinishReason.recitation,
-        f.FinishReason.other => FinishReason.unspecified,
+        f.FinishReason.safety ||
+        f.FinishReason.blocklist ||
+        f.FinishReason.prohibitedContent ||
+        f.FinishReason.spii ||
+        f.FinishReason.imageSafety ||
+        f.FinishReason.imageProhibitedContent ||
+        f.FinishReason.language => FinishReason.contentFilter,
+        f.FinishReason.recitation ||
+        f.FinishReason.imageRecitation => FinishReason.recitation,
+        f.FinishReason.other ||
         f.FinishReason.malformedFunctionCall ||
+        f.FinishReason.imageOther ||
+        f.FinishReason.noImage ||
+        f.FinishReason.unexpectedToolCall ||
+        f.FinishReason.tooManyToolCalls ||
+        f.FinishReason.missingThoughtSignature ||
+        f.FinishReason.malformedResponse ||
         null => FinishReason.unspecified,
       };
 }

--- a/packages/langchain_firebase/pubspec.yaml
+++ b/packages/langchain_firebase/pubspec.yaml
@@ -23,7 +23,7 @@ resolution: workspace
 
 dependencies:
   collection: ^1.19.1
-  firebase_ai: ^3.4.0
+  firebase_ai: ^3.15.0
   firebase_app_check: ^0.4.1+1
   firebase_auth: ^6.1.1
   firebase_core: ^4.2.0

--- a/packages/langchain_firebase/pubspec.yaml
+++ b/packages/langchain_firebase/pubspec.yaml
@@ -23,7 +23,7 @@ resolution: workspace
 
 dependencies:
   collection: ^1.19.1
-  firebase_ai: ^3.15.0
+  firebase_ai: ^4.0.0
   firebase_app_check: ^0.4.1+1
   firebase_auth: ^6.1.1
   firebase_core: ^4.2.0

--- a/packages/langchain_firebase/test/chat_models/vertex_ai/mappers_test.dart
+++ b/packages/langchain_firebase/test/chat_models/vertex_ai/mappers_test.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import 'package:firebase_ai/firebase_ai.dart' as f;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_firebase/src/chat_models/vertex_ai/mappers.dart';
+
+void main() {
+  test('preserves ordered parts, thoughts, signatures, and unknown data', () {
+    final signature = base64Encode(utf8.encode('signature'));
+    final parts = <f.Part>[
+      f.TextPart.forTest(
+        'reasoning',
+        isThought: true,
+        thoughtSignature: signature,
+      ),
+      const f.TextPart('answer'),
+      const f.FunctionCall.forTest(
+        'weather',
+        {'city': 'Madrid'},
+        id: 'call-1',
+        thoughtSignature: 'tool-signature',
+      ),
+      f.UnknownPart({
+        'futurePart': {'value': 1},
+      }),
+    ];
+    final response = f.GenerateContentResponse([
+      f.Candidate(f.Content.model(parts), null, null, null, null),
+    ], null);
+
+    final message = response.toChatResult('response-1', 'gemini').output;
+    final replayed = <ChatMessage>[message].toContentList().single.parts;
+
+    expect(message.contentBlocks.map((block) => block.runtimeType), [
+      AIChatMessageReasoningBlock,
+      AIChatMessageTextBlock,
+      AIChatMessageToolCall,
+      AIChatMessageNonStandardBlock,
+    ]);
+    expect(message.toolCalls.single.id, 'call-1');
+    expect(
+      ((message.contentBlocks.first.providerData['firebase']
+              as Map<String, dynamic>)['part']
+          as Map<String, dynamic>)['thoughtSignature'],
+      signature,
+    );
+    expect(
+      (replayed[0].toJson() as Map<String, Object?>)['thoughtSignature'],
+      signature,
+    );
+    expect(
+      (replayed[2].toJson() as Map<String, Object?>)['thoughtSignature'],
+      'tool-signature',
+    );
+  });
+
+  test('keeps parallel same-name calls separate by native id', () {
+    f.GenerateContentResponse chunk(
+      final Map<String, Object?> madrid,
+      final Map<String, Object?> paris,
+    ) => f.GenerateContentResponse([
+      f.Candidate(
+        f.Content.model([
+          f.FunctionCall('weather', madrid, id: 'call-madrid'),
+          f.FunctionCall('weather', paris, id: 'call-paris'),
+        ]),
+        null,
+        null,
+        null,
+        null,
+      ),
+    ], null);
+
+    final starts = chunk(
+      const {},
+      const {},
+    ).toChatResult('response-1', 'gemini').output;
+    final finishes = chunk(
+      const {'city': 'Madrid'},
+      const {'city': 'Paris'},
+    ).toChatResult('response-1', 'gemini').output;
+    final calls = starts.concat(finishes).toolCalls;
+
+    expect(calls.map((call) => call.id), ['call-madrid', 'call-paris']);
+    expect(calls.map((call) => call.arguments['city']), ['Madrid', 'Paris']);
+  });
+}

--- a/packages/langchain_firebase/test/chat_models/vertex_ai/mappers_test.dart
+++ b/packages/langchain_firebase/test/chat_models/vertex_ai/mappers_test.dart
@@ -85,4 +85,39 @@ void main() {
     expect(calls.map((call) => call.id), ['call-madrid', 'call-paris']);
     expect(calls.map((call) => call.arguments['city']), ['Madrid', 'Paris']);
   });
+
+  test('keeps a final signed text part separate while streaming', () {
+    const signature = 'final-text-signature';
+    f.GenerateContentResponse response(final f.Part part) =>
+        f.GenerateContentResponse([
+          f.Candidate(f.Content.model([part]), null, null, null, null),
+        ], null);
+
+    final first = response(
+      const f.TextPart('visible answer'),
+    ).toChatResult('stream-id', 'gemini').output;
+    final signedBoundary = response(
+      const f.TextPart.forTest('', thoughtSignature: signature),
+    ).toChatResult('stream-id', 'gemini').output;
+    final merged = first.concat(signedBoundary);
+
+    expect(merged.contentBlocks, hasLength(2));
+    expect(
+      merged.contentBlocks.last,
+      isA<AIChatMessageTextBlock>()
+          .having((block) => block.text, 'text', isEmpty)
+          .having((block) => block.isMergeable, 'isMergeable', isFalse),
+    );
+
+    final replayed = <ChatMessage>[merged].toContentList().single.parts;
+    expect(replayed, hasLength(2));
+    expect(
+      (replayed.first.toJson() as Map<String, Object?>)['thoughtSignature'],
+      isNull,
+    );
+    expect(
+      (replayed.last.toJson() as Map<String, Object?>)['thoughtSignature'],
+      signature,
+    );
+  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,7 @@ melos:
         csv: ^7.1.0
         anthropic_sdk_dart: ^7.0.0
         equatable: ^2.0.7
-        firebase_ai: ^3.15.0
+        firebase_ai: ^4.0.0
         firebase_app_check: ^0.4.1+1
         firebase_auth: ^6.1.1
         firebase_core: ^4.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,7 @@ melos:
         csv: ^7.1.0
         anthropic_sdk_dart: ^7.0.0
         equatable: ^2.0.7
-        firebase_ai: ^3.4.0
+        firebase_ai: ^3.15.0
         firebase_app_check: ^0.4.1+1
         firebase_auth: ^6.1.1
         firebase_core: ^4.2.0


### PR DESCRIPTION
## Summary

- Migrates Firebase AI chat mapping to ordered AI content blocks.
- Preserves thoughts, signatures, text, inline/file media, function calls and responses, metadata, and unknown native data in their original order.
- Uses native tool-call IDs so parallel same-name calls remain distinct.
- Upgrades to `firebase_ai` 4.0.0.

## Details

Firebase parts are represented as typed LangChain blocks while retaining raw provider data for lossless forward compatibility. Tool-result IDs and function names are mapped separately, matching the structural behavior of the Google providers.

`firebase_ai` 4.0 removes deprecated Imagen APIs that LangChain does not consume. The package resolves with the workspace's existing SDK constraints and requires no LangChain source changes beyond the content mapper.

This PR builds on the OpenAI provider migration merged in #963.

## Test plan

- [x] Bootstrap the complete workspace using published dependencies only
- [x] Resolve `firebase_ai` 4.0.0 and its compatible Firebase dependencies
- [x] Run package source/test/example analysis
- [x] Run non-live `langchain_firebase` tests with Flutter
- [x] Verify ordered `Part` fidelity and parallel same-name tool calls
