### PR TITLE
feat(langchain_mistralai): preserve ordered AI content

### DIFF
--- a/packages/langchain_mistralai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/mappers.dart
@@ -38,7 +38,12 @@ extension ChatMessageListMapper on List<ChatMessage> {
     final hasNativePartData = msg.contentBlocks.any(
       (block) => _nativeContentPart(block) != null,
     );
-    final content = nativeParts.isNotEmpty && hasNativePartData
+    final hasStructuredContent = msg.contentBlocks.any(
+      (block) =>
+          block is! AIChatMessageTextBlock && block is! AIChatMessageToolCall,
+    );
+    final content =
+        nativeParts.isNotEmpty && (hasNativePartData || hasStructuredContent)
         ? mistral.MessageContent.parts(nativeParts)
         : msg.content.isNotEmpty
         ? mistral.MessageContent.text(msg.content)
@@ -320,6 +325,7 @@ List<AIChatMessageContentBlock> _mapDeltaContent(
         toolCall,
         responseId: responseId,
         fallbackIndex: fallbackIndex,
+        useFallbackId: false,
       ),
   ];
   if (blocks.isEmpty && raw.isNotEmpty) {
@@ -340,6 +346,7 @@ AIChatMessageToolCall _mapMistralToolCall(
   final mistral.ToolCall toolCall, {
   required final String responseId,
   required final int fallbackIndex,
+  final bool useFallbackId = true,
 }) {
   final function = toolCall.function;
   final index = toolCall.index ?? fallbackIndex;
@@ -351,9 +358,13 @@ AIChatMessageToolCall _mapMistralToolCall(
     }
   } catch (_) {}
   return AIChatMessageToolCall(
+    // Continuation deltas commonly omit the provider ID. In streams the
+    // explicit index is the correlation key until the opening ID is known.
     id: toolCall.id.isNotEmpty
         ? toolCall.id
-        : 'mistral:$responseId:tool:$index',
+        : useFallbackId
+        ? 'mistral:$responseId:tool:$index'
+        : '',
     index: index,
     name: function.name,
     argumentsRaw: function.arguments,

--- a/packages/langchain_mistralai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/mappers.dart
@@ -17,15 +17,7 @@ extension ChatMessageListMapper on List<ChatMessage> {
       final HumanChatMessage msg => mistral.ChatMessage.user(
         msg.contentAsString,
       ),
-      final AIChatMessage msg =>
-        msg.toolCalls.isNotEmpty
-            ? mistral.ChatMessage.assistant(
-                msg.content.isNotEmpty ? msg.content : null,
-                toolCalls: msg.toolCalls
-                    .map(_mapToolCall)
-                    .toList(growable: false),
-              )
-            : mistral.ChatMessage.assistant(msg.content),
+      final AIChatMessage msg => _mapAIMessage(msg),
       final ToolChatMessage msg => mistral.ChatMessage.tool(
         toolCallId: msg.toolCallId,
         content: msg.content,
@@ -37,12 +29,53 @@ extension ChatMessageListMapper on List<ChatMessage> {
     };
   }
 
+  mistral.AssistantMessage _mapAIMessage(final AIChatMessage msg) {
+    final nativeParts = msg.contentBlocks
+        .where((block) => block is! AIChatMessageToolCall)
+        .map(_mapContentBlock)
+        .nonNulls
+        .toList(growable: false);
+    final hasNativePartData = msg.contentBlocks.any(
+      (block) => _nativeContentPart(block) != null,
+    );
+    final content = nativeParts.isNotEmpty && hasNativePartData
+        ? mistral.MessageContent.parts(nativeParts)
+        : msg.content.isNotEmpty
+        ? mistral.MessageContent.text(msg.content)
+        : null;
+    return mistral.AssistantMessage(
+      content: content,
+      toolCalls: msg.toolCalls.isNotEmpty
+          ? msg.toolCalls.map(_mapToolCall).toList(growable: false)
+          : null,
+    );
+  }
+
+  mistral.ContentPart? _mapContentBlock(final AIChatMessageContentBlock block) {
+    final native = _nativeContentPart(block);
+    if (native != null) return mistral.ContentPart.fromJson(native);
+    return switch (block) {
+      final AIChatMessageTextBlock block => mistral.TextContentPart(block.text),
+      final AIChatMessageReasoningBlock block => mistral.ThinkContentPart(
+        thinking: [mistral.TextContentPart(block.reasoning)],
+        closed: true,
+      ),
+      final AIChatMessageNonStandardBlock block
+          when block.value is Map<String, dynamic> =>
+        mistral.UnknownContentPart(block.value! as Map<String, dynamic>),
+      _ => null,
+    };
+  }
+
   mistral.ToolCall _mapToolCall(final AIChatMessageToolCall toolCall) {
     return mistral.ToolCall(
       id: toolCall.id,
+      index: toolCall.index,
       function: mistral.FunctionCall(
         name: toolCall.name,
-        arguments: json.encode(toolCall.arguments),
+        arguments: toolCall.argumentsRaw.isNotEmpty
+            ? toolCall.argumentsRaw
+            : json.encode(toolCall.arguments),
       ),
     );
   }
@@ -75,35 +108,41 @@ extension ChatToolChoiceMapper on ChatToolChoice {
 
 extension ChatResultMapper on mistral.ChatCompletionResponse {
   ChatResult toChatResult({final bool streaming = false}) {
+    final choice = firstChoice;
+    final message = choice?.message;
+    final contentBlocks = <AIChatMessageContentBlock>[
+      ..._mapMessageContent(
+        message?.content,
+        responseId: id,
+        choiceIndex: choice?.index ?? 0,
+      ),
+      for (final (fallbackIndex, toolCall)
+          in (message?.toolCalls ?? const <mistral.ToolCall>[]).indexed)
+        _mapMistralToolCall(
+          toolCall,
+          responseId: id,
+          fallbackIndex: fallbackIndex,
+        ),
+      if (message == null)
+        for (final (deltaIndex, delta)
+            in (choice?.messages ?? const <mistral.DeltaContent>[]).indexed)
+          ..._mapDeltaContent(
+            delta,
+            responseId: id,
+            choiceIndex: choice?.index ?? 0,
+            deltaIndex: deltaIndex,
+          ),
+    ];
     return ChatResult(
       id: id,
-      output: AIChatMessage(
-        content: text ?? '',
-        toolCalls: hasToolCalls
-            ? toolCalls.map(_mapResponseToolCall).toList(growable: false)
-            : const [],
+      output: AIChatMessage.withBlocks(
+        contentBlocks: contentBlocks,
+        legacyContent: _visibleText(contentBlocks),
       ),
       finishReason: _mapFinishReason(finishReason),
       metadata: {'model': model, 'created': created},
       usage: _mapUsage(usage),
       streaming: streaming,
-    );
-  }
-
-  AIChatMessageToolCall _mapResponseToolCall(final mistral.ToolCall toolCall) {
-    final function = toolCall.function;
-    var args = <String, dynamic>{};
-    try {
-      final arguments = function.arguments;
-      if (arguments.isNotEmpty) {
-        args = json.decode(arguments);
-      }
-    } catch (_) {}
-    return AIChatMessageToolCall(
-      id: toolCall.id,
-      name: function.name,
-      argumentsRaw: function.arguments,
-      arguments: args,
     );
   }
 
@@ -121,35 +160,25 @@ extension CreateChatCompletionStreamResponseMapper
     on mistral.ChatCompletionStreamResponse {
   /// Converts a [mistral.ChatCompletionStreamResponse] to a [ChatResult].
   ChatResult toChatResult() {
+    final choice = firstChoice;
+    final contentBlocks = choice == null
+        ? const <AIChatMessageContentBlock>[]
+        : _mapDeltaContent(
+            choice.delta,
+            responseId: id,
+            choiceIndex: choice.index,
+            deltaIndex: 0,
+          );
     return ChatResult(
       id: id,
-      output: AIChatMessage(
-        content: text ?? '',
-        toolCalls: hasToolCalls
-            ? toolCalls.map(_mapStreamToolCall).toList(growable: false)
-            : const [],
+      output: AIChatMessage.withBlocks(
+        contentBlocks: contentBlocks,
+        legacyContent: choice?.delta.content ?? '',
       ),
       finishReason: _mapFinishReason(finishReason),
       metadata: {'model': model, 'created': created},
       usage: _mapStreamUsage(usage),
       streaming: true,
-    );
-  }
-
-  AIChatMessageToolCall _mapStreamToolCall(final mistral.ToolCall toolCall) {
-    final function = toolCall.function;
-    var args = <String, dynamic>{};
-    try {
-      final arguments = function.arguments;
-      if (arguments.isNotEmpty) {
-        args = json.decode(arguments);
-      }
-    } catch (_) {}
-    return AIChatMessageToolCall(
-      id: toolCall.id,
-      name: function.name,
-      argumentsRaw: function.arguments,
-      arguments: args,
     );
   }
 
@@ -161,6 +190,203 @@ extension CreateChatCompletionStreamResponseMapper
     );
   }
 }
+
+List<AIChatMessageContentBlock> _mapMessageContent(
+  final mistral.MessageContent? content, {
+  required final String responseId,
+  required final int choiceIndex,
+}) => switch (content) {
+  final mistral.MessageTextContent content when content.text.isNotEmpty => [
+    AIChatMessageTextBlock(
+      text: content.text,
+      id: 'mistral:$responseId:$choiceIndex:content:0',
+      index: 0,
+      providerData: {
+        'mistral': {'messageContent': content.toJson()},
+      },
+    ),
+  ],
+  final mistral.MessagePartsContent content => [
+    for (final (index, part) in content.parts.indexed)
+      _mapMistralContentPart(
+        part,
+        responseId: responseId,
+        choiceIndex: choiceIndex,
+        index: index,
+      ),
+  ],
+  _ => const [],
+};
+
+AIChatMessageContentBlock _mapMistralContentPart(
+  final mistral.ContentPart part, {
+  required final String responseId,
+  required final int choiceIndex,
+  required final int index,
+}) {
+  final id = 'mistral:$responseId:$choiceIndex:content:$index';
+  final providerData = {
+    'mistral': {'contentPart': part.toJson()},
+  };
+  return switch (part) {
+    final mistral.TextContentPart part => AIChatMessageTextBlock(
+      text: part.text,
+      id: id,
+      index: index,
+      providerData: providerData,
+    ),
+    final mistral.ThinkContentPart part => AIChatMessageReasoningBlock(
+      reasoning: _contentPartsText(part.thinking),
+      id: id,
+      index: index,
+      providerData: providerData,
+    ),
+    final mistral.ImageUrlContentPart part => AIChatMessageMediaBlock(
+      data: part.url,
+      id: id,
+      index: index,
+      providerData: providerData,
+    ),
+    final mistral.AudioContentPart part => AIChatMessageMediaBlock(
+      data: part.inputAudio,
+      id: id,
+      index: index,
+      providerData: providerData,
+    ),
+    final mistral.DocumentUrlContentPart part => AIChatMessageFileBlock(
+      uri: part.documentUrl,
+      name: part.documentName,
+      id: id,
+      index: index,
+      providerData: providerData,
+    ),
+    final mistral.FileContentPart part => AIChatMessageFileBlock(
+      uri: part.fileId,
+      id: id,
+      index: index,
+      providerData: providerData,
+    ),
+    final mistral.ToolFileContentPart part => AIChatMessageServerToolResult(
+      toolCallId: '',
+      name: part.tool,
+      result: part.toJson(),
+      id: id,
+      index: index,
+      providerData: providerData,
+    ),
+    final mistral.ToolReferenceContentPart part =>
+      AIChatMessageServerToolResult(
+        toolCallId: '',
+        name: part.tool,
+        result: part.toJson(),
+        id: id,
+        index: index,
+        providerData: providerData,
+      ),
+    mistral.ReferenceContentPart() => AIChatMessageProviderMetadataBlock(
+      id: id,
+      index: index,
+      providerData: providerData,
+    ),
+    final mistral.UnknownContentPart part => AIChatMessageNonStandardBlock(
+      value: part.raw,
+      id: id,
+      index: index,
+      providerData: providerData,
+    ),
+  };
+}
+
+List<AIChatMessageContentBlock> _mapDeltaContent(
+  final mistral.DeltaContent delta, {
+  required final String responseId,
+  required final int choiceIndex,
+  required final int deltaIndex,
+}) {
+  final raw = delta.toJson();
+  final blocks = <AIChatMessageContentBlock>[
+    if ((delta.content ?? '').isNotEmpty)
+      AIChatMessageTextBlock(
+        text: delta.content!,
+        id: 'mistral:$responseId:$choiceIndex:message:$deltaIndex:text',
+        index: delta.index ?? deltaIndex,
+        providerData: {
+          'mistral': {'delta': raw},
+        },
+      ),
+    for (final (fallbackIndex, toolCall)
+        in (delta.toolCalls ?? const <mistral.ToolCall>[]).indexed)
+      _mapMistralToolCall(
+        toolCall,
+        responseId: responseId,
+        fallbackIndex: fallbackIndex,
+      ),
+  ];
+  if (blocks.isEmpty && raw.isNotEmpty) {
+    blocks.add(
+      AIChatMessageProviderMetadataBlock(
+        id: 'mistral:$responseId:$choiceIndex:message:$deltaIndex:metadata',
+        index: delta.index ?? deltaIndex,
+        providerData: {
+          'mistral': {'delta': raw},
+        },
+      ),
+    );
+  }
+  return blocks;
+}
+
+AIChatMessageToolCall _mapMistralToolCall(
+  final mistral.ToolCall toolCall, {
+  required final String responseId,
+  required final int fallbackIndex,
+}) {
+  final function = toolCall.function;
+  final index = toolCall.index ?? fallbackIndex;
+  var args = <String, dynamic>{};
+  try {
+    final arguments = function.arguments;
+    if (arguments.isNotEmpty) {
+      args = (json.decode(arguments) as Map).cast<String, dynamic>();
+    }
+  } catch (_) {}
+  return AIChatMessageToolCall(
+    id: toolCall.id.isNotEmpty
+        ? toolCall.id
+        : 'mistral:$responseId:tool:$index',
+    index: index,
+    name: function.name,
+    argumentsRaw: function.arguments,
+    arguments: args,
+    providerData: {
+      'mistral': {'toolCall': toolCall.toJson()},
+    },
+  );
+}
+
+Map<String, dynamic>? _nativeContentPart(
+  final AIChatMessageContentBlock block,
+) {
+  final mistralData = block.providerData['mistral'];
+  if (mistralData is! Map) return null;
+  final contentPart = mistralData['contentPart'];
+  return contentPart is Map ? contentPart.cast<String, dynamic>() : null;
+}
+
+String _contentPartsText(final List<mistral.ContentPart> parts) => parts
+    .map(
+      (part) => switch (part) {
+        final mistral.TextContentPart part => part.text,
+        final mistral.ThinkContentPart part => _contentPartsText(part.thinking),
+        _ => '',
+      },
+    )
+    .join();
+
+String _visibleText(final List<AIChatMessageContentBlock> blocks) => blocks
+    .whereType<AIChatMessageTextBlock>()
+    .map((block) => block.text)
+    .join();
 
 FinishReason _mapFinishReason(final mistral.FinishReason? reason) =>
     switch (reason) {

--- a/packages/langchain_mistralai/pubspec.yaml
+++ b/packages/langchain_mistralai/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   langchain_core: 0.4.1
   langchain_tiktoken: ^1.0.1
   meta: ^1.16.0
-  mistralai_dart: ^1.3.0
+  mistralai_dart: ^6.1.0
 
 dev_dependencies:
   langchain: ^0.8.1

--- a/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
+++ b/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_mistralai/test/chat_models/mappers_content_blocks_test.dart
+++ b/packages/langchain_mistralai/test/chat_models/mappers_content_blocks_test.dart
@@ -107,6 +107,22 @@ void main() {
     );
   });
 
+  test('replays explicitly constructed reasoning as structured content', () {
+    const message = AIChatMessage.withBlocks(
+      contentBlocks: [
+        AIChatMessageReasoningBlock(reasoning: 'reasoning'),
+        AIChatMessageTextBlock(text: 'answer'),
+      ],
+    );
+
+    final mapped =
+        [message].toChatMessages().single as mistral.AssistantMessage;
+    final parts = (mapped.content! as mistral.MessagePartsContent).parts;
+
+    expect(parts.first, isA<mistral.ThinkContentPart>());
+    expect(parts.last, const mistral.TextContentPart('answer'));
+  });
+
   test('streams parallel same-name calls by provider index', () {
     mistral.ChatCompletionStreamResponse chunk(
       final List<mistral.ToolCall> calls,

--- a/packages/langchain_mistralai/test/chat_models/mappers_content_blocks_test.dart
+++ b/packages/langchain_mistralai/test/chat_models/mappers_content_blocks_test.dart
@@ -1,0 +1,159 @@
+import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_mistralai/src/chat_models/mappers.dart';
+import 'package:mistralai_dart/mistralai_dart.dart' as mistral;
+import 'package:test/test.dart';
+
+void main() {
+  test('preserves ordered text and tool-call content', () {
+    const response = mistral.ChatCompletionResponse(
+      id: 'completion-1',
+      object: 'chat.completion',
+      created: 1,
+      model: 'mistral-small-latest',
+      choices: [
+        mistral.ChatChoice(
+          index: 0,
+          message: mistral.AssistantMessage(
+            content: mistral.MessageContent.text('Checking the weather.'),
+            toolCalls: [
+              mistral.ToolCall(
+                id: 'call-1',
+                index: 0,
+                function: mistral.FunctionCall(
+                  name: 'weather',
+                  arguments: '{"city":"Madrid"}',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    final message = response.toChatResult().output;
+
+    expect(message.contentBlocks.map((block) => block.runtimeType), [
+      AIChatMessageTextBlock,
+      AIChatMessageToolCall,
+    ]);
+    expect(message.content, 'Checking the weather.');
+    expect(message.toolCalls.single.arguments, {'city': 'Madrid'});
+    final providerData =
+        message.toolCalls.single.providerData['mistral']
+            as Map<String, dynamic>;
+    final toolCallData = providerData['toolCall'] as Map<String, dynamic>;
+    expect(toolCallData['index'], 0);
+  });
+
+  test('preserves reasoning and unknown content parts for replay', () {
+    final response = mistral.ChatCompletionResponse(
+      id: 'completion-1',
+      object: 'chat.completion',
+      created: 1,
+      model: 'magistral-small-latest',
+      choices: [
+        mistral.ChatChoice(
+          index: 0,
+          message: mistral.AssistantMessage(
+            content: mistral.MessageContent.parts([
+              const mistral.ThinkContentPart(
+                thinking: [mistral.TextContentPart('reasoning')],
+                closed: true,
+                signature: 'opaque-signature',
+              ),
+              const mistral.TextContentPart('answer'),
+              mistral.UnknownContentPart(const {
+                'type': 'future_content',
+                'value': 42,
+              }),
+            ]),
+          ),
+        ),
+      ],
+    );
+
+    final message = response.toChatResult().output;
+    final replayed =
+        [message].toChatMessages().single as mistral.AssistantMessage;
+
+    expect(message.contentBlocks.map((block) => block.runtimeType), [
+      AIChatMessageReasoningBlock,
+      AIChatMessageTextBlock,
+      AIChatMessageNonStandardBlock,
+    ]);
+    expect(message.content, 'answer');
+    final original = response.message! as mistral.AssistantMessage;
+    expect(replayed.content!.toJson(), original.content!.toJson());
+  });
+
+  test('replays raw tool-call arguments', () {
+    const message = AIChatMessage.withBlocks(
+      contentBlocks: [
+        AIChatMessageToolCall(
+          id: 'call-1',
+          name: 'weather',
+          argumentsRaw: '{ "city" : "Madrid" }',
+          arguments: {'city': 'Madrid'},
+        ),
+      ],
+    );
+
+    final mapped =
+        [message].toChatMessages().single as mistral.AssistantMessage;
+
+    expect(
+      mapped.toolCalls!.single.function.arguments,
+      '{ "city" : "Madrid" }',
+    );
+  });
+
+  test('streams parallel same-name calls by provider index', () {
+    mistral.ChatCompletionStreamResponse chunk(
+      final List<mistral.ToolCall> calls,
+    ) => mistral.ChatCompletionStreamResponse(
+      id: 'completion-1',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'mistral-small-latest',
+      choices: [
+        mistral.ChatChoiceDelta(
+          index: 0,
+          delta: mistral.DeltaContent(toolCalls: calls),
+        ),
+      ],
+    );
+
+    final starts = chunk(const [
+      mistral.ToolCall(
+        id: 'call-madrid',
+        index: 0,
+        function: mistral.FunctionCall(name: 'weather', arguments: ''),
+      ),
+      mistral.ToolCall(
+        id: 'call-paris',
+        index: 1,
+        function: mistral.FunctionCall(name: 'weather', arguments: ''),
+      ),
+    ]).toChatResult().output;
+    final arguments = chunk(const [
+      mistral.ToolCall(
+        id: '',
+        index: 0,
+        function: mistral.FunctionCall(
+          name: '',
+          arguments: '{"city":"Madrid"}',
+        ),
+      ),
+      mistral.ToolCall(
+        id: '',
+        index: 1,
+        function: mistral.FunctionCall(name: '', arguments: '{"city":"Paris"}'),
+      ),
+    ]).toChatResult().output;
+
+    final calls = starts.concat(arguments).toolCalls;
+
+    expect(calls.map((call) => call.id), ['call-madrid', 'call-paris']);
+    expect(calls.map((call) => call.arguments['city']), ['Madrid', 'Paris']);
+  });
+}

--- a/packages/langchain_mistralai/test/embeddings/mistralai_embeddings_test.dart
+++ b/packages/langchain_mistralai/test/embeddings/mistralai_embeddings_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,7 +85,7 @@ melos:
         logging: ^1.3.0
         math_expressions: ^3.0.0
         meta: ^1.16.0
-        mistralai_dart: ^1.3.0
+        mistralai_dart: ^6.1.0
         objectbox: ^5.1.0
         ollama_dart: ^1.4.0
         openai_dart: ^1.4.0


### PR DESCRIPTION
## Summary

- Migrates Mistral chat mapping to ordered AI content blocks.
- Preserves thinking/signature content, text, media, files, references, raw tool arguments, and unknown native content.
- Requires the published `mistralai_dart ^6.1.0` client so streamed tool-call indexes provide stable identity.

## Details

Native content order and unsupported payloads are retained instead of flattened or dropped. Streaming continuation chunks without a provider call ID use the official provider index, preventing one logical call from splitting while keeping concurrent same-name calls distinct.

Explicitly constructed reasoning blocks also force structured native content, even when they do not already carry Mistral provider data.

The package and centralized Melos constraints both declare the required 6.1.0 minimum. This PR builds on the Firebase provider migration merged in #964.

## References

- Client support for streamed tool-call indexes: davidmigloz/ai_clients_dart#295.

## Test plan

- [x] Resolve `mistralai_dart` 6.1.0 from pub.dev without overrides
- [x] Run full-workspace `melos analyze`
- [x] Run all non-live `langchain_mistralai` tests
- [x] Verify ordered reasoning/tool replay and parallel same-name streams
- [x] Run live Mistral chat and streaming tests
