### PR TITLE
feat(langchain_ollama): preserve ordered AI content

### DIFF
--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama/mappers.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama/mappers.dart
@@ -6,9 +6,9 @@ import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:langchain_core/tools.dart';
 import 'package:ollama_dart/ollama_dart.dart' as o;
-import 'package:uuid/uuid.dart';
 
 import '../../llms/types.dart';
+import '../../utils.dart';
 import 'chat_ollama.dart';
 import 'types.dart';
 
@@ -41,7 +41,7 @@ o.ChatRequest createChatRequest(
     model: options?.model ?? defaultOptions.model ?? ChatOllama.defaultModel,
     messages: messages.toMessages(),
     format: (options?.format ?? defaultOptions.format)?.toChatFormat(),
-    keepAlive: options?.keepAlive ?? defaultOptions.keepAlive,
+    keepAlive: mapKeepAlive(options?.keepAlive ?? defaultOptions.keepAlive),
     think: (options?.think ?? defaultOptions.think)?.toThinkValue(),
     tools: _mapTools(
       tools: options?.tools ?? defaultOptions.tools,
@@ -55,7 +55,7 @@ o.ChatRequest createChatRequest(
       topP: options?.topP ?? defaultOptions.topP,
       minP: options?.minP ?? defaultOptions.minP,
       temperature: options?.temperature ?? defaultOptions.temperature,
-      stop: options?.stop ?? defaultOptions.stop,
+      stop: mapStopSequences(options?.stop ?? defaultOptions.stop),
       numCtx: options?.numCtx ?? defaultOptions.numCtx,
       numKeep: options?.numKeep ?? defaultOptions.numKeep,
       tfsZ: options?.tfsZ ?? defaultOptions.tfsZ,
@@ -178,9 +178,24 @@ extension OllamaChatMessagesMapper on List<ChatMessage> {
   }
 
   List<o.ChatMessage> _mapAIMessage(final AIChatMessage message) {
+    final reasoning = message.contentBlocks
+        .whereType<AIChatMessageReasoningBlock>()
+        .map((block) => block.reasoning)
+        .join();
+    final content = message.contentBlocks
+        .whereType<AIChatMessageTextBlock>()
+        .map((block) => block.text)
+        .join();
+    final images = message.contentBlocks
+        .whereType<AIChatMessageMediaBlock>()
+        .map((block) => block.data)
+        .toList(growable: false);
     return [
-      o.ChatMessage.assistant(
-        message.content,
+      o.ChatMessage(
+        role: o.MessageRole.assistant,
+        content: content,
+        thinking: reasoning.isNotEmpty ? reasoning : null,
+        images: images.isNotEmpty ? images : null,
         toolCalls: message.toolCalls.isNotEmpty
             ? message.toolCalls.map(_mapToolCall).toList(growable: false)
             : null,
@@ -200,21 +215,18 @@ extension OllamaChatMessagesMapper on List<ChatMessage> {
 
 extension ChatResultMapper on o.ChatResponse {
   ChatResult toChatResult(final String id, {final bool streaming = false}) {
-    final content = [
-      if (message?.thinking != null) message!.thinking!,
-      message?.content ?? '',
-    ].join('');
+    final contentBlocks = _mapOllamaMessage(message, responseId: id);
     return ChatResult(
       id: id,
-      output: AIChatMessage(
-        content: content,
-        toolCalls:
-            message?.toolCalls?.map(_mapToolCall).toList(growable: false) ??
-            const [],
+      output: AIChatMessage.withBlocks(
+        contentBlocks: contentBlocks,
+        legacyContent: '${message?.thinking ?? ''}${message?.content ?? ''}',
       ),
       finishReason: _mapFinishReason(doneReason),
       metadata: {
         'model': model,
+        'remote_model': remoteModel,
+        'remote_host': remoteHost,
         'created_at': createdAt,
         'done': done,
         'total_duration': totalDuration,
@@ -223,18 +235,10 @@ extension ChatResultMapper on o.ChatResponse {
         'prompt_eval_duration': promptEvalDuration,
         'eval_count': evalCount,
         'eval_duration': evalDuration,
+        'logprobs': logprobs?.map((item) => item.toJson()).toList(),
       },
       usage: _mapUsage(),
       streaming: streaming,
-    );
-  }
-
-  AIChatMessageToolCall _mapToolCall(final o.ToolCall toolCall) {
-    return AIChatMessageToolCall(
-      id: const Uuid().v4(),
-      name: toolCall.function?.name ?? '',
-      argumentsRaw: json.encode(toolCall.function?.arguments ?? const {}),
-      arguments: toolCall.function?.arguments ?? const {},
     );
   }
 
@@ -259,33 +263,104 @@ extension ChatResultMapper on o.ChatResponse {
 
 extension ChatStreamResultMapper on o.ChatStreamEvent {
   ChatResult toChatResult(final String id, {final bool streaming = false}) {
-    final content = [
-      if (message?.thinking != null) message!.thinking!,
-      message?.content ?? '',
-    ].join('');
+    final contentBlocks = _mapOllamaMessage(message, responseId: id);
     return ChatResult(
       id: id,
-      output: AIChatMessage(
-        content: content,
-        toolCalls:
-            message?.toolCalls?.map(_mapToolCall).toList(growable: false) ??
-            const [],
+      output: AIChatMessage.withBlocks(
+        contentBlocks: contentBlocks,
+        legacyContent: '${message?.thinking ?? ''}${message?.content ?? ''}',
       ),
-      finishReason: (done ?? false)
+      finishReason: doneReason != null
+          ? _mapOllamaFinishReason(doneReason)
+          : (done ?? false)
           ? FinishReason.stop
           : FinishReason.unspecified,
-      metadata: {'model': model, 'created_at': createdAt, 'done': done},
-      usage: const LanguageModelUsage(),
+      metadata: {
+        'model': model,
+        'remote_model': remoteModel,
+        'remote_host': remoteHost,
+        'created_at': createdAt,
+        'done': done,
+        'total_duration': totalDuration,
+        'load_duration': loadDuration,
+        'prompt_eval_count': promptEvalCount,
+        'prompt_eval_duration': promptEvalDuration,
+        'eval_count': evalCount,
+        'eval_duration': evalDuration,
+        'logprobs': logprobs?.map((item) => item.toJson()).toList(),
+      },
+      usage: LanguageModelUsage(
+        promptTokens: promptEvalCount,
+        responseTokens: evalCount,
+        totalTokens: (promptEvalCount != null || evalCount != null)
+            ? (promptEvalCount ?? 0) + (evalCount ?? 0)
+            : null,
+      ),
       streaming: streaming,
     );
   }
-
-  AIChatMessageToolCall _mapToolCall(final o.ToolCall toolCall) {
-    return AIChatMessageToolCall(
-      id: const Uuid().v4(),
-      name: toolCall.function?.name ?? '',
-      argumentsRaw: json.encode(toolCall.function?.arguments ?? const {}),
-      arguments: toolCall.function?.arguments ?? const {},
-    );
-  }
 }
+
+List<AIChatMessageContentBlock> _mapOllamaMessage(
+  final o.ChatResponseMessage? message, {
+  required final String responseId,
+}) {
+  if (message == null) return const [];
+  final rawMessage = message.toJson();
+  final providerData = {
+    'ollama': {'message': rawMessage},
+  };
+  return [
+    if ((message.thinking ?? '').isNotEmpty)
+      AIChatMessageReasoningBlock(
+        reasoning: message.thinking!,
+        id: 'ollama:$responseId:thinking',
+        index: 0,
+        providerData: providerData,
+      ),
+    if ((message.content ?? '').isNotEmpty)
+      AIChatMessageTextBlock(
+        text: message.content!,
+        id: 'ollama:$responseId:content',
+        index: 1,
+        providerData: providerData,
+      ),
+    for (final (index, image) in (message.images ?? const <String>[]).indexed)
+      AIChatMessageMediaBlock(
+        data: image,
+        id: 'ollama:$responseId:image:$index',
+        index: index + 2,
+        providerData: providerData,
+      ),
+    for (final (index, toolCall)
+        in (message.toolCalls ?? const <o.ToolCall>[]).indexed)
+      _mapOllamaToolCall(toolCall, responseId: responseId, index: index),
+  ];
+}
+
+AIChatMessageToolCall _mapOllamaToolCall(
+  final o.ToolCall toolCall, {
+  required final String responseId,
+  required final int index,
+}) {
+  final arguments = toolCall.function?.arguments ?? const <String, dynamic>{};
+  return AIChatMessageToolCall(
+    id: 'ollama:$responseId:tool:$index',
+    index: index,
+    name: toolCall.function?.name ?? '',
+    argumentsRaw: json.encode(arguments),
+    arguments: arguments,
+    providerData: {
+      'ollama': {'toolCall': toolCall.toJson()},
+    },
+  );
+}
+
+FinishReason _mapOllamaFinishReason(final o.DoneReason? reason) =>
+    switch (reason) {
+      o.DoneReason.stop => FinishReason.stop,
+      o.DoneReason.length => FinishReason.length,
+      o.DoneReason.load => FinishReason.unspecified,
+      o.DoneReason.unload => FinishReason.unspecified,
+      null => FinishReason.unspecified,
+    };

--- a/packages/langchain_ollama/lib/src/embeddings/ollama_embeddings.dart
+++ b/packages/langchain_ollama/lib/src/embeddings/ollama_embeddings.dart
@@ -4,6 +4,8 @@ import 'package:langchain_core/embeddings.dart';
 import 'package:langchain_core/language_models.dart';
 import 'package:ollama_dart/ollama_dart.dart';
 
+import '../utils.dart';
+
 /// Wrapper around [Ollama](https://ollama.ai) Embeddings API.
 ///
 /// Ollama allows you to run open-source large language models,
@@ -115,8 +117,10 @@ class OllamaEmbeddings extends Embeddings {
     final data = await _client.embeddings.create(
       request: EmbedRequest(
         model: model,
-        input: documents.map((final doc) => doc.pageContent).toList(),
-        keepAlive: keepAlive?.toString(),
+        input: EmbedInput.list(
+          documents.map((final doc) => doc.pageContent).toList(),
+        ),
+        keepAlive: mapKeepAlive(keepAlive),
       ),
     );
     return data.embeddings ?? [];
@@ -127,8 +131,8 @@ class OllamaEmbeddings extends Embeddings {
     final data = await _client.embeddings.create(
       request: EmbedRequest(
         model: model,
-        input: query,
-        keepAlive: keepAlive?.toString(),
+        input: EmbedInput.string(query),
+        keepAlive: mapKeepAlive(keepAlive),
       ),
     );
     return data.embedding ?? [];

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -6,6 +6,7 @@ import 'package:langchain_tiktoken/langchain_tiktoken.dart';
 import 'package:ollama_dart/ollama_dart.dart';
 import 'package:uuid/uuid.dart';
 
+import '../utils.dart';
 import 'mappers.dart';
 import 'types.dart';
 
@@ -227,7 +228,7 @@ class Ollama extends BaseLLM<OllamaOptions> {
       context: options?.context ?? defaultOptions.context,
       format: (options?.format ?? defaultOptions.format)?.toFormat(),
       raw: options?.raw ?? defaultOptions.raw,
-      keepAlive: options?.keepAlive ?? defaultOptions.keepAlive,
+      keepAlive: mapKeepAlive(options?.keepAlive ?? defaultOptions.keepAlive),
       think: (options?.think ?? defaultOptions.think)?.toThinkValue(),
       stream: stream,
       options: ModelOptions(
@@ -237,7 +238,7 @@ class Ollama extends BaseLLM<OllamaOptions> {
         topP: options?.topP ?? defaultOptions.topP,
         minP: options?.minP ?? defaultOptions.minP,
         temperature: options?.temperature ?? defaultOptions.temperature,
-        stop: options?.stop ?? defaultOptions.stop,
+        stop: mapStopSequences(options?.stop ?? defaultOptions.stop),
         numCtx: options?.numCtx ?? defaultOptions.numCtx,
         numKeep: options?.numKeep ?? defaultOptions.numKeep,
         tfsZ: options?.tfsZ ?? defaultOptions.tfsZ,

--- a/packages/langchain_ollama/lib/src/utils.dart
+++ b/packages/langchain_ollama/lib/src/utils.dart
@@ -1,0 +1,12 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:ollama_dart/ollama_dart.dart';
+
+KeepAlive? mapKeepAlive(final int? value) => switch (value) {
+  null => null,
+  <= 0 => KeepAlive.number(value),
+  _ => KeepAlive.duration('${value}m'),
+};
+
+StopSequence? mapStopSequences(final List<String>? values) =>
+    values == null ? null : StopSequence.list(values);

--- a/packages/langchain_ollama/pubspec.yaml
+++ b/packages/langchain_ollama/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   langchain_core: 0.4.1
   langchain_tiktoken: ^1.0.1
   meta: ^1.16.0
-  ollama_dart: ^1.4.0
+  ollama_dart: ^2.6.0
   uuid: ^4.5.1
 
 dev_dependencies:

--- a/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
+++ b/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
@@ -1,3 +1,6 @@
+@Tags(['integration'])
+library;
+
 // ignore_for_file: avoid_redundant_argument_values
 import 'dart:convert';
 import 'dart:io';

--- a/packages/langchain_ollama/test/chat_models/mappers_content_blocks_test.dart
+++ b/packages/langchain_ollama/test/chat_models/mappers_content_blocks_test.dart
@@ -1,0 +1,107 @@
+import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_ollama/src/chat_models/chat_ollama/mappers.dart';
+import 'package:ollama_dart/ollama_dart.dart' as ollama;
+import 'package:test/test.dart';
+
+void main() {
+  test('preserves reasoning, text, images, and parallel tool calls', () {
+    const response = ollama.ChatResponse(
+      model: 'qwen3',
+      message: ollama.ChatResponseMessage(
+        role: ollama.MessageRole.assistant,
+        thinking: 'reasoning',
+        content: 'answer',
+        images: ['image-data'],
+        toolCalls: [
+          ollama.ToolCall(
+            function: ollama.ToolCallFunction(
+              name: 'weather',
+              arguments: {'city': 'Madrid'},
+            ),
+          ),
+          ollama.ToolCall(
+            function: ollama.ToolCallFunction(
+              name: 'weather',
+              arguments: {'city': 'Paris'},
+            ),
+          ),
+        ],
+      ),
+      done: true,
+      doneReason: ollama.DoneReason.stop,
+    );
+
+    final message = response.toChatResult('response-1').output;
+
+    expect(message.contentBlocks.map((block) => block.runtimeType), [
+      AIChatMessageReasoningBlock,
+      AIChatMessageTextBlock,
+      AIChatMessageMediaBlock,
+      AIChatMessageToolCall,
+      AIChatMessageToolCall,
+    ]);
+    expect(message.content, 'reasoninganswer');
+    expect(message.toolCalls.map((call) => call.id), [
+      'ollama:response-1:tool:0',
+      'ollama:response-1:tool:1',
+    ]);
+    expect(message.toolCalls.map((call) => call.arguments['city']), [
+      'Madrid',
+      'Paris',
+    ]);
+  });
+
+  test('replays accumulated thinking, content, images, and tool calls', () {
+    const response = ollama.ChatResponse(
+      message: ollama.ChatResponseMessage(
+        thinking: 'reasoning',
+        content: 'answer',
+        images: ['image-data'],
+        toolCalls: [
+          ollama.ToolCall(
+            function: ollama.ToolCallFunction(
+              name: 'weather',
+              arguments: {'city': 'Madrid'},
+            ),
+          ),
+        ],
+      ),
+    );
+    final message = response.toChatResult('response-1').output;
+
+    final replayed = [message].toMessages().single;
+
+    expect(replayed.thinking, 'reasoning');
+    expect(replayed.content, 'answer');
+    expect(replayed.images, ['image-data']);
+    expect(replayed.toolCalls!.single.function!.arguments, {'city': 'Madrid'});
+  });
+
+  test('merges streamed reasoning and visible text independently', () {
+    const first = ollama.ChatStreamEvent(
+      message: ollama.ChatResponseMessage(thinking: 'reason', content: 'ans'),
+    );
+    const second = ollama.ChatStreamEvent(
+      message: ollama.ChatResponseMessage(thinking: 'ing', content: 'wer'),
+      done: true,
+      doneReason: ollama.DoneReason.stop,
+    );
+
+    final message = first
+        .toChatResult('response-1', streaming: true)
+        .output
+        .concat(second.toChatResult('response-1', streaming: true).output);
+
+    expect(
+      message.contentBlocks
+          .whereType<AIChatMessageReasoningBlock>()
+          .single
+          .reasoning,
+      'reasoning',
+    );
+    expect(
+      message.contentBlocks.whereType<AIChatMessageTextBlock>().single.text,
+      'answer',
+    );
+  });
+}

--- a/packages/langchain_ollama/test/embeddings/ollama_test.dart
+++ b/packages/langchain_ollama/test/embeddings/ollama_test.dart
@@ -1,3 +1,6 @@
+@Tags(['integration'])
+library;
+
 import 'dart:io';
 
 import 'package:langchain_core/documents.dart';

--- a/packages/langchain_ollama/test/llms/ollama_test.dart
+++ b/packages/langchain_ollama/test/llms/ollama_test.dart
@@ -1,3 +1,6 @@
+@Tags(['integration'])
+library;
+
 // ignore_for_file: avoid_redundant_argument_values
 import 'dart:io';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ melos:
         meta: ^1.16.0
         mistralai_dart: ^6.1.0
         objectbox: ^5.1.0
-        ollama_dart: ^1.4.0
+        ollama_dart: ^2.6.0
         openai_dart: ^1.4.0
         path: ^1.9.1
         pinecone: ^0.7.2


### PR DESCRIPTION
## Summary

- Migrates Ollama chat mapping to ordered AI content blocks.
- Preserves reasoning, visible text, images, and tool calls across responses, streaming concatenation, and request replay.
- Requires the published `ollama_dart ^2.6.0` client to replay accumulated assistant thinking in conversation history.

## Details

Reasoning and visible text stream as independent blocks, while provider tool-call order and identity remain stable. The outbound mapper includes prior assistant thinking instead of dropping it during multi-turn reasoning/tool interactions.

The client migration also adopts typed `EmbedInput`, `KeepAlive`, and `StopSequence` values across chat, embeddings, and LLM requests.

The package and centralized Melos constraints both declare the required 2.6.0 minimum. This PR builds on the Mistral provider migration merged in #965.

## References

- Client support for assistant thinking replay: davidmigloz/ai_clients_dart#296.

## Test plan

- [x] Resolve `ollama_dart` 2.6.0 from pub.dev without overrides
- [x] Run full-workspace `melos analyze`
- [x] Run all non-live `langchain_ollama` tests
- [x] Verify reasoning/text streaming and complete replay
