### PR TITLE
feat(langchain_core)!: make AI message content block-native

### DIFF
--- a/.github/workflows/full_test.yaml
+++ b/.github/workflows/full_test.yaml
@@ -6,6 +6,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/full_test.yaml
+++ b/.github/workflows/full_test.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          delay_seconds: 5
+          retry_wait_seconds: 5
           command: melos bootstrap
 
       - name: Analyze full workspace

--- a/.github/workflows/full_test.yaml
+++ b/.github/workflows/full_test.yaml
@@ -1,0 +1,53 @@
+name: Full workspace checks
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Analyze & run non-live tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        with:
+          channel: 'stable'
+
+      - name: Set up Flutter
+        run: |
+          flutter config --no-analytics
+          dart --disable-analytics
+
+      - name: Install Melos
+        uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
+        with:
+          melos-version: '7.4.0'
+          run-bootstrap: false
+
+      - name: Bootstrap
+        uses: nick-invision/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          delay_seconds: 5
+          command: melos bootstrap
+
+      - name: Analyze full workspace
+        run: melos analyze
+
+      - name: Run all non-live tests
+        run: melos test:unit

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,6 +8,7 @@ analyzer:
     todo: ignore
     sdk_version_since: ignore # TODO remove when fixed https://github.com/dart-lang/sdk/issues/52327
   exclude:
+    - "**/build/**"
     - "**/generated_plugin_registrant.dart"
     - "**/generated/**"
     - "**/*.gen.dart"

--- a/examples/docs_examples/bin/expression_language/cookbook/retrieval.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/retrieval.dart
@@ -294,7 +294,7 @@ Question: {question}''');
     inputValues: {
       'question': ChatMessage.humanText('How much does my order cost?'),
     },
-    outputValues: {'answer': ChatMessage.ai('You have to pay 100€')},
+    outputValues: {'answer': ChatMessage.aiText('You have to pay 100€')},
   );
 
   final res = await conversationalQaChain.invoke({

--- a/examples/docs_examples/bin/expression_language/cookbook/streaming.dart
+++ b/examples/docs_examples/bin/expression_language/cookbook/streaming.dart
@@ -22,7 +22,7 @@ Future<void> _languageModels() async {
   final chunks = <ChatResult>[];
   await for (final chunk in stream) {
     chunks.add(chunk);
-    stdout.write('${chunk.output.content}|');
+    stdout.write('${chunk.output.contentAsString}|');
   }
   // Hello|!| I| am| a| language| model| AI| created| by| Open|AI|,|...
 

--- a/examples/docs_examples/bin/get_started/quickstart.dart
+++ b/examples/docs_examples/bin/get_started/quickstart.dart
@@ -66,7 +66,7 @@ Future<void> _commaSeparatedListOutputParser() async {
   final res = await const CommaSeparatedListOutputParser().invoke(
     const ChatResult(
       id: 'id',
-      output: AIChatMessage(content: 'hi, bye'),
+      output: AIChatMessage(content: [AIChatMessageTextBlock(text: 'hi, bye')]),
       finishReason: FinishReason.stop,
       metadata: {},
       usage: LanguageModelUsage(),
@@ -87,7 +87,7 @@ class CommaSeparatedListOutputParser
     final OutputParserOptions? options,
   }) async {
     final message = input.output;
-    return message.content.trim().split(',');
+    return message.contentAsString.trim().split(',');
   }
 }
 

--- a/examples/docs_examples/bin/modules/agents/agent_types/tools_agent.dart
+++ b/examples/docs_examples/bin/modules/agents/agent_types/tools_agent.dart
@@ -121,6 +121,7 @@ Future<void> _toolsAgentLCEL() async {
                 ChatMessage.tool(
                   toolCallId: s.action.id,
                   content: s.observation,
+                  name: s.action.tool,
                 ),
               ];
         })

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/how_to/tools.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/how_to/tools.dart
@@ -260,12 +260,13 @@ Future<void> _toolMessage() async {
     final toolMessage = ChatMessage.tool(
       toolCallId: toolCall.id,
       content: toolRes,
+      name: toolCall.name,
     );
     messages.add(toolMessage);
   }
 
   final res2 = await model.invoke(PromptValue.chat(messages));
-  print(res2.output.content);
+  print(res2.output.contentAsString);
   // The calculations yield the following results:
   // - 3 * 12 = 36
   // - 11 + 49 = 60
@@ -286,7 +287,7 @@ Future<void> _fewShotPrompting() async {
 
   final examples = [
     ChatMessage.humanText('Calculate 3 ✖️ 12 and 11 ➕ 49'),
-    ChatMessage.ai(
+    ChatMessage.aiText(
       '',
       toolCalls: const [
         AIChatMessageToolCall(
@@ -303,9 +304,9 @@ Future<void> _fewShotPrompting() async {
         ),
       ],
     ),
-    ChatMessage.tool(toolCallId: 'call_1', content: '36'),
-    ChatMessage.tool(toolCallId: 'call_2', content: '60'),
-    ChatMessage.ai(
+    ChatMessage.tool(toolCallId: 'call_1', content: '36', name: 'calculator'),
+    ChatMessage.tool(toolCallId: 'call_2', content: '60', name: 'calculator'),
+    ChatMessage.aiText(
       'The calculations yield the following results:\n- 3 ✖️ 12 = 36\n- 11 ➕ 49 = 60',
     ),
   ];

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/anthropic.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/anthropic.dart
@@ -68,7 +68,7 @@ Future<void> _multiModal() async {
       ),
     ]),
   );
-  print(res.output.content);
+  print(res.output.contentAsString);
   // -> 'The fruit in the image is an apple.'
 
   chatModel.close();

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/googleai.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/googleai.dart
@@ -69,7 +69,7 @@ Future<void> _chatGoogleGenerativeAIMultiModal() async {
       ),
     ]),
   );
-  print(res.output.content);
+  print(res.output.contentAsString);
   // -> 'That is an apple.'
 
   chatModel.close();
@@ -124,7 +124,7 @@ Future<void> _codeExecution() async {
       'Return only the last term without explanations.',
     ),
   );
-  final text = res.output.content;
+  final text = res.output.contentAsString;
   print(text); // 34
   final executableCode = res.metadata['executable_code'] as String;
   print(executableCode);

--- a/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/ollama.dart
+++ b/examples/docs_examples/bin/modules/model_io/models/chat_models/integrations/ollama.dart
@@ -78,7 +78,7 @@ Future<void> _chatOllamaMultimodal() async {
     ]),
   );
   final res = await chatModel.invoke(PromptValue.chat([prompt]));
-  print(res.output.content);
+  print(res.output.contentAsString);
   // -> 'An Apple'
 }
 
@@ -307,7 +307,7 @@ Future<void> _flights() async {
   // Check if the model decided to use the provided function
   if (response.output.toolCalls.isEmpty) {
     print("The model didn't use the function. Its response was:");
-    print(response.output.content);
+    print(response.output.contentAsString);
     return;
   }
 
@@ -319,13 +319,17 @@ Future<void> _flights() async {
     );
     // Add function response to the conversation
     messages.add(
-      ChatMessage.tool(toolCallId: toolCall.id, content: functionResponse),
+      ChatMessage.tool(
+        toolCallId: toolCall.id,
+        content: functionResponse,
+        name: toolCall.name,
+      ),
     );
   }
 
   // Second API call: Get final response from the model
   final finalResponse = await chatModel.invoke(PromptValue.chat(messages));
-  print(finalResponse.output.content);
+  print(finalResponse.output.contentAsString);
   // The flight time from New York (NYC) to Los Angeles (LAX) is approximately 5 hours and 30 minutes.
 }
 

--- a/examples/hello_world_backend/bin/sonnets.dart
+++ b/examples/hello_world_backend/bin/sonnets.dart
@@ -32,6 +32,6 @@ class SonnetsService {
   Future<String> generateSonnet(final List<String> topics) async {
     final prompt = _chatPromptTemplate.formatMessages({'topics': topics});
     final response = await _llm.call(prompt);
-    return response.content;
+    return response.contentAsString;
   }
 }

--- a/examples/hello_world_cli/bin/hello_world_cli.dart
+++ b/examples/hello_world_cli/bin/hello_world_cli.dart
@@ -26,6 +26,6 @@ void main(final List<String> arguments) async {
     final query = stdin.readLineSync() ?? '';
     final humanMessage = ChatMessage.humanText(query);
     final aiMessage = await llm.call([humanMessage]);
-    stdout.writeln(aiMessage.content.trim());
+    stdout.writeln(aiMessage.contentAsString.trim());
   }
 }

--- a/packages/langchain/lib/src/agents/tools.dart
+++ b/packages/langchain/lib/src/agents/tools.dart
@@ -180,6 +180,7 @@ class ToolsAgent extends BaseSingleActionAgent {
       final functionMsg = ChatMessage.tool(
         toolCallId: lastStep.action.id,
         content: lastStep.observation,
+        name: lastStep.action.tool,
       );
       agentInput = functionMsg;
     } else {
@@ -216,6 +217,7 @@ class ToolsAgent extends BaseSingleActionAgent {
                   ChatMessage.tool(
                     toolCallId: s.action.id,
                     content: s.observation,
+                    name: s.action.tool,
                   ),
                 ];
           })
@@ -296,7 +298,7 @@ class ToolsAgentOutputParser
               log:
                   'Invoking: `${toolCall.name}` '
                   'with `${toolCall.arguments}`\n'
-                  'Responded: ${message.content}\n',
+                  'Responded: ${message.contentAsString}\n',
               messageLog: [message],
             );
           })
@@ -304,8 +306,8 @@ class ToolsAgentOutputParser
     } else {
       return [
         AgentFinish(
-          returnValues: {'output': message.content},
-          log: message.content,
+          returnValues: {'output': message.contentAsString},
+          log: message.contentAsString,
         ),
       ];
     }

--- a/packages/langchain/lib/src/chains/combine_documents/map_reduce.dart
+++ b/packages/langchain/lib/src/chains/combine_documents/map_reduce.dart
@@ -176,7 +176,7 @@ class MapReduceDocumentsChain extends BaseCombineDocumentsChain {
   }
 
   String _getContent(final dynamic content) => switch (content) {
-    final AIChatMessage resultMsg => resultMsg.content,
+    final AIChatMessage resultMsg => resultMsg.contentAsString,
     _ => content,
   };
 }

--- a/packages/langchain/lib/src/chains/combine_documents/stuff.dart
+++ b/packages/langchain/lib/src/chains/combine_documents/stuff.dart
@@ -144,7 +144,7 @@ class StuffDocumentsChain extends BaseCombineDocumentsChain {
     final llmOutput = await llmChain.call(llmInputs);
     final content = llmOutput[llmChain.outputKey];
     final output = switch (content) {
-      final AIChatMessage resultMsg => resultMsg.content,
+      final AIChatMessage resultMsg => resultMsg.contentAsString,
       _ => content,
     };
     return {

--- a/packages/langchain/test/agents/content_block_tool_routing_test.dart
+++ b/packages/langchain/test/agents/content_block_tool_routing_test.dart
@@ -3,8 +3,8 @@ import 'package:test/test.dart';
 
 void main() {
   test('parallel same-name content-block calls route independently', () async {
-    const message = AIChatMessage.withBlocks(
-      contentBlocks: [
+    const message = AIChatMessage(
+      content: [
         AIChatMessageToolCall(
           id: 'call-madrid',
           index: 0,

--- a/packages/langchain/test/agents/tools_agent_test.dart
+++ b/packages/langchain/test/agents/tools_agent_test.dart
@@ -164,6 +164,7 @@ AgentExecutor testLCDLEquivalent({
                     ChatMessage.tool(
                       toolCallId: s.action.id,
                       content: s.observation,
+                      name: s.action.tool,
                     ),
                   ];
             })

--- a/packages/langchain/test/chat_history/in_memory_test.dart
+++ b/packages/langchain/test/chat_history/in_memory_test.dart
@@ -29,7 +29,7 @@ void main() {
     test('Test removeLast', () async {
       final history = ChatMessageHistory();
       final message = ChatMessage.humanText('This is a test');
-      final message2 = ChatMessage.ai('This is an AI msg');
+      final message2 = ChatMessage.aiText('This is an AI msg');
       await history.addChatMessage(message);
       await history.addChatMessage(message2);
       final oldestMessage = await history.removeLast();
@@ -44,7 +44,7 @@ void main() {
     test('Test removeFirst', () async {
       final history = ChatMessageHistory();
       final message = ChatMessage.humanText('This is a test');
-      final message2 = ChatMessage.ai('This is an AI msg');
+      final message2 = ChatMessage.aiText('This is an AI msg');
       await history.addChatMessage(message);
       await history.addChatMessage(message2);
       final oldestMessage = await history.removeFirst();

--- a/packages/langchain/test/memory/buffer_test.dart
+++ b/packages/langchain/test/memory/buffer_test.dart
@@ -30,7 +30,7 @@ void main() {
       );
       final expectedResult = [
         ChatMessage.humanText('bar'),
-        ChatMessage.ai('foo'),
+        ChatMessage.aiText('foo'),
       ];
       final result2 = await memory.loadMemoryVariables();
       expect(result2, {BaseMemory.defaultMemoryKey: expectedResult});
@@ -45,11 +45,11 @@ void main() {
         inputValues: {
           'foo': ChatMessage.tool(toolCallId: 'foo', content: 'bar'),
         },
-        outputValues: {'bar': ChatMessage.ai('baz')},
+        outputValues: {'bar': ChatMessage.aiText('baz')},
       );
       final expectedResult = [
         ChatMessage.tool(toolCallId: 'foo', content: 'bar'),
-        ChatMessage.ai('baz'),
+        ChatMessage.aiText('baz'),
       ];
       final result2 = await memory.loadMemoryVariables();
       expect(result2, {BaseMemory.defaultMemoryKey: expectedResult});
@@ -58,7 +58,7 @@ void main() {
     test('Test buffer memory with pre-loaded history', () async {
       final pastMessages = [
         ChatMessage.humanText("My name's Jonas"),
-        ChatMessage.ai('Nice to meet you, Jonas!'),
+        ChatMessage.aiText('Nice to meet you, Jonas!'),
       ];
       final memory = ConversationBufferMemory(
         returnMessages: true,
@@ -97,7 +97,7 @@ void main() {
         );
         final expectedResult = [
           ChatMessage.humanText('bar'),
-          ChatMessage.ai('foo'),
+          ChatMessage.aiText('foo'),
         ];
         final result1 = await memory.loadMemoryVariables();
         expect(result1, {BaseMemory.defaultMemoryKey: expectedResult});
@@ -119,7 +119,7 @@ void main() {
       );
       final expectedResult = [
         ChatMessage.humanText('bar2'),
-        ChatMessage.ai('foo'),
+        ChatMessage.aiText('foo'),
       ];
       final result1 = await memory.loadMemoryVariables();
       expect(result1, {BaseMemory.defaultMemoryKey: expectedResult});

--- a/packages/langchain/test/memory/buffer_window_test.dart
+++ b/packages/langchain/test/memory/buffer_window_test.dart
@@ -28,7 +28,7 @@ void main() {
       );
       final expectedResult = [
         ChatMessage.humanText('bar'),
-        ChatMessage.ai('foo'),
+        ChatMessage.aiText('foo'),
       ];
       final result2 = await memory.loadMemoryVariables();
       expect(result2, {BaseMemory.defaultMemoryKey: expectedResult});
@@ -40,7 +40,7 @@ void main() {
 
       final expectedResult2 = [
         ChatMessage.humanText('bar1'),
-        ChatMessage.ai('foo1'),
+        ChatMessage.aiText('foo1'),
       ];
       final result3 = await memory.loadMemoryVariables();
       expect(result3, {BaseMemory.defaultMemoryKey: expectedResult2});
@@ -49,7 +49,7 @@ void main() {
     test('Test buffer memory with pre-loaded history', () async {
       final pastMessages = [
         ChatMessage.humanText("My name's Jonas"),
-        ChatMessage.ai('Nice to meet you, Jonas!'),
+        ChatMessage.aiText('Nice to meet you, Jonas!'),
       ];
       final memory = ConversationBufferWindowMemory(
         returnMessages: true,
@@ -61,9 +61,9 @@ void main() {
 
     test('Test k limit', () async {
       final m1 = ChatMessage.humanText("My name's Jonas");
-      final m2 = ChatMessage.ai('Nice to meet you, Jonas!');
+      final m2 = ChatMessage.aiText('Nice to meet you, Jonas!');
       final m3 = ChatMessage.humanText('What is your name?');
-      final m4 = ChatMessage.ai("My name's GPT-3");
+      final m4 = ChatMessage.aiText("My name's GPT-3");
       final pastMessages = [m1, m2, m3, m4];
       // k = 0
       final memory0 = ConversationBufferWindowMemory(

--- a/packages/langchain/test/memory/summary_test.dart
+++ b/packages/langchain/test/memory/summary_test.dart
@@ -139,7 +139,7 @@ void main() {
       );
       final pastMessages = [
         ChatMessage.humanText("My name's Jonas"),
-        ChatMessage.ai('Nice to meet you, Jonas!'),
+        ChatMessage.aiText('Nice to meet you, Jonas!'),
       ];
       final memory = await ConversationSummaryMemory.fromMessages(
         llm: model,
@@ -209,7 +209,7 @@ void main() {
       final memory = ConversationSummaryMemory(
         llm: model,
         summaryPromptTemplate: prompt,
-        summaryMessageBuilder: ChatMessage.ai,
+        summaryMessageBuilder: ChatMessage.aiText,
       );
       await memory.saveContext(
         inputValues: {'foo': "My name's Jonas"},

--- a/packages/langchain/test/memory/token_buffer_test.dart
+++ b/packages/langchain/test/memory/token_buffer_test.dart
@@ -34,7 +34,7 @@ void main() {
       );
       final expectedResult = [
         ChatMessage.humanText('bar'),
-        ChatMessage.ai('foo'),
+        ChatMessage.aiText('foo'),
       ];
       final result2 = await memory.loadMemoryVariables();
       expect(result2, {BaseMemory.defaultMemoryKey: expectedResult});
@@ -45,9 +45,9 @@ void main() {
       );
 
       final expectedResult2 = [
-        ChatMessage.ai('foo'),
+        ChatMessage.aiText('foo'),
         ChatMessage.humanText('bar1'),
-        ChatMessage.ai('foo1'),
+        ChatMessage.aiText('foo1'),
       ];
       final result3 = await memory.loadMemoryVariables();
       expect(result3, {BaseMemory.defaultMemoryKey: expectedResult2});
@@ -56,7 +56,7 @@ void main() {
     test('Test buffer memory with pre-loaded history', () async {
       final pastMessages = [
         ChatMessage.humanText("My name's Jonas"),
-        ChatMessage.ai('Nice to meet you, Jonas!'),
+        ChatMessage.aiText('Nice to meet you, Jonas!'),
       ];
       const model = FakeEchoLLM();
       final memory = ConversationTokenBufferMemory(

--- a/packages/langchain_anthropic/example/langchain_anthropic_example.dart
+++ b/packages/langchain_anthropic/example/langchain_anthropic_example.dart
@@ -35,5 +35,7 @@ Future<void> _example2() async {
   final Stream<ChatResult> stream = llm.stream(
     PromptValue.string('Tell me a joke'),
   );
-  await stream.forEach((final chunk) => stdout.write(chunk.output.content));
+  await stream.forEach(
+    (final chunk) => stdout.write(chunk.output.contentAsString),
+  );
 }

--- a/packages/langchain_anthropic/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_anthropic/lib/src/chat_models/mappers.dart
@@ -148,9 +148,9 @@ extension ChatMessageListMapper on List<ChatMessage> {
   }
 
   a.InputMessage _mapAIChatMessage(final AIChatMessage msg) {
-    final blocks = msg.contentBlocks;
+    final blocks = msg.content;
     if (blocks.length == 1 && blocks.single is AIChatMessageTextBlock) {
-      return a.InputMessage.assistant(msg.content);
+      return a.InputMessage.assistant(msg.contentAsString);
     }
     return a.InputMessage.assistantBlocks(
       blocks.map(_mapAIContentBlock).toList(growable: false),
@@ -179,10 +179,7 @@ extension MessageMapper on a.Message {
     ];
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: blocks,
-        legacyContent: '$thinking$text',
-      ),
+      output: AIChatMessage(content: blocks),
       finishReason: _mapFinishReason(stopReason),
       metadata: {'model': model, 'stop_sequence': stopSequence},
       usage: _mapUsage(usage),
@@ -221,12 +218,11 @@ class MessageStreamEventTransformer
 
     return ChatResult(
       id: msg.id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: [
+      output: AIChatMessage(
+        content: [
           for (final (index, block) in msg.content.indexed)
             _mapContentBlock(block, messageId: msg.id, index: index),
         ],
-        legacyContent: '${msg.thinking}${msg.text}',
       ),
       finishReason: _mapFinishReason(msg.stopReason),
       metadata: {
@@ -241,7 +237,7 @@ class MessageStreamEventTransformer
   ChatResult _mapMessageDeltaEvent(final a.MessageDeltaEvent e) {
     return ChatResult(
       id: lastMessageId ?? '',
-      output: const AIChatMessage.withBlocks(contentBlocks: []),
+      output: const AIChatMessage(content: []),
       finishReason: _mapFinishReason(e.delta.stopReason),
       metadata: {
         if (e.delta.stopSequence != null) 'stop_sequence': e.delta.stopSequence,
@@ -263,10 +259,7 @@ class MessageStreamEventTransformer
 
     return ChatResult(
       id: lastMessageId ?? '',
-      output: AIChatMessage.withBlocks(
-        contentBlocks: [block],
-        legacyContent: block.legacyContent,
-      ),
+      output: AIChatMessage(content: [block]),
       finishReason: FinishReason.unspecified,
       metadata: const {},
       usage: const LanguageModelUsage(),
@@ -283,10 +276,7 @@ class MessageStreamEventTransformer
     );
     return ChatResult(
       id: lastMessageId ?? '',
-      output: AIChatMessage.withBlocks(
-        contentBlocks: [block],
-        legacyContent: block.legacyContent,
-      ),
+      output: AIChatMessage(content: [block]),
       finishReason: FinishReason.unspecified,
       metadata: {'index': e.index},
       usage: const LanguageModelUsage(),

--- a/packages/langchain_anthropic/test/chat_models/chat_anthropic_test.dart
+++ b/packages/langchain_anthropic/test/chat_models/chat_anthropic_test.dart
@@ -50,7 +50,7 @@ void main() {
         expect(res.finishReason, isNot(FinishReason.unspecified));
         expect(res.metadata['model'], contains(model.toLowerCase()));
         expect(
-          res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
+          res.output.contentAsString.replaceAll(RegExp(r'[\s\n]'), ''),
           contains('123456789'),
         );
         await Future<void>.delayed(const Duration(seconds: 5));
@@ -76,7 +76,7 @@ void main() {
         ]),
       );
 
-      expect(res.output.content.toLowerCase(), contains('apple'));
+      expect(res.output.contentAsString.toLowerCase(), contains('apple'));
     });
 
     test('Test stop sequence', () async {
@@ -90,7 +90,7 @@ void main() {
           stopSequences: ['4'],
         ),
       );
-      final text = res.output.content;
+      final text = res.output.contentAsString;
       expect(text, contains('123'));
       expect(text, isNot(contains('456789')));
       expect(res.finishReason, FinishReason.stop);
@@ -101,7 +101,7 @@ void main() {
         PromptValue.string('Tell me a joke'),
         options: const ChatAnthropicOptions(model: defaultModel, maxTokens: 10),
       );
-      expect(res.output.content.length, lessThan(50));
+      expect(res.output.contentAsString.length, lessThan(50));
       expect(res.finishReason, FinishReason.length);
     });
 
@@ -111,7 +111,7 @@ void main() {
           'List the numbers from 1 to 9 in order '
           'without any spaces, commas or additional explanations.',
         ),
-        ChatMessage.ai('123456789'),
+        ChatMessage.aiText('123456789'),
         ChatMessage.humanText('Remove the number 4 from the list'),
       ]);
       final res = await chatModel.invoke(
@@ -121,7 +121,7 @@ void main() {
           temperature: 0,
         ),
       );
-      expect(res.output.content, contains('12356789'));
+      expect(res.output.contentAsString, contains('12356789'));
     });
 
     test('Test streaming', () async {
@@ -135,7 +135,7 @@ void main() {
       var content = '';
       var count = 0;
       await for (final res in stream) {
-        content += res.output.content;
+        content += res.output.contentAsString;
         count++;
       }
       expect(count, greaterThan(1));
@@ -197,6 +197,7 @@ void main() {
         final functionMessage1 = ChatMessage.tool(
           toolCallId: toolCall1.id,
           content: json.encode(functionResult1),
+          name: toolCall1.name,
         );
 
         final functionResult2 = {
@@ -207,6 +208,7 @@ void main() {
         final functionMessage2 = ChatMessage.tool(
           toolCallId: toolCall2.id,
           content: json.encode(functionResult2),
+          name: toolCall2.name,
         );
 
         final res2 = await model.invoke(
@@ -221,8 +223,8 @@ void main() {
         final aiMessage2 = res2.output;
 
         expect(aiMessage2.toolCalls, isEmpty);
-        expect(aiMessage2.content, contains('22'));
-        expect(aiMessage2.content, contains('25'));
+        expect(aiMessage2.contentAsString, contains('22'));
+        expect(aiMessage2.contentAsString, contains('25'));
       },
     );
 

--- a/packages/langchain_anthropic/test/chat_models/mappers_test.dart
+++ b/packages/langchain_anthropic/test/chat_models/mappers_test.dart
@@ -30,15 +30,15 @@ void main() {
       final output = message.toChatResult().output;
       final replayed = <ChatMessage>[output].toInputMessages().single;
 
-      expect(output.contentBlocks.map((block) => block.runtimeType), [
+      expect(output.content.map((block) => block.runtimeType), [
         AIChatMessageReasoningBlock,
         AIChatMessageToolCall,
         AIChatMessageTextBlock,
         AIChatMessageServerToolCall,
       ]);
-      expect(output.content, 'reasoningIt is sunny.');
+      expect(output.contentAsString, 'It is sunny.');
       expect(
-        (output.contentBlocks.first.providerData['anthropic']
+        (output.content.first.providerData['anthropic']
             as Map<String, dynamic>)['signature'],
         'opaque-signature',
       );
@@ -66,8 +66,8 @@ void main() {
       final output = message.toChatResult().output;
       final replayed = <ChatMessage>[output].toInputMessages().single;
 
-      expect(output.contentBlocks.first, isA<AIChatMessageReasoningBlock>());
-      expect(output.contentBlocks.last, isA<AIChatMessageNonStandardBlock>());
+      expect(output.content.first, isA<AIChatMessageReasoningBlock>());
+      expect(output.content.last, isA<AIChatMessageNonStandardBlock>());
       expect(
         replayed.toJson()['content'],
         responseBlocks.map((block) => block.toJson()).toList(),
@@ -132,9 +132,8 @@ void main() {
         final output = results
             .map((result) => result.output)
             .reduce((first, next) => first.concat(next));
-        final reasoning =
-            output.contentBlocks[0] as AIChatMessageReasoningBlock;
-        final toolCall = output.contentBlocks[1] as AIChatMessageToolCall;
+        final reasoning = output.content[0] as AIChatMessageReasoningBlock;
+        final toolCall = output.content[1] as AIChatMessageToolCall;
         final replayed = <ChatMessage>[output].toInputMessages().single;
 
         expect(reasoning.reasoning, 'reasoning');
@@ -144,7 +143,7 @@ void main() {
           'opaque-signature',
         );
         expect(toolCall.arguments, {'city': 'Madrid'});
-        expect(output.content, 'reasoningIt is sunny.');
+        expect(output.contentAsString, 'It is sunny.');
         expect(replayed.toJson()['content'], [
           {
             'type': 'thinking',

--- a/packages/langchain_chroma/test/vector_stores/chroma_test.dart
+++ b/packages/langchain_chroma/test/vector_stores/chroma_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_community/lib/src/document_loaders/csv.dart
+++ b/packages/langchain_community/lib/src/document_loaders/csv.dart
@@ -115,7 +115,7 @@ class CsvLoader extends BaseDocumentLoader {
   Stream<Document> lazyLoad() async* {
     final file = XFile(filePath);
 
-    final csvLinesStream = file
+    final csvRowsStream = file
         .openRead()
         .cast<List<int>>()
         .transform(utf8.decoder)
@@ -124,11 +124,12 @@ class CsvLoader extends BaseDocumentLoader {
             fieldDelimiter: fieldDelimiter,
             quoteCharacter: fieldTextDelimiter,
           ),
-        );
+        )
+        .expand((final rows) => rows);
 
     final fieldsToPositions = <String, int>{};
     final pageContentFields = <String>[];
-    await for (final row in csvLinesStream) {
+    await for (final row in csvRowsStream) {
       // Process CSV header
       if (fieldsToPositions.isEmpty) {
         assert(row.isNotEmpty, 'Header row cannot be empty');

--- a/packages/langchain_community/test/document_loaders/directory_test.dart
+++ b/packages/langchain_community/test/document_loaders/directory_test.dart
@@ -92,8 +92,13 @@ void main() {
       );
 
       final loadedDocs = await loader.load();
+      final loadedSources = loadedDocs
+          .map((doc) => doc.metadata['source'])
+          .toSet();
 
-      expect(loadedDocs, hasLength(2));
+      // A sampled file can produce more than one document (for example, CSV),
+      // so assert the number of sampled files rather than output documents.
+      expect(loadedSources, hasLength(2));
     });
 
     test('Test directory loader with custom metadata builder', () {

--- a/packages/langchain_community/test/document_loaders/web_test.dart
+++ b/packages/langchain_community/test/document_loaders/web_test.dart
@@ -1,3 +1,6 @@
+@Tags(['integration'])
+library;
+
 import 'package:langchain_community/langchain_community.dart';
 import 'package:test/test.dart';
 

--- a/packages/langchain_community/test/tools/tavily_test.dart
+++ b/packages/langchain_community/test/tools/tavily_test.dart
@@ -1,3 +1,6 @@
+@Tags(['integration'])
+library;
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/packages/langchain_community/test/vector_stores/objectbox/objectbox_test.dart
+++ b/packages/langchain_community/test/vector_stores/objectbox/objectbox_test.dart
@@ -1,3 +1,6 @@
+@Tags(['integration'])
+library;
+
 import 'dart:io';
 
 import 'package:langchain_community/langchain_community.dart';

--- a/packages/langchain_core/MIGRATION.md
+++ b/packages/langchain_core/MIGRATION.md
@@ -1,0 +1,88 @@
+# Migration guide
+
+## Ordered AI message content blocks
+
+`AIChatMessage.content` is now an ordered collection of
+`AIChatMessageContentBlock` values. This preserves reasoning, media, tool calls,
+provider metadata, and provider-native payloads in their original order.
+
+### Constructing messages
+
+Before:
+
+```dart
+final message = AIChatMessage(
+  content: 'The weather is sunny.',
+  toolCalls: [toolCall],
+);
+```
+
+After:
+
+```dart
+final message = AIChatMessage(
+  content: [
+    const AIChatMessageTextBlock(text: 'The weather is sunny.'),
+    toolCall,
+  ],
+);
+```
+
+For a text-only message, use the convenience constructor:
+
+```dart
+final message = AIChatMessage.text('The weather is sunny.');
+// Or through the base factory:
+final baseMessage = ChatMessage.aiText('The weather is sunny.');
+```
+
+`AIChatMessageToolCall` is itself a content block. The `toolCalls` getter is
+still available, but is derived from `content`.
+
+### Reading visible text and reasoning
+
+`contentAsString` and `ChatResult.outputAsString` now contain visible text
+blocks only. Reasoning is available explicitly from the ordered blocks:
+
+```dart
+final visibleText = message.contentAsString;
+final reasoning = message.content
+    .whereType<AIChatMessageReasoningBlock>()
+    .map((block) => block.reasoning)
+    .join();
+```
+
+Code that previously relied on Anthropic thinking appearing in
+`contentAsString` must read reasoning blocks instead.
+
+### Treating tool-call IDs as opaque
+
+Google tool-call IDs are now the provider ID when one is supplied, or a
+deterministic response/candidate/part ID otherwise. They are no longer the
+function name. Preserve the ID and use it to associate the tool result with the
+specific call:
+
+```dart
+final call = message.toolCalls.first;
+final result = ToolChatMessage(
+  toolCallId: call.id,
+  content: await runTool(call.name, call.arguments),
+  name: call.name,
+);
+```
+
+Passing both values keeps parallel calls to the same function distinct while
+letting providers such as Google send the required function name separately
+from the opaque call ID. The built-in agents preserve both automatically.
+
+### Serialization
+
+`AIChatMessage.toMap()` now writes the canonical ordered block list under
+`content`. It no longer writes the legacy string and top-level `toolCalls`
+fields. `AIChatMessage.fromMap()` continues to read both the legacy map format
+and the transitional `contentBlocks` format, so stored histories can be read
+and rewritten in the canonical format.
+
+Provider-specific values are stored in each block's `providerData`, nested by
+provider name. Treat those values as opaque unless you are implementing a
+provider adapter.

--- a/packages/langchain_core/README.md
+++ b/packages/langchain_core/README.md
@@ -20,6 +20,8 @@ LangChain Expression Language (LCEL) is a _declarative language_ for composing c
 
 For full documentation see the [API reference](https://pub.dev/documentation/langchain_core/latest/).
 
+For breaking API migrations, see the [migration guide](MIGRATION.md).
+
 ![LangChain.dart packages](https://raw.githubusercontent.com/davidmigloz/langchain_dart/main/docs/img/langchain_packages.png)
 
 ## Why build on top of LangChain Core?

--- a/packages/langchain_core/lib/src/chat_history/base.dart
+++ b/packages/langchain_core/lib/src/chat_history/base.dart
@@ -22,16 +22,17 @@ abstract base class BaseChatMessageHistory {
 
   /// Add an AI message to the history.
   Future<void> addAIChatMessage(final String message) {
-    return addChatMessage(ChatMessage.ai(message));
+    return addChatMessage(ChatMessage.aiText(message));
   }
 
   /// Add a Tool response message to the history.
   Future<void> addToolChatMessage({
     required final String toolCallId,
     required final String content,
+    final String? name,
   }) {
     return addChatMessage(
-      ChatMessage.tool(toolCallId: toolCallId, content: content),
+      ChatMessage.tool(toolCallId: toolCallId, content: content, name: name),
     );
   }
 

--- a/packages/langchain_core/lib/src/chat_models/base.dart
+++ b/packages/langchain_core/lib/src/chat_models/base.dart
@@ -58,7 +58,7 @@ abstract class SimpleChatModel<Options extends ChatModelOptions>
     final Options? options,
   }) async {
     final text = await callInternal(input.toChatMessages(), options: options);
-    final message = AIChatMessage(content: text);
+    final message = AIChatMessage.text(text);
     return ChatResult(
       id: '1',
       output: message,

--- a/packages/langchain_core/lib/src/chat_models/content_blocks.dart
+++ b/packages/langchain_core/lib/src/chat_models/content_blocks.dart
@@ -42,9 +42,6 @@ sealed class AIChatMessageContentBlock {
       ? 'index:$index'
       : null;
 
-  /// Legacy string projection of this block.
-  String get legacyContent;
-
   /// Converts this block to a map.
   Map<String, dynamic> toMap();
 
@@ -228,9 +225,6 @@ final class AIChatMessageTextBlock extends AIChatMessageContentBlock {
       );
 
   @override
-  String get legacyContent => text;
-
-  @override
   Map<String, dynamic> toMap() => {
     'type': 'text',
     'text': text,
@@ -270,9 +264,6 @@ final class AIChatMessageReasoningBlock extends AIChatMessageContentBlock {
         isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
-
-  @override
-  String get legacyContent => reasoning;
 
   @override
   Map<String, dynamic> toMap() => {
@@ -319,9 +310,6 @@ final class AIChatMessageMediaBlock extends AIChatMessageContentBlock {
         isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
-
-  @override
-  String get legacyContent => data;
 
   @override
   Map<String, dynamic> toMap() => {
@@ -376,9 +364,6 @@ final class AIChatMessageFileBlock extends AIChatMessageContentBlock {
         isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
-
-  @override
-  String get legacyContent => uri;
 
   @override
   Map<String, dynamic> toMap() => {
@@ -437,9 +422,6 @@ final class AIChatMessageToolCall extends AIChatMessageContentBlock {
         isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
-
-  @override
-  String get legacyContent => '';
 
   @override
   Map<String, dynamic> toMap() => {
@@ -523,9 +505,6 @@ final class AIChatMessageServerToolCall extends AIChatMessageContentBlock {
       );
 
   @override
-  String get legacyContent => '';
-
-  @override
   Map<String, dynamic> toMap() => {
     'type': 'serverToolCall',
     'name': name,
@@ -592,9 +571,6 @@ final class AIChatMessageServerToolResult extends AIChatMessageContentBlock {
       );
 
   @override
-  String get legacyContent => '';
-
-  @override
   Map<String, dynamic> toMap() => {
     'type': 'serverToolResult',
     'toolCallId': toolCallId,
@@ -648,9 +624,6 @@ final class AIChatMessageProviderMetadataBlock
   );
 
   @override
-  String get legacyContent => '';
-
-  @override
   Map<String, dynamic> toMap() => {
     'type': 'providerMetadata',
     ..._metadataMap(this),
@@ -688,9 +661,6 @@ final class AIChatMessageNonStandardBlock extends AIChatMessageContentBlock {
         isMergeable: _readIsMergeable(map),
         providerData: _readProviderData(map),
       );
-
-  @override
-  String get legacyContent => '';
 
   @override
   Map<String, dynamic> toMap() => {

--- a/packages/langchain_core/lib/src/chat_models/fake.dart
+++ b/packages/langchain_core/lib/src/chat_models/fake.dart
@@ -31,7 +31,7 @@ class FakeChatModel extends BaseChatModel<FakeChatModelOptions> {
     final FakeChatModelOptions? options,
   }) async {
     final text = responses[_i++ % responses.length];
-    final message = AIChatMessage(content: text);
+    final message = AIChatMessage.text(text);
     return ChatResult(
       id: '1',
       output: message,
@@ -53,7 +53,7 @@ class FakeChatModel extends BaseChatModel<FakeChatModelOptions> {
     return Stream.fromIterable(res).map(
       (final char) => ChatResult(
         id: 'fake-chat-model',
-        output: AIChatMessage(content: char),
+        output: AIChatMessage.text(char),
         finishReason: FinishReason.stop,
         metadata: {
           'model': options?.model ?? defaultOptions.model,
@@ -161,7 +161,7 @@ class FakeEchoChatModel extends BaseChatModel<FakeEchoChatModelOptions> {
     }
 
     final text = input.toChatMessages().last.contentAsString;
-    final message = AIChatMessage(content: text);
+    final message = AIChatMessage.text(text);
     return ChatResult(
       id: '1',
       output: message,
@@ -191,7 +191,7 @@ class FakeEchoChatModel extends BaseChatModel<FakeEchoChatModelOptions> {
 
       return ChatResult(
         id: 'fake-echo-chat-model',
-        output: AIChatMessage(content: char),
+        output: AIChatMessage.text(char),
         finishReason: FinishReason.stop,
         metadata: {
           'model': options?.model ?? defaultOptions.model,

--- a/packages/langchain_core/lib/src/chat_models/types.dart
+++ b/packages/langchain_core/lib/src/chat_models/types.dart
@@ -50,7 +50,7 @@ class ChatResult extends LanguageModelResult<AIChatMessage> {
   });
 
   @override
-  String get outputAsString => output.content;
+  String get outputAsString => output.contentAsString;
 
   @override
   ChatResult concat(final LanguageModelResult<AIChatMessage> other) {
@@ -119,16 +119,21 @@ sealed class ChatMessage {
       HumanChatMessage(content: ChatMessageContent.text(text));
 
   /// Type of message that is spoken by the AI.
-  factory ChatMessage.ai(
-    final String content, {
+  factory ChatMessage.ai(final List<AIChatMessageContentBlock> content) =>
+      AIChatMessage(content: content);
+
+  /// Convenience constructor for a visible-text AI message.
+  factory ChatMessage.aiText(
+    final String text, {
     final List<AIChatMessageToolCall> toolCalls = const [],
-  }) => AIChatMessage(content: content, toolCalls: toolCalls);
+  }) => AIChatMessage.text(text, toolCalls: toolCalls);
 
   /// Type of message that is the response of calling a tool.
   factory ChatMessage.tool({
     required final String toolCallId,
     required final String content,
-  }) => ToolChatMessage(toolCallId: toolCallId, content: content);
+    final String? name,
+  }) => ToolChatMessage(toolCallId: toolCallId, content: content, name: name);
 
   /// Chat message with custom role.
   factory ChatMessage.custom(
@@ -153,7 +158,11 @@ sealed class ChatMessage {
             )
             .join('\n'),
     },
-    final AIChatMessage ai => ai.content,
+    final AIChatMessage ai =>
+      ai.content
+          .whereType<AIChatMessageTextBlock>()
+          .map((block) => block.text)
+          .join(),
     final ToolChatMessage tool => tool.content,
     final CustomChatMessage custom => custom.content,
   };
@@ -320,39 +329,48 @@ HumanChatMessage{
 @immutable
 class AIChatMessage extends ChatMessage {
   /// {@macro ai_chat_message}
-  const AIChatMessage({
-    required String content,
-    List<AIChatMessageToolCall> toolCalls = const [],
-  }) : _legacyContent = content,
-       _legacyToolCalls = toolCalls,
-       _contentBlocks = null;
+  const AIChatMessage({required this.content});
 
-  /// Creates an AI message from its canonical ordered content blocks.
-  const AIChatMessage.withBlocks({
-    required List<AIChatMessageContentBlock> contentBlocks,
-    String? legacyContent,
-  }) : _contentBlocks = contentBlocks,
-       _legacyContent = legacyContent,
-       _legacyToolCalls = const [];
+  /// Creates an AI message containing visible text and optional tool calls.
+  factory AIChatMessage.text(
+    final String text, {
+    final List<AIChatMessageToolCall> toolCalls = const [],
+  }) => AIChatMessage(
+    content: [
+      if (text.isNotEmpty) AIChatMessageTextBlock(text: text),
+      ...toolCalls,
+    ],
+  );
 
   /// Converts a map to a [AIChatMessage].
   factory AIChatMessage.fromMap(Map<String, dynamic> map) {
-    final blocks = map['contentBlocks'] as List<dynamic>?;
-    if (blocks != null) {
-      return AIChatMessage.withBlocks(
-        contentBlocks: blocks
+    final content = map['content'];
+    if (content is List) {
+      return AIChatMessage(
+        content: content
             .map((item) => (item as Map).cast<String, dynamic>())
             .map(AIChatMessageContentBlock.fromMap)
             .toList(growable: false),
-        legacyContent: map['content'] as String?,
       );
     }
+    final transitionalBlocks = map['contentBlocks'] as List<dynamic>?;
+    if (transitionalBlocks != null) {
+      return AIChatMessage(
+        content: transitionalBlocks
+            .map((item) => (item as Map).cast<String, dynamic>())
+            .map(AIChatMessageContentBlock.fromMap)
+            .toList(growable: false),
+      );
+    }
+    final legacyContent = content as String? ?? '';
     return AIChatMessage(
-      content: map['content'] as String? ?? '',
-      toolCalls: (map['toolCalls'] as List<dynamic>? ?? const [])
-          .map((item) => (item as Map).cast<String, dynamic>())
-          .map(AIChatMessageToolCall.fromMap)
-          .toList(growable: false),
+      content: [
+        if (legacyContent.isNotEmpty)
+          AIChatMessageTextBlock(text: legacyContent),
+        ...(map['toolCalls'] as List<dynamic>? ?? const [])
+            .map((item) => (item as Map).cast<String, dynamic>())
+            .map(AIChatMessageToolCall.fromMap),
+      ],
     );
   }
 
@@ -360,38 +378,17 @@ class AIChatMessage extends ChatMessage {
   @override
   Map<String, dynamic> toMap() => {
     ...super.toMap(),
-    'content': content,
-    'toolCalls': toolCalls.map((t) => t.toMap()).toList(growable: false),
-    'contentBlocks': contentBlocks
-        .map((block) => block.toMap())
-        .toList(growable: false),
+    'content': content.map((block) => block.toMap()).toList(growable: false),
     'type': 'ai',
   };
 
-  final String? _legacyContent;
-  final List<AIChatMessageToolCall> _legacyToolCalls;
-  final List<AIChatMessageContentBlock>? _contentBlocks;
-
-  /// The legacy string projection of the message.
-  String get content =>
-      _legacyContent ?? contentBlocks.map((b) => b.legacyContent).join();
-
   /// The canonical ordered content blocks.
-  List<AIChatMessageContentBlock> get contentBlocks =>
-      _contentBlocks ??
-      [
-        if ((_legacyContent ?? '').isNotEmpty)
-          AIChatMessageTextBlock(text: _legacyContent!),
-        ..._legacyToolCalls,
-      ];
+  final List<AIChatMessageContentBlock> content;
 
   /// The list of tool that the model wants to call.
   /// If the model does not want to call any tool, this list will be empty.
   List<AIChatMessageToolCall> get toolCalls =>
-      _contentBlocks?.whereType<AIChatMessageToolCall>().toList(
-        growable: false,
-      ) ??
-      _legacyToolCalls;
+      content.whereType<AIChatMessageToolCall>().toList(growable: false);
 
   /// Default prefix for [AIChatMessage].
   static const defaultPrefix = 'AI';
@@ -399,15 +396,13 @@ class AIChatMessage extends ChatMessage {
   @override
   bool operator ==(covariant final AIChatMessage other) {
     const listEquals = DeepCollectionEquality();
-    return identical(this, other) ||
-        content == other.content &&
-            listEquals.equals(contentBlocks, other.contentBlocks);
+    return identical(this, other) || listEquals.equals(content, other.content);
   }
 
   @override
   int get hashCode {
     const listEquals = DeepCollectionEquality();
-    return Object.hash(content, listEquals.hash(contentBlocks));
+    return listEquals.hash(content);
   }
 
   @override
@@ -416,70 +411,20 @@ class AIChatMessage extends ChatMessage {
       return this;
     }
 
-    if (_contentBlocks != null || other._contentBlocks != null) {
-      final mergedBlocks = [...contentBlocks];
-      for (final otherBlock in other.contentBlocks) {
-        final matchingIndex = mergedBlocks.indexWhere(
-          (block) => block.canMerge(otherBlock),
-        );
-        if (matchingIndex == -1) {
-          mergedBlocks.add(otherBlock);
-        } else {
-          mergedBlocks[matchingIndex] = mergedBlocks[matchingIndex].concat(
-            otherBlock,
-          );
-        }
-      }
-      return AIChatMessage.withBlocks(
-        contentBlocks: mergedBlocks,
-        legacyContent: content + other.content,
+    final mergedBlocks = [...content];
+    for (final otherBlock in other.content) {
+      final matchingIndex = mergedBlocks.indexWhere(
+        (block) => block.canMerge(otherBlock),
       );
-    }
-
-    final toolCalls = <AIChatMessageToolCall>[];
-    if (this.toolCalls.isNotEmpty || other.toolCalls.isNotEmpty) {
-      final thisToolCallsById = {
-        for (final toolCall in this.toolCalls) toolCall.id: toolCall,
-      };
-      final otherToolCallsById = {
-        for (final toolCall in other.toolCalls)
-          (toolCall.id.isNotEmpty
-                  ? toolCall.id
-                  : (this.toolCalls.lastOrNull?.id ?? '')):
-              toolCall,
-      };
-      final toolCallsIds = {
-        ...thisToolCallsById.keys,
-        ...otherToolCallsById.keys,
-      };
-
-      for (final id in toolCallsIds) {
-        final thisToolCall = thisToolCallsById[id];
-        final otherToolCall = otherToolCallsById[id];
-        toolCalls.add(
-          AIChatMessageToolCall(
-            id: id,
-            name: (thisToolCall?.name ?? '') + (otherToolCall?.name ?? ''),
-            argumentsRaw:
-                (thisToolCall?.argumentsRaw ?? '') +
-                (otherToolCall?.argumentsRaw ?? ''),
-            arguments: {
-              ...?thisToolCall?.arguments,
-              ...?otherToolCall?.arguments,
-            },
-            providerData: mergeProviderData(
-              thisToolCall?.providerData ?? const {},
-              otherToolCall?.providerData ?? const {},
-            ),
-          ),
+      if (matchingIndex == -1) {
+        mergedBlocks.add(otherBlock);
+      } else {
+        mergedBlocks[matchingIndex] = mergedBlocks[matchingIndex].concat(
+          otherBlock,
         );
       }
     }
-
-    return AIChatMessage(
-      content: content + other.content,
-      toolCalls: toolCalls,
-    );
+    return AIChatMessage(content: mergedBlocks);
   }
 
   @override
@@ -487,7 +432,6 @@ class AIChatMessage extends ChatMessage {
     return '''
 AIChatMessage{
   content: $content,
-  toolCalls: $toolCalls,
 }''';
   }
 }
@@ -498,12 +442,17 @@ AIChatMessage{
 @immutable
 class ToolChatMessage extends ChatMessage {
   /// {@macro tool_chat_message}
-  const ToolChatMessage({required this.toolCallId, required this.content});
+  const ToolChatMessage({
+    required this.toolCallId,
+    required this.content,
+    this.name,
+  });
 
   /// Converts a map to a [ToolChatMessage].
   factory ToolChatMessage.fromMap(Map<String, dynamic> map) => ToolChatMessage(
     toolCallId: map['toolCallId'] as String,
     content: map['content'] as String,
+    name: map['name'] as String?,
   );
 
   /// Converts this ChatMessage to a map along with a type hint for deserialization.
@@ -512,6 +461,7 @@ class ToolChatMessage extends ChatMessage {
     ...super.toMap(),
     'content': content,
     'toolCallId': toolCallId,
+    if (name != null) 'name': name,
     'type': 'tool',
   };
 
@@ -521,16 +471,21 @@ class ToolChatMessage extends ChatMessage {
   /// The response of the tool call.
   final String content;
 
+  /// The name of the tool that produced this response, when known.
+  final String? name;
+
   /// Default prefix for [ToolChatMessage].
   static const defaultPrefix = 'Tool';
 
   @override
   bool operator ==(covariant final ToolChatMessage other) =>
       identical(this, other) ||
-      toolCallId == other.toolCallId && content == other.content;
+      toolCallId == other.toolCallId &&
+          content == other.content &&
+          name == other.name;
 
   @override
-  int get hashCode => toolCallId.hashCode ^ content.hashCode;
+  int get hashCode => Object.hash(toolCallId, content, name);
 
   @override
   ToolChatMessage concat(final ChatMessage other) {
@@ -541,6 +496,7 @@ class ToolChatMessage extends ChatMessage {
     return ToolChatMessage(
       toolCallId: toolCallId,
       content: content + other.content,
+      name: other.name ?? name,
     );
   }
 
@@ -549,6 +505,7 @@ class ToolChatMessage extends ChatMessage {
     return '''
 ToolChatMessage{
   toolCallId: $toolCallId,
+  name: $name,
   content: $content,
 }''';
   }

--- a/packages/langchain_core/lib/src/prompts/chat_prompt.dart
+++ b/packages/langchain_core/lib/src/prompts/chat_prompt.dart
@@ -581,7 +581,7 @@ final class AIChatMessagePromptTemplate extends StringMessagePromptTemplate {
 
   @override
   ChatMessage format([final InputValues values = const {}]) {
-    return ChatMessage.ai(prompt.format(values));
+    return ChatMessage.aiText(prompt.format(values));
   }
 
   @override

--- a/packages/langchain_core/test/chains/llm_chain_test.dart
+++ b/packages/langchain_core/test/chains/llm_chain_test.dart
@@ -91,7 +91,10 @@ void main() {
       final prompt = PromptTemplate.fromTemplate('Print {foo}');
       final chain = LLMChain(prompt: prompt, llm: model);
       final res = await chain.call({'foo': 'Hello world!'});
-      expect(res[LLMChain.defaultOutputKey], ChatMessage.ai('Hello world!'));
+      expect(
+        res[LLMChain.defaultOutputKey],
+        ChatMessage.aiText('Hello world!'),
+      );
       expect(res['foo'], 'Hello world!');
     });
   });

--- a/packages/langchain_core/test/chat_models/ai_chat_message_content_blocks_test.dart
+++ b/packages/langchain_core/test/chat_models/ai_chat_message_content_blocks_test.dart
@@ -1,4 +1,5 @@
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -10,27 +11,35 @@ void main() {
         argumentsRaw: '{}',
         arguments: {},
       );
-      const message = AIChatMessage.withBlocks(
-        contentBlocks: [
+      const message = AIChatMessage(
+        content: [
           AIChatMessageReasoningBlock(reasoning: 'check', index: 0),
           firstCall,
           AIChatMessageTextBlock(text: 'sunny', index: 2),
         ],
       );
 
-      expect(message.contentBlocks, [
+      expect(message.content, [
         isA<AIChatMessageReasoningBlock>(),
         same(firstCall),
         isA<AIChatMessageTextBlock>(),
       ]);
       expect(message.toolCalls, [firstCall]);
-      expect(message.content, 'checksunny');
+      expect(message.contentAsString, 'sunny');
+
+      const result = ChatResult(
+        id: 'result-1',
+        output: message,
+        finishReason: FinishReason.stop,
+        metadata: {},
+        usage: LanguageModelUsage(),
+      );
+      expect(result.outputAsString, 'sunny');
     });
 
-    test('round-trips canonical and legacy serialization', () {
-      const message = AIChatMessage.withBlocks(
-        legacyContent: 'legacy projection',
-        contentBlocks: [
+    test('round-trips canonical serialization', () {
+      const message = AIChatMessage(
+        content: [
           AIChatMessageReasoningBlock(
             reasoning: 'hidden',
             id: 'reasoning-1',
@@ -53,15 +62,15 @@ void main() {
       final map = message.toMap();
       final restored = AIChatMessage.fromMap(map);
 
-      expect(map['content'], 'legacy projection');
-      expect(map['toolCalls'], hasLength(1));
-      expect(map['contentBlocks'], hasLength(3));
+      expect(map['content'], hasLength(3));
       expect(
-        (map['contentBlocks'] as List).first,
+        (map['content'] as List).first,
         containsPair('isMergeable', false),
       );
+      expect(map, isNot(contains('toolCalls')));
+      expect(map, isNot(contains('contentBlocks')));
       expect(restored, message);
-      expect(restored.content, 'legacy projection');
+      expect(restored.contentAsString, 'visible');
     });
 
     test('reads legacy maps without tool calls', () {
@@ -70,22 +79,36 @@ void main() {
         'content': 'hello',
       });
 
-      expect(message.content, 'hello');
-      expect(message.contentBlocks.single, isA<AIChatMessageTextBlock>());
+      expect(message.contentAsString, 'hello');
+      expect(message.content.single, isA<AIChatMessageTextBlock>());
       expect(message.toolCalls, isEmpty);
+    });
+
+    test('reads transitional content-block maps', () {
+      final message = AIChatMessage.fromMap(const {
+        'type': 'ai',
+        'content': 'legacy projection',
+        'contentBlocks': [
+          {'type': 'reasoning', 'reasoning': 'hidden'},
+          {'type': 'text', 'text': 'visible'},
+        ],
+      });
+
+      expect(message.content, hasLength(2));
+      expect(message.contentAsString, 'visible');
     });
   });
 
   group('AIChatMessage block streaming', () {
     test('merges only matching stable stream identities', () {
-      const first = AIChatMessage.withBlocks(
-        contentBlocks: [
+      const first = AIChatMessage(
+        content: [
           AIChatMessageTextBlock(text: 'hel', index: 0),
           AIChatMessageReasoningBlock(reasoning: 'rea', index: 1),
         ],
       );
-      const second = AIChatMessage.withBlocks(
-        contentBlocks: [
+      const second = AIChatMessage(
+        content: [
           AIChatMessageTextBlock(text: 'lo', index: 0),
           AIChatMessageReasoningBlock(reasoning: 'son', index: 1),
         ],
@@ -93,16 +116,16 @@ void main() {
 
       final result = first.concat(second);
 
-      expect((result.contentBlocks[0] as AIChatMessageTextBlock).text, 'hello');
+      expect((result.content[0] as AIChatMessageTextBlock).text, 'hello');
       expect(
-        (result.contentBlocks[1] as AIChatMessageReasoningBlock).reasoning,
+        (result.content[1] as AIChatMessageReasoningBlock).reasoning,
         'reason',
       );
     });
 
     test('keeps parallel same-name calls separate by stream index', () {
-      const starts = AIChatMessage.withBlocks(
-        contentBlocks: [
+      const starts = AIChatMessage(
+        content: [
           AIChatMessageToolCall(
             id: '',
             index: 0,
@@ -119,8 +142,8 @@ void main() {
           ),
         ],
       );
-      const finishes = AIChatMessage.withBlocks(
-        contentBlocks: [
+      const finishes = AIChatMessage(
+        content: [
           AIChatMessageToolCall(
             id: '',
             index: 0,
@@ -148,39 +171,35 @@ void main() {
     });
 
     test('does not merge blocks without an id or index', () {
-      const first = AIChatMessage.withBlocks(
-        contentBlocks: [AIChatMessageTextBlock(text: 'one')],
+      const first = AIChatMessage(
+        content: [AIChatMessageTextBlock(text: 'one')],
       );
-      const second = AIChatMessage.withBlocks(
-        contentBlocks: [AIChatMessageTextBlock(text: 'two')],
+      const second = AIChatMessage(
+        content: [AIChatMessageTextBlock(text: 'two')],
       );
 
-      expect(first.concat(second).contentBlocks, hasLength(2));
+      expect(first.concat(second).content, hasLength(2));
     });
 
     test('does not let a matching index override different stable ids', () {
-      const first = AIChatMessage.withBlocks(
-        contentBlocks: [
-          AIChatMessageTextBlock(text: 'one', id: 'block-1', index: 0),
-        ],
+      const first = AIChatMessage(
+        content: [AIChatMessageTextBlock(text: 'one', id: 'block-1', index: 0)],
       );
-      const second = AIChatMessage.withBlocks(
-        contentBlocks: [
-          AIChatMessageTextBlock(text: 'two', id: 'block-2', index: 0),
-        ],
+      const second = AIChatMessage(
+        content: [AIChatMessageTextBlock(text: 'two', id: 'block-2', index: 0)],
       );
 
-      expect(first.concat(second).contentBlocks, hasLength(2));
+      expect(first.concat(second).content, hasLength(2));
     });
 
     test('retains completed provider part boundaries', () {
-      const first = AIChatMessage.withBlocks(
-        contentBlocks: [
+      const first = AIChatMessage(
+        content: [
           AIChatMessageTextBlock(text: 'answer', id: 'part-0', index: 0),
         ],
       );
-      const signedBoundary = AIChatMessage.withBlocks(
-        contentBlocks: [
+      const signedBoundary = AIChatMessage(
+        content: [
           AIChatMessageTextBlock(
             text: '',
             id: 'part-0',
@@ -192,9 +211,9 @@ void main() {
 
       final result = first.concat(signedBoundary);
 
-      expect(result.contentBlocks, hasLength(2));
+      expect(result.content, hasLength(2));
       expect(
-        result.contentBlocks.last,
+        result.content.last,
         isA<AIChatMessageTextBlock>().having(
           (block) => block.isMergeable,
           'isMergeable',

--- a/packages/langchain_core/test/chat_models/ai_chat_message_tool_call_test.dart
+++ b/packages/langchain_core/test/chat_models/ai_chat_message_tool_call_test.dart
@@ -105,8 +105,7 @@ void main() {
   group('AIChatMessage.concat tool-call provider data', () {
     test('preserves provider data when merging streamed chunks', () {
       const first = AIChatMessage(
-        content: '',
-        toolCalls: [
+        content: [
           AIChatMessageToolCall(
             id: 'call_1',
             name: 'getWea',
@@ -119,8 +118,7 @@ void main() {
         ],
       );
       const second = AIChatMessage(
-        content: '',
-        toolCalls: [
+        content: [
           AIChatMessageToolCall(
             id: 'call_1',
             name: 'ther',
@@ -142,8 +140,7 @@ void main() {
 
     test('later chunks win on conflicting nested provider-data keys', () {
       const first = AIChatMessage(
-        content: '',
-        toolCalls: [
+        content: [
           AIChatMessageToolCall(
             id: 'call_1',
             name: 'getWeather',
@@ -156,8 +153,7 @@ void main() {
         ],
       );
       const second = AIChatMessage(
-        content: '',
-        toolCalls: [
+        content: [
           AIChatMessageToolCall(
             id: 'call_1',
             name: '',

--- a/packages/langchain_core/test/chat_models/types.dart
+++ b/packages/langchain_core/test/chat_models/types.dart
@@ -20,7 +20,7 @@ void main() {
             ),
           ]),
         ),
-        ChatMessage.ai(
+        ChatMessage.aiText(
           'Assistant Response',
           toolCalls: const [
             AIChatMessageToolCall(
@@ -37,7 +37,11 @@ void main() {
             ),
           ],
         ),
-        ChatMessage.tool(toolCallId: 'some-id2', content: 'Tool Call content'),
+        ChatMessage.tool(
+          toolCallId: 'some-id2',
+          content: 'Tool Call content',
+          name: 'some name',
+        ),
         ChatMessage.custom('huh?', role: 'internal-monologue'),
       ];
       final promptValue = PromptValue.chat(testMessages);
@@ -57,6 +61,17 @@ void main() {
         jsonEncode(PromptValue.fromMap(promptValue.toMap()).toMap()),
         jsonEncode(promptValue.toMap()),
       );
+    });
+
+    test('ToolChatMessage retains the tool name', () {
+      const message = ToolChatMessage(
+        toolCallId: 'call-1',
+        content: 'sunny',
+        name: 'weather',
+      );
+
+      expect(ToolChatMessage.fromMap(message.toMap()), message);
+      expect(message.toMap()['name'], 'weather');
     });
 
     test('ChatToolChoice', () {

--- a/packages/langchain_core/test/output_parsers/string_test.dart
+++ b/packages/langchain_core/test/output_parsers/string_test.dart
@@ -23,7 +23,9 @@ void main() {
     test('StringOutputParser from ChatResult', () async {
       const result = ChatResult(
         id: 'id',
-        output: AIChatMessage(content: 'Hello world!'),
+        output: AIChatMessage(
+          content: [AIChatMessageTextBlock(text: 'Hello world!')],
+        ),
         finishReason: FinishReason.stop,
         metadata: {},
         usage: LanguageModelUsage(),

--- a/packages/langchain_core/test/output_parsers/tools_test.dart
+++ b/packages/langchain_core/test/output_parsers/tools_test.dart
@@ -7,10 +7,10 @@ void main() {
   const result = ChatResult(
     id: 'id',
     output: AIChatMessage(
-      content: '',
-      toolCalls: [
+      content: [
         AIChatMessageToolCall(
           id: 'id',
+          index: 0,
           name: 'test',
           argumentsRaw: '{"foo":"bar","bar":"foo"}',
           arguments: {'foo': 'bar', 'bar': 'foo'},
@@ -26,10 +26,10 @@ void main() {
     ChatResult(
       id: 'id',
       output: AIChatMessage(
-        content: '',
-        toolCalls: [
+        content: [
           AIChatMessageToolCall(
             id: 'id',
+            index: 0,
             name: 'test',
             argumentsRaw: '{"foo":"bar"',
             arguments: {},
@@ -44,10 +44,10 @@ void main() {
     ChatResult(
       id: 'id',
       output: AIChatMessage(
-        content: '',
-        toolCalls: [
+        content: [
           AIChatMessageToolCall(
             id: '',
+            index: 0,
             name: '',
             argumentsRaw: ', ',
             arguments: {},
@@ -62,10 +62,10 @@ void main() {
     ChatResult(
       id: 'id',
       output: AIChatMessage(
-        content: '',
-        toolCalls: [
+        content: [
           AIChatMessageToolCall(
             id: '',
+            index: 0,
             name: '',
             argumentsRaw: '"bar":"foo"}',
             arguments: {},

--- a/packages/langchain_core/test/prompts/chat_prompt_test.dart
+++ b/packages/langchain_core/test/prompts/chat_prompt_test.dart
@@ -24,7 +24,7 @@ void main() {
         ChatMessage.humanText(
           "Hello Foo, I'm Bar. Thanks for the This is a context",
         ),
-        ChatMessage.ai("I'm an AI. I'm Foo. I'm Bar."),
+        ChatMessage.aiText("I'm an AI. I'm Foo. I'm Bar."),
         ChatMessage.custom(
           "I'm a generic message. I'm Foo. I'm Bar.",
           role: 'test',
@@ -55,7 +55,7 @@ void main() {
         ChatMessage.humanText(
           "Hello Foo, I'm Bar. Thanks for the This is a context",
         ),
-        ChatMessage.ai("I'm an AI. I'm Foo. I'm Bar."),
+        ChatMessage.aiText("I'm an AI. I'm Foo. I'm Bar."),
         ChatMessage.custom(
           "I'm a generic message. I'm Foo. I'm Bar.",
           role: 'test',
@@ -87,7 +87,7 @@ void main() {
           ChatMessage.humanText(
             "Hello Foo, I'm Bar. Thanks for the This is a context",
           ),
-          ChatMessage.ai("I'm an AI. I'm Foo. I'm Bar."),
+          ChatMessage.aiText("I'm an AI. I'm Foo. I'm Bar."),
           ChatMessage.custom(
             "I'm a generic message. I'm Foo. I'm Bar.",
             role: 'test',
@@ -311,7 +311,7 @@ void main() {
       final humanMessage = ChatMessage.humanText(
         'What is the best way to learn programming?',
       );
-      final aiMessage = ChatMessage.ai('''
+      final aiMessage = ChatMessage.aiText('''
 1. Choose a programming language: Decide on a programming language that you want to learn. 
 
 2. Start with the basics: Familiarize yourself with the basic programming concepts such as variables, data types and control structures.

--- a/packages/langchain_core/test/runnables/batch_test.dart
+++ b/packages/langchain_core/test/runnables/batch_test.dart
@@ -90,7 +90,7 @@ void main() {
         PromptValue.string('test3'),
       ]);
       expect(
-        res.map((final e) => e.output.content).toList(),
+        res.map((final e) => e.output.contentAsString).toList(),
         equals(['test1', 'test2', 'test3']),
       );
     });

--- a/packages/langchain_core/test/runnables/binding_test.dart
+++ b/packages/langchain_core/test/runnables/binding_test.dart
@@ -100,7 +100,7 @@ class _FakeOptionsChatModel
     return Stream.fromIterable(prompt).map(
       (final char) => ChatResult(
         id: 'fake-options-chat-model',
-        output: AIChatMessage(content: char),
+        output: AIChatMessage.text(char),
         finishReason: FinishReason.stop,
         metadata: const {},
         usage: const LanguageModelUsage(),

--- a/packages/langchain_core/test/runnables/fallbacks_test.dart
+++ b/packages/langchain_core/test/runnables/fallbacks_test.dart
@@ -22,7 +22,7 @@ void main() {
     test('RunnableFallback should return main runnable output', () async {
       final modelWithFallback = model.withFallbacks([fallbackModel]);
       final res = await modelWithFallback.invoke(input);
-      expect(res.output.content, 'why is the sky blue');
+      expect(res.output.contentAsString, 'why is the sky blue');
     });
 
     test('Should call fallback runnable if main runnable fails', () async {
@@ -31,7 +31,7 @@ void main() {
       );
       final modelWithFallback = brokenModel.withFallbacks([fallbackModel]);
       final res = await modelWithFallback.invoke(input);
-      expect(res.output.content, 'fallback response');
+      expect(res.output.contentAsString, 'fallback response');
     });
 
     test('Test batch response of main runnable in RunnableFallback', () async {
@@ -45,8 +45,8 @@ void main() {
         {'topic': 'bears'},
         {'topic': 'cats'},
       ]);
-      expect(res[0].output.content, 'tell me a joke about bears');
-      expect(res[1].output.content, 'tell me a joke about cats');
+      expect(res[0].output.contentAsString, 'tell me a joke about bears');
+      expect(res[1].output.contentAsString, 'tell me a joke about cats');
     });
 
     test('Test fallbacks response in batch', () async {
@@ -60,7 +60,7 @@ void main() {
       final res = await chainWithFallbacks.batch([
         {'topic': 'bears'},
       ]);
-      expect(res.first.output.content, 'fallback response');
+      expect(res.first.output.contentAsString, 'fallback response');
     });
 
     test('Should throw error if none of runnable returned output', () {

--- a/packages/langchain_core/test/runnables/invoke_test.dart
+++ b/packages/langchain_core/test/runnables/invoke_test.dart
@@ -50,7 +50,7 @@ void main() {
     test('ChatModel as Runnable', () async {
       const run = FakeEchoChatModel();
       final res = await run.invoke(PromptValue.string('Hello world!'));
-      expect(res.output.content, 'Hello world!');
+      expect(res.output.contentAsString, 'Hello world!');
     });
 
     test('OutputParser as Runnable', () async {

--- a/packages/langchain_core/test/runnables/retry_test.dart
+++ b/packages/langchain_core/test/runnables/retry_test.dart
@@ -20,7 +20,7 @@ void main() {
     test('Runnable retry should return output for invoke', () async {
       final modelWithRetry = model.withRetry(maxRetries: 2);
       final res = await modelWithRetry.invoke(input);
-      expect(res.output.content, 'why is the sky blue');
+      expect(res.output.contentAsString, 'why is the sky blue');
     });
 
     test('Runnable retry should return output for batch', () async {
@@ -30,8 +30,8 @@ void main() {
         {'topic': 'bears'},
         {'topic': 'cats'},
       ]);
-      expect(res[0].output.content, 'tell me a joke about bears');
-      expect(res[1].output.content, 'tell me a joke about cats');
+      expect(res[0].output.contentAsString, 'tell me a joke about bears');
+      expect(res[1].output.contentAsString, 'tell me a joke about cats');
     });
 
     test('Should retry based RetryOptions, maxRetries = 2', () {

--- a/packages/langchain_core/test/runnables/stream_test.dart
+++ b/packages/langchain_core/test/runnables/stream_test.dart
@@ -80,7 +80,7 @@ void main() {
       expect(streamList.length, 12);
       expect(streamList, isA<List<ChatResult>>());
 
-      final res = streamList.map((final i) => i.output.content).join();
+      final res = streamList.map((final i) => i.output.contentAsString).join();
       expect(res, 'Hello world!');
     });
 
@@ -233,7 +233,7 @@ void main() {
       output = output?.concat(i) ?? i;
     });
     expect(count, 11);
-    expect(output?.output.content, 'Hello World');
+    expect(output?.output.contentAsString, 'Hello World');
   });
 
   test('Test call to Tool from streaming input', () async {

--- a/packages/langchain_firebase/example/lib/main.dart
+++ b/packages/langchain_firebase/example/lib/main.dart
@@ -314,7 +314,7 @@ class _ChatWidgetState extends State<ChatWidget> {
       _generatedContent.add((image: null, text: message, fromUser: true));
 
       final response = await _chain.invoke(chatMessage);
-      final text = response.output.content;
+      final text = response.output.contentAsString;
       _generatedContent.add((image: null, text: text, fromUser: false));
 
       if (text.isEmpty) {
@@ -377,7 +377,7 @@ class _ChatWidgetState extends State<ChatWidget> {
 
       final response = await _chain.invoke(chatMessage);
 
-      final text = response.output.content;
+      final text = response.output.contentAsString;
       _generatedContent.add((image: null, text: text, fromUser: false));
 
       if (text.isEmpty) {
@@ -418,7 +418,7 @@ class _ChatWidgetState extends State<ChatWidget> {
 
       _generatedContent.add((image: null, text: message, fromUser: true));
       final response = await _chain.invoke(chatMessage);
-      final text = response.output.content;
+      final text = response.output.contentAsString;
       _generatedContent.add((image: null, text: text, fromUser: false));
 
       if (text.isEmpty) {
@@ -481,6 +481,7 @@ class _ChatWidgetState extends State<ChatWidget> {
       final toolMessage = ChatMessage.tool(
         toolCallId: toolCall.id,
         content: jsonEncode(result),
+        name: toolCall.name,
       );
 
       response = await _chain.invoke(toolMessage);
@@ -490,10 +491,10 @@ class _ChatWidgetState extends State<ChatWidget> {
       );
     }
     // When the model responds with non-null text content, print it.
-    if (response.output.content.isNotEmpty) {
+    if (response.output.contentAsString.isNotEmpty) {
       _generatedContent.add((
         image: null,
-        text: response.output.content,
+        text: response.output.contentAsString,
         fromUser: false,
       ));
       setState(() {

--- a/packages/langchain_firebase/lib/src/chat_models/firebase_parts_mapper.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/firebase_parts_mapper.dart
@@ -16,21 +16,8 @@ List<AIChatMessageContentBlock> firebasePartsToContentBlocks(
     ),
 ];
 
-String firebasePartsToLegacyContent(final List<f.Part> parts) => parts
-    .map(
-      (part) => switch (part) {
-        final f.TextPart part => part.text,
-        final f.InlineDataPart part => base64Encode(part.bytes),
-        final f.FileData part => part.fileUri,
-        f.Part() => '',
-      },
-    )
-    .join('\n');
-
-List<f.Part> aiMessageToFirebaseParts(final AIChatMessage message) => message
-    .contentBlocks
-    .map(_contentBlockToFirebasePart)
-    .toList(growable: false);
+List<f.Part> aiMessageToFirebaseParts(final AIChatMessage message) =>
+    message.content.map(_contentBlockToFirebasePart).toList(growable: false);
 
 AIChatMessageContentBlock _firebasePartToContentBlock(
   final f.Part part, {

--- a/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_firebase/lib/src/chat_models/vertex_ai/mappers.dart
@@ -103,7 +103,11 @@ extension ChatMessagesMapper on List<ChatMessage> {
     } catch (_) {
       response = {'result': msg.content};
     }
-    return f.FunctionResponse(msg.toolCallId, response);
+    return f.FunctionResponse(
+      msg.name ?? msg.toolCallId,
+      response,
+      id: msg.toolCallId,
+    );
   }
 
   f.Content _mapCustomChatMessage(final CustomChatMessage msg) {
@@ -116,12 +120,11 @@ extension GenerateContentResponseMapper on f.GenerateContentResponse {
     final candidate = candidates.first;
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: firebasePartsToContentBlocks(
+      output: AIChatMessage(
+        content: firebasePartsToContentBlocks(
           candidate.content.parts,
           responseId: id,
         ),
-        legacyContent: firebasePartsToLegacyContent(candidate.content.parts),
       ),
       finishReason: _mapFinishReason(candidate.finishReason),
       metadata: {

--- a/packages/langchain_firebase/test/chat_models/vertex_ai/mappers_test.dart
+++ b/packages/langchain_firebase/test/chat_models/vertex_ai/mappers_test.dart
@@ -32,7 +32,7 @@ void main() {
     final message = response.toChatResult('response-1', 'gemini').output;
     final replayed = <ChatMessage>[message].toContentList().single.parts;
 
-    expect(message.contentBlocks.map((block) => block.runtimeType), [
+    expect(message.content.map((block) => block.runtimeType), [
       AIChatMessageReasoningBlock,
       AIChatMessageTextBlock,
       AIChatMessageToolCall,
@@ -40,7 +40,7 @@ void main() {
     ]);
     expect(message.toolCalls.single.id, 'call-1');
     expect(
-      ((message.contentBlocks.first.providerData['firebase']
+      ((message.content.first.providerData['firebase']
               as Map<String, dynamic>)['part']
           as Map<String, dynamic>)['thoughtSignature'],
       signature,
@@ -101,9 +101,9 @@ void main() {
     ).toChatResult('stream-id', 'gemini').output;
     final merged = first.concat(signedBoundary);
 
-    expect(merged.contentBlocks, hasLength(2));
+    expect(merged.content, hasLength(2));
     expect(
-      merged.contentBlocks.last,
+      merged.content.last,
       isA<AIChatMessageTextBlock>()
           .having((block) => block.text, 'text', isEmpty)
           .having((block) => block.isMergeable, 'isMergeable', isFalse),
@@ -119,5 +119,19 @@ void main() {
       (replayed.last.toJson() as Map<String, Object?>)['thoughtSignature'],
       signature,
     );
+  });
+
+  test('maps opaque tool-call IDs separately from function names', () {
+    final content = <ChatMessage>[
+      ChatMessage.tool(
+        toolCallId: 'call-1',
+        name: 'weather',
+        content: '{"temperature":22}',
+      ),
+    ].toContentList();
+
+    final response = content.single.parts.single as f.FunctionResponse;
+    expect(response.id, 'call-1');
+    expect(response.name, 'weather');
   });
 }

--- a/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_ai/mappers.dart
@@ -111,7 +111,11 @@ extension ChatMessagesMapper on List<ChatMessage> {
       response = {'result': msg.content};
     }
     return g.FunctionResponsePart(
-      g.FunctionResponse(name: msg.toolCallId, response: response),
+      g.FunctionResponse(
+        id: msg.toolCallId,
+        name: msg.name ?? msg.toolCallId,
+        response: response,
+      ),
     );
   }
 
@@ -129,13 +133,10 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
 
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: googlePartsToContentBlocks(
+      output: AIChatMessage(
+        content: googlePartsToContentBlocks(
           candidate.content?.parts ?? const [],
           responseId: id,
-        ),
-        legacyContent: googlePartsToLegacyContent(
-          candidate.content?.parts ?? const [],
         ),
       ),
       finishReason: _mapFinishReason(candidate.finishReason),

--- a/packages/langchain_google/lib/src/chat_models/google_parts_mapper.dart
+++ b/packages/langchain_google/lib/src/chat_models/google_parts_mapper.dart
@@ -17,21 +17,8 @@ List<AIChatMessageContentBlock> googlePartsToContentBlocks(
     ),
 ];
 
-String googlePartsToLegacyContent(final List<g.Part> parts) => parts
-    .map(
-      (part) => switch (part) {
-        final g.TextPart part => part.text,
-        final g.InlineDataPart part => part.inlineData.data,
-        final g.FileDataPart part => part.fileData.fileUri,
-        g.Part() => '',
-      },
-    )
-    .join('\n');
-
-List<g.Part> aiMessageToGoogleParts(final AIChatMessage message) => message
-    .contentBlocks
-    .map(_contentBlockToGooglePart)
-    .toList(growable: false);
+List<g.Part> aiMessageToGoogleParts(final AIChatMessage message) =>
+    message.content.map(_contentBlockToGooglePart).toList(growable: false);
 
 AIChatMessageContentBlock _googlePartToContentBlock(
   final g.Part part, {

--- a/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
+++ b/packages/langchain_google/lib/src/chat_models/vertex_ai/mappers.dart
@@ -111,7 +111,11 @@ extension ChatMessagesMapper on List<ChatMessage> {
       response = {'result': msg.content};
     }
     return g.FunctionResponsePart(
-      g.FunctionResponse(name: msg.toolCallId, response: response),
+      g.FunctionResponse(
+        id: msg.toolCallId,
+        name: msg.name ?? msg.toolCallId,
+        response: response,
+      ),
     );
   }
 
@@ -129,13 +133,10 @@ extension GenerateContentResponseMapper on g.GenerateContentResponse {
 
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: googlePartsToContentBlocks(
+      output: AIChatMessage(
+        content: googlePartsToContentBlocks(
           candidate.content?.parts ?? const [],
           responseId: id,
-        ),
-        legacyContent: googlePartsToLegacyContent(
-          candidate.content?.parts ?? const [],
         ),
       ),
       finishReason: _mapFinishReason(candidate.finishReason),

--- a/packages/langchain_google/test/chat_models/google_ai/chat_google_generative_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/chat_google_generative_ai_test.dart
@@ -53,7 +53,7 @@ void main() {
         expect(res.metadata['model'], startsWith(model));
         expect(res.metadata['block_reason'], isNull);
         expect(
-          res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
+          res.output.contentAsString.replaceAll(RegExp(r'[\s\n]'), ''),
           contains('123456789'),
         );
       }
@@ -70,7 +70,7 @@ void main() {
           temperature: 0,
         ),
       );
-      expect(res.output.content, isNotEmpty);
+      expect(res.output.contentAsString, isNotEmpty);
     });
 
     test('Text-and-image input', () async {
@@ -92,7 +92,7 @@ void main() {
         ]),
       );
 
-      expect(res.output.content.toLowerCase(), contains('apple'));
+      expect(res.output.contentAsString.toLowerCase(), contains('apple'));
     });
 
     test('Test stop sequence', () async {
@@ -106,7 +106,7 @@ void main() {
           stopSequences: ['4'],
         ),
       );
-      final text = res.output.content;
+      final text = res.output.contentAsString;
       expect(text, contains('123'));
       expect(text, isNot(contains('456789')));
     });
@@ -119,7 +119,7 @@ void main() {
           maxOutputTokens: 2,
         ),
       );
-      expect(res.output.content.length, lessThan(20));
+      expect(res.output.contentAsString.length, lessThan(20));
       expect(res.finishReason, FinishReason.length);
     });
 
@@ -129,7 +129,7 @@ void main() {
           'List the numbers from 1 to 9 in order '
           'without any spaces, commas or additional explanations.',
         ),
-        ChatMessage.ai('123456789'),
+        ChatMessage.aiText('123456789'),
         ChatMessage.humanText('Remove the number 4 from the list'),
       ]);
       final res = await chatModel.invoke(
@@ -139,7 +139,7 @@ void main() {
           temperature: 0,
         ),
       );
-      expect(res.output.content, contains('12356789'));
+      expect(res.output.contentAsString, contains('12356789'));
     });
 
     test('Test streaming', () async {
@@ -153,7 +153,7 @@ void main() {
       var content = '';
       var count = 0;
       await for (final res in stream) {
-        content += res.output.content;
+        content += res.output.contentAsString;
         count++;
       }
       expect(count, greaterThan(1));
@@ -180,7 +180,7 @@ void main() {
 
         expect(chunks, hasLength(greaterThan(1)));
         final merged = chunks.reduce((first, next) => first.concat(next));
-        final signedBlocks = merged.output.contentBlocks
+        final signedBlocks = merged.output.content
             .where((block) {
               final googleData = block.providerData['google'];
               final rawPart = googleData is Map ? googleData['part'] : null;
@@ -270,6 +270,7 @@ void main() {
         final functionMessage1 = ChatMessage.tool(
           toolCallId: toolCall1.id,
           content: json.encode(functionResult1),
+          name: toolCall1.name,
         );
 
         final functionResult2 = {
@@ -280,6 +281,7 @@ void main() {
         final functionMessage2 = ChatMessage.tool(
           toolCallId: toolCall2.id,
           content: json.encode(functionResult2),
+          name: toolCall2.name,
         );
 
         final res2 = await model.invoke(
@@ -294,8 +296,8 @@ void main() {
         final aiMessage2 = res2.output;
 
         expect(aiMessage2.toolCalls, isEmpty);
-        expect(aiMessage2.content, contains('22'));
-        expect(aiMessage2.content, contains('25'));
+        expect(aiMessage2.contentAsString, contains('22'));
+        expect(aiMessage2.contentAsString, contains('25'));
       },
     );
 
@@ -309,7 +311,7 @@ void main() {
           enableCodeExecution: true,
         ),
       );
-      final text = res.output.content;
+      final text = res.output.contentAsString;
       expect(text, contains('34'));
       expect(res.metadata['executable_code'], isNotNull);
       expect(res.metadata['code_execution_result'], isNotNull);
@@ -365,6 +367,7 @@ void main() {
           ChatMessage.tool(
             toolCallId: call.id,
             content: json.encode({'result': result}),
+            name: call.name,
           ),
         );
       }
@@ -377,8 +380,8 @@ void main() {
       final aiMessage2 = res2.output;
       expect(aiMessage2.toolCalls, isEmpty);
       // The final answer should incorporate both tool results: 3 and 13.
-      expect(aiMessage2.content, contains('3'));
-      expect(aiMessage2.content, contains('13'));
+      expect(aiMessage2.contentAsString, contains('3'));
+      expect(aiMessage2.contentAsString, contains('13'));
     });
   });
 }

--- a/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/google_ai/mappers_test.dart
@@ -91,8 +91,7 @@ void main() {
       final first = response.toChatResult('id-1', 'gemini-2.5-flash').output;
       final merged = first.concat(
         AIChatMessage(
-          content: '',
-          toolCalls: [
+          content: [
             AIChatMessageToolCall(
               id: first.toolCalls.single.id,
               name: '',
@@ -135,9 +134,9 @@ void main() {
           .output;
       final merged = first.concat(signedBoundary);
 
-      expect(merged.contentBlocks, hasLength(2));
+      expect(merged.content, hasLength(2));
       expect(
-        merged.contentBlocks.last,
+        merged.content.last,
         isA<AIChatMessageTextBlock>()
             .having((block) => block.text, 'text', isEmpty)
             .having((block) => block.isMergeable, 'isMergeable', isFalse),
@@ -159,8 +158,7 @@ void main() {
         final signature = utf8.encode('signature-bytes');
         final messages = <ChatMessage>[
           AIChatMessage(
-            content: '',
-            toolCalls: [
+            content: [
               AIChatMessageToolCall(
                 id: 'getWeather',
                 name: 'getWeather',
@@ -184,8 +182,7 @@ void main() {
     test('maps no thoughtSignature when provider data lacks one', () {
       final messages = <ChatMessage>[
         const AIChatMessage(
-          content: '',
-          toolCalls: [
+          content: [
             AIChatMessageToolCall(
               id: 'getWeather',
               name: 'getWeather',
@@ -200,6 +197,34 @@ void main() {
 
       final part = content.single.parts.single as g.FunctionCallPart;
       expect(part.thoughtSignature, isNull);
+    });
+
+    test('maps opaque tool-call IDs separately from function names', () {
+      final content = <ChatMessage>[
+        ChatMessage.tool(
+          toolCallId: 'call-madrid',
+          name: 'getWeather',
+          content: '{"temperature":22}',
+        ),
+        ChatMessage.tool(
+          toolCallId: 'call-paris',
+          name: 'getWeather',
+          content: '{"temperature":25}',
+        ),
+      ].toContentList();
+
+      final responses = content.single.parts
+          .whereType<g.FunctionResponsePart>()
+          .map((part) => part.functionResponse)
+          .toList();
+      expect(responses.map((response) => response.id), [
+        'call-madrid',
+        'call-paris',
+      ]);
+      expect(responses.map((response) => response.name), [
+        'getWeather',
+        'getWeather',
+      ]);
     });
   });
 
@@ -251,7 +276,7 @@ void main() {
 
       final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
-      expect(result.output.content, startsWith('visible'));
+      expect(result.output.contentAsString, startsWith('visible'));
     });
 
     test('preserves ordered parts and common metadata through replay', () {
@@ -318,7 +343,7 @@ void main() {
       final message = response.toChatResult('response-1', 'gemini').output;
       final replayed = <ChatMessage>[message].toContentList().single.parts;
 
-      expect(message.contentBlocks.map((block) => block.runtimeType), [
+      expect(message.content.map((block) => block.runtimeType), [
         AIChatMessageReasoningBlock,
         AIChatMessageTextBlock,
         AIChatMessageMediaBlock,

--- a/packages/langchain_google/test/chat_models/vertex_ai/chat_vertex_ai_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai/chat_vertex_ai_test.dart
@@ -58,7 +58,7 @@ void main() {
       );
       final messages = [ChatMessage.humanText('Tell me a joke.')];
       final res = await chat(messages);
-      expect(res.content, isNotEmpty);
+      expect(res.contentAsString, isNotEmpty);
     });
 
     test('Test invoke to ChatVertexAI', () async {
@@ -75,7 +75,7 @@ void main() {
         ChatMessage.humanText('Tell me a joke.'),
       ]);
       final res = await chat.invoke(prompt);
-      expect(res.output.content, isNotEmpty);
+      expect(res.output.contentAsString, isNotEmpty);
     });
 
     test('Test stream to ChatVertexAI', () async {
@@ -94,7 +94,7 @@ void main() {
       final results = await stream.toList();
       expect(results, isNotEmpty);
       for (final result in results) {
-        expect(result.output.content, isNotEmpty);
+        expect(result.output.contentAsString, isNotEmpty);
       }
     });
 

--- a/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
+++ b/packages/langchain_google/test/chat_models/vertex_ai/mappers_test.dart
@@ -91,8 +91,7 @@ void main() {
       final first = response.toChatResult('id-1', 'gemini-2.5-flash').output;
       final merged = first.concat(
         AIChatMessage(
-          content: '',
-          toolCalls: [
+          content: [
             AIChatMessageToolCall(
               id: first.toolCalls.single.id,
               name: '',
@@ -135,9 +134,9 @@ void main() {
           .output;
       final merged = first.concat(signedBoundary);
 
-      expect(merged.contentBlocks, hasLength(2));
+      expect(merged.content, hasLength(2));
       expect(
-        merged.contentBlocks.last,
+        merged.content.last,
         isA<AIChatMessageTextBlock>()
             .having((block) => block.text, 'text', isEmpty)
             .having((block) => block.isMergeable, 'isMergeable', isFalse),
@@ -159,8 +158,7 @@ void main() {
         final signature = utf8.encode('signature-bytes');
         final messages = <ChatMessage>[
           AIChatMessage(
-            content: '',
-            toolCalls: [
+            content: [
               AIChatMessageToolCall(
                 id: 'getWeather',
                 name: 'getWeather',
@@ -184,8 +182,7 @@ void main() {
     test('maps no thoughtSignature when provider data lacks one', () {
       final messages = <ChatMessage>[
         const AIChatMessage(
-          content: '',
-          toolCalls: [
+          content: [
             AIChatMessageToolCall(
               id: 'getWeather',
               name: 'getWeather',
@@ -200,6 +197,34 @@ void main() {
 
       final part = content.single.parts.single as g.FunctionCallPart;
       expect(part.thoughtSignature, isNull);
+    });
+
+    test('maps opaque tool-call IDs separately from function names', () {
+      final content = <ChatMessage>[
+        ChatMessage.tool(
+          toolCallId: 'call-madrid',
+          name: 'getWeather',
+          content: '{"temperature":22}',
+        ),
+        ChatMessage.tool(
+          toolCallId: 'call-paris',
+          name: 'getWeather',
+          content: '{"temperature":25}',
+        ),
+      ].toContentList();
+
+      final responses = content.single.parts
+          .whereType<g.FunctionResponsePart>()
+          .map((part) => part.functionResponse)
+          .toList();
+      expect(responses.map((response) => response.id), [
+        'call-madrid',
+        'call-paris',
+      ]);
+      expect(responses.map((response) => response.name), [
+        'getWeather',
+        'getWeather',
+      ]);
     });
   });
 
@@ -251,7 +276,7 @@ void main() {
 
       final result = response.toChatResult('id-1', 'gemini-2.5-flash');
 
-      expect(result.output.content, startsWith('visible'));
+      expect(result.output.contentAsString, startsWith('visible'));
     });
 
     test('preserves ordered parts and common metadata through replay', () {
@@ -318,7 +343,7 @@ void main() {
       final message = response.toChatResult('response-1', 'gemini').output;
       final replayed = <ChatMessage>[message].toContentList().single.parts;
 
-      expect(message.contentBlocks.map((block) => block.runtimeType), [
+      expect(message.content.map((block) => block.runtimeType), [
         AIChatMessageReasoningBlock,
         AIChatMessageTextBlock,
         AIChatMessageMediaBlock,

--- a/packages/langchain_mistralai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_mistralai/lib/src/chat_models/mappers.dart
@@ -21,7 +21,7 @@ extension ChatMessageListMapper on List<ChatMessage> {
       final ToolChatMessage msg => mistral.ChatMessage.tool(
         toolCallId: msg.toolCallId,
         content: msg.content,
-        name: null,
+        name: msg.name,
       ),
       CustomChatMessage() => throw UnsupportedError(
         'Mistral AI does not support custom messages',
@@ -30,23 +30,24 @@ extension ChatMessageListMapper on List<ChatMessage> {
   }
 
   mistral.AssistantMessage _mapAIMessage(final AIChatMessage msg) {
-    final nativeParts = msg.contentBlocks
+    final nativeParts = msg.content
         .where((block) => block is! AIChatMessageToolCall)
         .map(_mapContentBlock)
         .nonNulls
         .toList(growable: false);
-    final hasNativePartData = msg.contentBlocks.any(
+    final hasNativePartData = msg.content.any(
       (block) => _nativeContentPart(block) != null,
     );
-    final hasStructuredContent = msg.contentBlocks.any(
+    final hasStructuredContent = msg.content.any(
       (block) =>
           block is! AIChatMessageTextBlock && block is! AIChatMessageToolCall,
     );
+    final visibleContent = msg.contentAsString;
     final content =
         nativeParts.isNotEmpty && (hasNativePartData || hasStructuredContent)
         ? mistral.MessageContent.parts(nativeParts)
-        : msg.content.isNotEmpty
-        ? mistral.MessageContent.text(msg.content)
+        : visibleContent.isNotEmpty
+        ? mistral.MessageContent.text(visibleContent)
         : null;
     return mistral.AssistantMessage(
       content: content,
@@ -140,10 +141,7 @@ extension ChatResultMapper on mistral.ChatCompletionResponse {
     ];
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: contentBlocks,
-        legacyContent: _visibleText(contentBlocks),
-      ),
+      output: AIChatMessage(content: contentBlocks),
       finishReason: _mapFinishReason(finishReason),
       metadata: {'model': model, 'created': created},
       usage: _mapUsage(usage),
@@ -176,10 +174,7 @@ extension CreateChatCompletionStreamResponseMapper
           );
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: contentBlocks,
-        legacyContent: choice?.delta.content ?? '',
-      ),
+      output: AIChatMessage(content: contentBlocks),
       finishReason: _mapFinishReason(finishReason),
       metadata: {'model': model, 'created': created},
       usage: _mapStreamUsage(usage),
@@ -392,11 +387,6 @@ String _contentPartsText(final List<mistral.ContentPart> parts) => parts
         _ => '',
       },
     )
-    .join();
-
-String _visibleText(final List<AIChatMessageContentBlock> blocks) => blocks
-    .whereType<AIChatMessageTextBlock>()
-    .map((block) => block.text)
     .join();
 
 FinishReason _mapFinishReason(final mistral.FinishReason? reason) =>

--- a/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
+++ b/packages/langchain_mistralai/test/chat_models/chat_mistralai_test.dart
@@ -46,14 +46,14 @@ void main() {
     test('Test call to ChatMistralAI', () async {
       final output = await chatModel([ChatMessage.humanText('Say foo:')]);
       expect(output, isA<AIChatMessage>());
-      expect(output.content, isNotEmpty);
+      expect(output.contentAsString, isNotEmpty);
     });
 
     test('Test invoke to ChatMistralAI', () async {
       final res = await chatModel.invoke(
         PromptValue.chat([ChatMessage.humanText('Hello, how are you?')]),
       );
-      expect(res.output.content, isNotEmpty);
+      expect(res.output.contentAsString, isNotEmpty);
     });
 
     test('Test model output contains metadata', () async {
@@ -67,7 +67,7 @@ void main() {
         ]),
       );
       expect(
-        res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
+        res.output.contentAsString.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('123456789'),
       );
       expect(res.id, isNotEmpty);

--- a/packages/langchain_mistralai/test/chat_models/mappers_content_blocks_test.dart
+++ b/packages/langchain_mistralai/test/chat_models/mappers_content_blocks_test.dart
@@ -32,11 +32,11 @@ void main() {
 
     final message = response.toChatResult().output;
 
-    expect(message.contentBlocks.map((block) => block.runtimeType), [
+    expect(message.content.map((block) => block.runtimeType), [
       AIChatMessageTextBlock,
       AIChatMessageToolCall,
     ]);
-    expect(message.content, 'Checking the weather.');
+    expect(message.contentAsString, 'Checking the weather.');
     expect(message.toolCalls.single.arguments, {'city': 'Madrid'});
     final providerData =
         message.toolCalls.single.providerData['mistral']
@@ -76,19 +76,19 @@ void main() {
     final replayed =
         [message].toChatMessages().single as mistral.AssistantMessage;
 
-    expect(message.contentBlocks.map((block) => block.runtimeType), [
+    expect(message.content.map((block) => block.runtimeType), [
       AIChatMessageReasoningBlock,
       AIChatMessageTextBlock,
       AIChatMessageNonStandardBlock,
     ]);
-    expect(message.content, 'answer');
+    expect(message.contentAsString, 'answer');
     final original = response.message! as mistral.AssistantMessage;
     expect(replayed.content!.toJson(), original.content!.toJson());
   });
 
   test('replays raw tool-call arguments', () {
-    const message = AIChatMessage.withBlocks(
-      contentBlocks: [
+    const message = AIChatMessage(
+      content: [
         AIChatMessageToolCall(
           id: 'call-1',
           name: 'weather',
@@ -108,8 +108,8 @@ void main() {
   });
 
   test('replays explicitly constructed reasoning as structured content', () {
-    const message = AIChatMessage.withBlocks(
-      contentBlocks: [
+    const message = AIChatMessage(
+      content: [
         AIChatMessageReasoningBlock(reasoning: 'reasoning'),
         AIChatMessageTextBlock(text: 'answer'),
       ],
@@ -121,6 +121,21 @@ void main() {
 
     expect(parts.first, isA<mistral.ThinkContentPart>());
     expect(parts.last, const mistral.TextContentPart('answer'));
+  });
+
+  test('replays a tool response with its call ID and name', () {
+    final mapped =
+        <ChatMessage>[
+              ChatMessage.tool(
+                toolCallId: 'call-1',
+                name: 'weather',
+                content: '{"temperature":22}',
+              ),
+            ].toChatMessages().single
+            as mistral.ToolMessage;
+
+    expect(mapped.toolCallId, 'call-1');
+    expect(mapped.name, 'weather');
   });
 
   test('streams parallel same-name calls by provider index', () {

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama/mappers.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama/mappers.dart
@@ -178,15 +178,15 @@ extension OllamaChatMessagesMapper on List<ChatMessage> {
   }
 
   List<o.ChatMessage> _mapAIMessage(final AIChatMessage message) {
-    final reasoning = message.contentBlocks
+    final reasoning = message.content
         .whereType<AIChatMessageReasoningBlock>()
         .map((block) => block.reasoning)
         .join();
-    final content = message.contentBlocks
+    final content = message.content
         .whereType<AIChatMessageTextBlock>()
         .map((block) => block.text)
         .join();
-    final images = message.contentBlocks
+    final images = message.content
         .whereType<AIChatMessageMediaBlock>()
         .map((block) => block.data)
         .toList(growable: false);
@@ -218,10 +218,7 @@ extension ChatResultMapper on o.ChatResponse {
     final contentBlocks = _mapOllamaMessage(message, responseId: id);
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: contentBlocks,
-        legacyContent: '${message?.thinking ?? ''}${message?.content ?? ''}',
-      ),
+      output: AIChatMessage(content: contentBlocks),
       finishReason: _mapFinishReason(doneReason),
       metadata: {
         'model': model,
@@ -266,10 +263,7 @@ extension ChatStreamResultMapper on o.ChatStreamEvent {
     final contentBlocks = _mapOllamaMessage(message, responseId: id);
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: contentBlocks,
-        legacyContent: '${message?.thinking ?? ''}${message?.content ?? ''}',
-      ),
+      output: AIChatMessage(content: contentBlocks),
       finishReason: doneReason != null
           ? _mapOllamaFinishReason(doneReason)
           : (done ?? false)

--- a/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
+++ b/packages/langchain_ollama/test/chat_models/chat_ollama_test.dart
@@ -111,7 +111,7 @@ void main() {
         ]),
       );
       expect(
-        res.output.content.replaceAll(RegExp(r'[\s\n-]'), ''),
+        res.output.contentAsString.replaceAll(RegExp(r'[\s\n-]'), ''),
         contains('123456789'),
       );
       expect(res.finishReason, FinishReason.stop);
@@ -131,8 +131,8 @@ void main() {
         PromptValue.string('write an ordered list of five items'),
         options: const ChatOllamaOptions(temperature: 0, stop: ['3']),
       );
-      expect(res.output.content.contains('2.'), isTrue);
-      expect(res.output.content.contains('3.'), isFalse);
+      expect(res.output.contentAsString.contains('2.'), isTrue);
+      expect(res.output.contentAsString.contains('3.'), isFalse);
       expect(res.finishReason, FinishReason.stop);
     });
 
@@ -203,7 +203,7 @@ void main() {
     test('Test Multi-turn conversations', () async {
       final prompt = PromptValue.chat([
         ChatMessage.humanText('List the numbers from 1 to 9 in order.'),
-        ChatMessage.ai('123456789'),
+        ChatMessage.aiText('123456789'),
         ChatMessage.humanText(
           'Remove the number "4" from the list. Output only the remaining numbers in ascending order.',
         ),
@@ -213,7 +213,7 @@ void main() {
         options: const ChatOllamaOptions(temperature: 0),
       );
       expect(
-        res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
+        res.output.contentAsString.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('12356789'),
       );
     });
@@ -238,7 +238,7 @@ void main() {
         options: const ChatOllamaOptions(model: visionModel, temperature: 0),
       );
 
-      expect(res.output.content.toLowerCase(), contains('apple'));
+      expect(res.output.contentAsString.toLowerCase(), contains('apple'));
     });
 
     const tool1 = ToolSpec(
@@ -314,6 +314,7 @@ void main() {
         final functionMessage1 = ChatMessage.tool(
           toolCallId: toolCall1.id,
           content: json.encode(functionResult1),
+          name: toolCall1.name,
         );
 
         final functionResult2 = {
@@ -324,6 +325,7 @@ void main() {
         final functionMessage2 = ChatMessage.tool(
           toolCallId: toolCall2.id,
           content: json.encode(functionResult2),
+          name: toolCall2.name,
         );
 
         final res2 = await model.invoke(
@@ -338,8 +340,8 @@ void main() {
         final aiMessage2 = res2.output;
 
         expect(aiMessage2.toolCalls, isEmpty);
-        expect(aiMessage2.content, contains('22'));
-        expect(aiMessage2.content, contains('25'));
+        expect(aiMessage2.contentAsString, contains('22'));
+        expect(aiMessage2.contentAsString, contains('25'));
       },
     );
 
@@ -379,7 +381,7 @@ void main() {
         ),
       );
       expect(res.output.toolCalls, isEmpty);
-      expect(res.output.content, isNotEmpty);
+      expect(res.output.contentAsString, isNotEmpty);
     });
 
     test('Test ChatToolChoice.forced', () async {

--- a/packages/langchain_ollama/test/chat_models/mappers_content_blocks_test.dart
+++ b/packages/langchain_ollama/test/chat_models/mappers_content_blocks_test.dart
@@ -33,14 +33,14 @@ void main() {
 
     final message = response.toChatResult('response-1').output;
 
-    expect(message.contentBlocks.map((block) => block.runtimeType), [
+    expect(message.content.map((block) => block.runtimeType), [
       AIChatMessageReasoningBlock,
       AIChatMessageTextBlock,
       AIChatMessageMediaBlock,
       AIChatMessageToolCall,
       AIChatMessageToolCall,
     ]);
-    expect(message.content, 'reasoninganswer');
+    expect(message.contentAsString, 'answer');
     expect(message.toolCalls.map((call) => call.id), [
       'ollama:response-1:tool:0',
       'ollama:response-1:tool:1',
@@ -93,14 +93,11 @@ void main() {
         .concat(second.toChatResult('response-1', streaming: true).output);
 
     expect(
-      message.contentBlocks
-          .whereType<AIChatMessageReasoningBlock>()
-          .single
-          .reasoning,
+      message.content.whereType<AIChatMessageReasoningBlock>().single.reasoning,
       'reasoning',
     );
     expect(
-      message.contentBlocks.whereType<AIChatMessageTextBlock>().single.text,
+      message.content.whereType<AIChatMessageTextBlock>().single.text,
       'answer',
     );
   });

--- a/packages/langchain_openai/lib/src/agents/tools.dart
+++ b/packages/langchain_openai/lib/src/agents/tools.dart
@@ -176,6 +176,7 @@ class OpenAIToolsAgent extends BaseSingleActionAgent {
       final functionMsg = ChatMessage.tool(
         toolCallId: lastStep.action.id,
         content: lastStep.observation,
+        name: lastStep.action.tool,
       );
       agentInput = functionMsg;
     } else {
@@ -212,6 +213,7 @@ class OpenAIToolsAgent extends BaseSingleActionAgent {
                   ChatMessage.tool(
                     toolCallId: s.action.id,
                     content: s.observation,
+                    name: s.action.tool,
                   ),
                 ];
           })
@@ -300,7 +302,7 @@ class OpenAIToolsAgentOutputParser
               log:
                   'Invoking: `${toolCall.name}` '
                   'with `${toolCall.arguments}`\n'
-                  'Responded: ${message.content}\n',
+                  'Responded: ${message.contentAsString}\n',
               messageLog: [message],
             );
           })
@@ -308,8 +310,8 @@ class OpenAIToolsAgentOutputParser
     } else {
       return [
         AgentFinish(
-          returnValues: {'output': message.content},
-          log: message.content,
+          returnValues: {'output': message.contentAsString},
+          log: message.contentAsString,
         ),
       ];
     }

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
@@ -61,9 +61,8 @@ oai.CreateResponseRequest createResponseRequest(
 extension ChatMessageListResponseMapper on List<ChatMessage> {
   oai.ResponseInput toResponseInput() {
     final containsResponseOutput = whereType<AIChatMessage>().any(
-      (message) => message.contentBlocks.any(
-        (block) => _openAIOutputItem(block) != null,
-      ),
+      (message) =>
+          message.content.any((block) => _openAIOutputItem(block) != null),
     );
     if (containsResponseOutput) {
       return oai.ResponseInput.fromOutputItems(
@@ -82,7 +81,7 @@ extension ChatMessageListResponseMapper on List<ChatMessage> {
       return;
     }
     final emittedItems = <String>{};
-    for (final block in message.contentBlocks) {
+    for (final block in message.content) {
       final rawItem = _openAIOutputItem(block);
       if (rawItem != null) {
         final key = '${rawItem['type']}:${rawItem['id'] ?? block.index}';
@@ -166,7 +165,7 @@ extension ChatMessageListResponseMapper on List<ChatMessage> {
   // as separate items (unlike Chat Completions which groups them in one message).
   Iterable<oai.Item> _mapAIMessage(final AIChatMessage msg) {
     final items = <oai.Item>[];
-    for (final block in msg.contentBlocks) {
+    for (final block in msg.content) {
       switch (block) {
         case final AIChatMessageTextBlock text:
           if (text.text.isNotEmpty) {
@@ -199,10 +198,7 @@ extension ResponseMapper on oai.Response {
   ChatResult toChatResult() {
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: _mapOpenAIOutputItems(output),
-        legacyContent: outputText,
-      ),
+      output: AIChatMessage(content: _mapOpenAIOutputItems(output)),
       finishReason: _mapFinishReason(status),
       metadata: {'model': model, 'created_at': createdAt},
       usage: _mapResponseUsage(usage),
@@ -305,8 +301,8 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
       case oai.RefusalDeltaEvent(:final delta):
         return ChatResult(
           id: responseId ?? '',
-          output: AIChatMessage.withBlocks(
-            contentBlocks: [
+          output: AIChatMessage(
+            content: [
               AIChatMessageNonStandardBlock(
                 value: event.toJson(),
                 id: _responseContentBlockId(
@@ -334,7 +330,7 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
         final result = response.toChatResult();
         return ChatResult(
           id: result.id,
-          output: const AIChatMessage.withBlocks(contentBlocks: []),
+          output: const AIChatMessage(content: []),
           finishReason: result.finishReason,
           metadata: result.metadata,
           usage: result.usage,
@@ -349,13 +345,7 @@ extension ResponseStreamAccumulatorMapper on oai.ResponseStreamAccumulator {
 
     return ChatResult(
       id: responseId ?? '',
-      output: AIChatMessage.withBlocks(
-        contentBlocks: blocks,
-        legacyContent: blocks
-            .whereType<AIChatMessageTextBlock>()
-            .map((block) => block.legacyContent)
-            .join(),
-      ),
+      output: AIChatMessage(content: blocks),
       finishReason: _mapStreamFinishReason(status),
       metadata: const {},
       usage: _mapResponseUsage(usage),

--- a/packages/langchain_openai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/mappers.dart
@@ -140,7 +140,7 @@ extension ChatMessageListMapper on List<ChatMessage> {
 
   oai.ChatMessage _mapAIMessage(final AIChatMessage aiChatMessage) {
     return oai.ChatMessage.assistant(
-      content: aiChatMessage.content,
+      content: aiChatMessage.contentAsString,
       toolCalls: aiChatMessage.toolCalls.isNotEmpty
           ? aiChatMessage.toolCalls
                 .map(_mapMessageToolCall)
@@ -181,8 +181,8 @@ extension CreateChatCompletionResponseMapper on oai.ChatCompletion {
 
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: [
+      output: AIChatMessage(
+        content: [
           if (msg.hasReasoningContent)
             AIChatMessageReasoningBlock(
               reasoning: msg.reasoningContent ?? msg.reasoning ?? '',
@@ -210,7 +210,6 @@ extension CreateChatCompletionResponseMapper on oai.ChatCompletion {
           for (final (index, toolCall) in (msg.toolCalls ?? const []).indexed)
             _mapMessageToolCall(toolCall, index: index + 2, responseId: id),
         ],
-        legacyContent: msg.content ?? '',
       ),
       finishReason: _mapFinishReason(choice.finishReason),
       metadata: {
@@ -291,8 +290,8 @@ extension CreateChatCompletionStreamResponseMapper on oai.ChatStreamEvent {
 
     return ChatResult(
       id: id,
-      output: AIChatMessage.withBlocks(
-        contentBlocks: [
+      output: AIChatMessage(
+        content: [
           if (delta?.hasReasoningContent ?? false)
             AIChatMessageReasoningBlock(
               reasoning: delta?.reasoningContent ?? delta?.reasoning ?? '',
@@ -315,7 +314,6 @@ extension CreateChatCompletionStreamResponseMapper on oai.ChatStreamEvent {
               in delta?.toolCalls ?? const <oai.ToolCallDelta>[])
             _mapMessageToolCall(toolCall, responseId: id),
         ],
-        legacyContent: delta?.content ?? '',
       ),
       finishReason: _mapFinishReason(choice?.finishReason),
       metadata: {

--- a/packages/langchain_openai/test/agents/tools_test.dart
+++ b/packages/langchain_openai/test/agents/tools_test.dart
@@ -144,6 +144,7 @@ void main() {
                       ChatMessage.tool(
                         toolCallId: s.action.id,
                         content: s.observation,
+                        name: s.action.tool,
                       ),
                     ];
               })

--- a/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
@@ -33,7 +33,7 @@ void main() {
       });
 
       test('should map AIChatMessage to assistant text item', () {
-        final messages = [ChatMessage.ai('I am fine.')];
+        final messages = [ChatMessage.aiText('I am fine.')];
         final input = messages.toResponseInput();
 
         final items = switch (input) {
@@ -46,7 +46,7 @@ void main() {
 
       test('should map AIChatMessage with tool calls to separate items', () {
         final messages = [
-          ChatMessage.ai(
+          ChatMessage.aiText(
             'Let me check.',
             toolCalls: const [
               AIChatMessageToolCall(
@@ -76,7 +76,7 @@ void main() {
 
       test('should map AIChatMessage without content to only tool calls', () {
         final messages = [
-          ChatMessage.ai(
+          ChatMessage.aiText(
             '',
             toolCalls: const [
               AIChatMessageToolCall(
@@ -272,13 +272,13 @@ void main() {
         final message = response.toChatResult().output;
         final replayed = <ChatMessage>[message].toResponseInput();
 
-        expect(message.contentBlocks.map((block) => block.runtimeType), [
+        expect(message.content.map((block) => block.runtimeType), [
           AIChatMessageReasoningBlock,
           AIChatMessageTextBlock,
           AIChatMessageToolCall,
           AIChatMessageServerToolCall,
         ]);
-        expect(message.content, 'I will check.');
+        expect(message.contentAsString, 'I will check.');
         expect(message.toolCalls.single.id, 'call_1');
         expect(replayed.toJson(), output);
       });
@@ -371,7 +371,7 @@ void main() {
             .map((result) => result.output)
             .reduce((first, next) => first.concat(next));
 
-        expect(output.contentBlocks, hasLength(2));
+        expect(output.content, hasLength(2));
         expect(output.contentAsString, 'firstsecond');
       });
 
@@ -402,8 +402,7 @@ void main() {
         final output = results
             .map((result) => result.output)
             .reduce((first, next) => first.concat(next));
-        final block =
-            output.contentBlocks.single as AIChatMessageServerToolCall;
+        final block = output.content.single as AIChatMessageServerToolCall;
 
         expect(block.name, 'web_search_call');
         expect(block.arguments['status'], 'completed');

--- a/packages/langchain_openai/test/chat_models/chat_openai_responses_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_responses_test.dart
@@ -42,7 +42,7 @@ void main() {
           final res = await chatModel.invoke(
             PromptValue.chat([ChatMessage.humanText('Say "hi"')]),
           );
-          expect(res.output.content, isNotEmpty);
+          expect(res.output.contentAsString, isNotEmpty);
           expect(res.id, isNotEmpty);
           expect(res.finishReason, FinishReason.stop);
           expect(res.metadata, containsPair('model', contains('gpt-4o-mini')));
@@ -55,7 +55,7 @@ void main() {
               ChatMessage.humanText('Hello'),
             ]),
           );
-          expect(res.output.content.toLowerCase(), contains('ok'));
+          expect(res.output.contentAsString.toLowerCase(), contains('ok'));
         });
       });
 
@@ -74,7 +74,7 @@ void main() {
 
           expect(count, greaterThan(1));
           expect(result, isNotNull);
-          expect(result!.output.content, isNotEmpty);
+          expect(result!.output.contentAsString, isNotEmpty);
           expect(result.finishReason, FinishReason.stop);
         });
       });
@@ -138,17 +138,18 @@ void main() {
           final res2 = await model.invoke(
             PromptValue.chat([
               ChatMessage.humanText('What is the weather in Barcelona?'),
-              ChatMessage.ai(
-                res1.output.content,
+              ChatMessage.aiText(
+                res1.output.contentAsString,
                 toolCalls: res1.output.toolCalls,
               ),
               ChatMessage.tool(
                 toolCallId: toolCall.id,
                 content: '{"temperature": 22, "condition": "sunny"}',
+                name: toolCall.name,
               ),
             ]),
           );
-          expect(res2.output.content, isNotEmpty);
+          expect(res2.output.contentAsString, isNotEmpty);
 
           model.close();
         });
@@ -228,10 +229,10 @@ void main() {
             ]),
           );
 
-          expect(res.output.content, isNotEmpty);
+          expect(res.output.contentAsString, isNotEmpty);
           // Should be valid JSON
-          expect(res.output.content, contains('"name"'));
-          expect(res.output.content, contains('"country"'));
+          expect(res.output.contentAsString, contains('"name"'));
+          expect(res.output.contentAsString, contains('"country"'));
 
           model.close();
         });
@@ -259,7 +260,10 @@ void main() {
             PromptValue.chat([ChatMessage.humanText('What is my name?')]),
             options: ChatOpenAIResponsesOptions(previousResponseId: res1.id),
           );
-          expect(res2.output.content.toLowerCase(), contains('langchaindart'));
+          expect(
+            res2.output.contentAsString.toLowerCase(),
+            contains('langchaindart'),
+          );
 
           model.close();
         });

--- a/packages/langchain_openai/test/chat_models/chat_openai_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_test.dart
@@ -52,7 +52,7 @@ void main() {
         ),
       );
       final res = await chat([ChatMessage.humanText('Hello')]);
-      expect(res.content, isNotEmpty);
+      expect(res.contentAsString, isNotEmpty);
     });
 
     test('Test generate to ChatOpenAI', () async {
@@ -60,11 +60,11 @@ void main() {
       final res = await chat.invoke(
         PromptValue.chat([
           ChatMessage.humanText('Hello, how are you?'),
-          ChatMessage.ai('I am fine, thank you.'),
+          ChatMessage.aiText('I am fine, thank you.'),
           ChatMessage.humanText('Good, what is your name?'),
         ]),
       );
-      expect(res.output.content, isNotEmpty);
+      expect(res.output.contentAsString, isNotEmpty);
     });
 
     test('Test model output contains metadata', () async {
@@ -97,8 +97,8 @@ void main() {
       final res = await chat([
         query,
       ], options: const ChatOpenAIOptions(stop: ['3']));
-      expect(res.content.contains('2.'), isTrue);
-      expect(res.content.contains('3.'), isFalse);
+      expect(res.contentAsString.contains('2.'), isTrue);
+      expect(res.contentAsString.contains('3.'), isFalse);
     });
 
     test('Test ChatOpenAI wrapper with system message', () async {
@@ -116,7 +116,7 @@ void main() {
         'write an ordered list of five items',
       );
       final res = await chat([systemMessage, humanMessage]);
-      expect(res.content, isNotEmpty);
+      expect(res.contentAsString, isNotEmpty);
     });
 
     const getCurrentWeatherTool = ToolSpec(
@@ -155,7 +155,7 @@ void main() {
 
         final aiMessage1 = res1.output;
 
-        expect(aiMessage1.content, isEmpty);
+        expect(aiMessage1.contentAsString, isEmpty);
         expect(aiMessage1.toolCalls, isNotEmpty);
         final toolCall = aiMessage1.toolCalls.first;
 
@@ -171,6 +171,7 @@ void main() {
         final functionMessage = ChatMessage.tool(
           toolCallId: toolCall.id,
           content: json.encode(functionResult),
+          name: toolCall.name,
         );
 
         final res2 = await chat.invoke(
@@ -181,7 +182,7 @@ void main() {
         final aiMessage2 = res2.output;
 
         expect(aiMessage2.toolCalls, isEmpty);
-        expect(aiMessage2.content, contains('22'));
+        expect(aiMessage2.contentAsString, contains('22'));
       },
     );
 
@@ -260,7 +261,7 @@ void main() {
       }
       expect(count, greaterThan(1));
       expect(
-        result!.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
+        result!.output.contentAsString.replaceAll(RegExp(r'[\s\n]'), ''),
         contains('123456789'),
       );
       expect(result.usage.promptTokens, greaterThan(0));
@@ -364,7 +365,8 @@ void main() {
 
       final res = await llm.invoke(prompt);
       final outputMsg = res.output;
-      final outputJson = json.decode(outputMsg.content) as Map<String, dynamic>;
+      final outputJson =
+          json.decode(outputMsg.contentAsString) as Map<String, dynamic>;
       expect(outputJson['companies'], isNotNull);
       final companies = outputJson['companies'] as List<dynamic>;
       expect(companies, hasLength(2));
@@ -423,7 +425,8 @@ void main() {
 
       final res = await llm.invoke(prompt);
       final outputMsg = res.output;
-      final outputJson = json.decode(outputMsg.content) as Map<String, dynamic>;
+      final outputJson =
+          json.decode(outputMsg.contentAsString) as Map<String, dynamic>;
       expect(outputJson['companies'], isNotNull);
       final companies = outputJson['companies'] as List<dynamic>;
       expect(companies, hasLength(2));
@@ -454,7 +457,7 @@ void main() {
       );
 
       final res = await chatModel.invoke(prompt);
-      expect(res.output.content.toLowerCase(), contains('apple'));
+      expect(res.output.contentAsString.toLowerCase(), contains('apple'));
     });
 
     test('Test multi-modal GPT-4 Vision with base64 image', () async {
@@ -477,7 +480,7 @@ void main() {
       );
 
       final res = await chatModel.invoke(prompt);
-      expect(res.output.content.toLowerCase(), contains('apple'));
+      expect(res.output.contentAsString.toLowerCase(), contains('apple'));
     });
 
     test('Test additive bind calls', () async {

--- a/packages/langchain_openai/test/chat_models/github_models_test.dart
+++ b/packages/langchain_openai/test/chat_models/github_models_test.dart
@@ -48,7 +48,7 @@ void main() {
 
         expect(res.id, isNotEmpty);
         expect(
-          res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
+          res.output.contentAsString.replaceAll(RegExp(r'[\s\n]'), ''),
           contains('123456789'),
         );
         expect(res.metadata, isNotEmpty, reason: model);
@@ -78,7 +78,10 @@ void main() {
         var content = '';
         var count = 0;
         await for (final res in stream) {
-          content += res.output.content.replaceAll(RegExp(r'[\s\n]'), '');
+          content += res.output.contentAsString.replaceAll(
+            RegExp(r'[\s\n]'),
+            '',
+          );
           count++;
         }
         expect(count, greaterThan(1), reason: model);
@@ -140,7 +143,7 @@ void main() {
 
         final aiMessage1 = res1.output;
 
-        expect(aiMessage1.content, isEmpty);
+        expect(aiMessage1.contentAsString, isEmpty);
         expect(aiMessage1.toolCalls, isNotEmpty);
         final toolCall = aiMessage1.toolCalls.first;
 
@@ -156,6 +159,7 @@ void main() {
         final functionMessage = ChatMessage.tool(
           toolCallId: toolCall.id,
           content: json.encode(functionResult),
+          name: toolCall.name,
         );
 
         final res2 = await chatModel.invoke(
@@ -166,7 +170,7 @@ void main() {
         final aiMessage2 = res2.output;
 
         expect(aiMessage2.toolCalls, isEmpty);
-        expect(aiMessage2.content, contains('22'));
+        expect(aiMessage2.contentAsString, contains('22'));
       },
     );
   });

--- a/packages/langchain_openai/test/chat_models/mappers_content_blocks_test.dart
+++ b/packages/langchain_openai/test/chat_models/mappers_content_blocks_test.dart
@@ -31,12 +31,12 @@ void main() {
 
     final message = completion.toChatResult('completion-1').output;
 
-    expect(message.contentBlocks.map((block) => block.runtimeType), [
+    expect(message.content.map((block) => block.runtimeType), [
       AIChatMessageReasoningBlock,
       AIChatMessageTextBlock,
       AIChatMessageToolCall,
     ]);
-    expect(message.content, 'answer');
+    expect(message.contentAsString, 'answer');
     expect(message.toolCalls.single.arguments, {'city': 'Madrid'});
   });
 

--- a/packages/langchain_openai/test/chat_models/open_router_test.dart
+++ b/packages/langchain_openai/test/chat_models/open_router_test.dart
@@ -47,7 +47,7 @@ void main() {
 
         expect(res.id, isNotEmpty);
         expect(
-          res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
+          res.output.contentAsString.replaceAll(RegExp(r'[\s\n]'), ''),
           contains('123456789'),
         );
         expect(res.metadata, isNotEmpty, reason: model);
@@ -79,7 +79,10 @@ void main() {
         var content = '';
         var count = 0;
         await for (final res in stream) {
-          content += res.output.content.replaceAll(RegExp(r'[\s\n]'), '');
+          content += res.output.contentAsString.replaceAll(
+            RegExp(r'[\s\n]'),
+            '',
+          );
           count++;
         }
         expect(count, greaterThan(1), reason: model);
@@ -142,7 +145,7 @@ void main() {
 
         final aiMessage1 = res1.output;
 
-        expect(aiMessage1.content, isEmpty);
+        expect(aiMessage1.contentAsString, isEmpty);
         expect(aiMessage1.toolCalls, isNotEmpty);
         final toolCall = aiMessage1.toolCalls.first;
 
@@ -158,6 +161,7 @@ void main() {
         final functionMessage = ChatMessage.tool(
           toolCallId: toolCall.id,
           content: json.encode(functionResult),
+          name: toolCall.name,
         );
 
         final res2 = await chatModel.invoke(
@@ -168,7 +172,7 @@ void main() {
         final aiMessage2 = res2.output;
 
         expect(aiMessage2.toolCalls, isEmpty);
-        expect(aiMessage2.content, contains('22'));
+        expect(aiMessage2.contentAsString, contains('22'));
       },
     );
   });

--- a/packages/langchain_openai/test/chat_models/together_ai_test.dart
+++ b/packages/langchain_openai/test/chat_models/together_ai_test.dart
@@ -44,7 +44,7 @@ void main() {
 
         expect(res.id, isNotEmpty);
         expect(
-          res.output.content.replaceAll(RegExp(r'[\s\n]'), ''),
+          res.output.contentAsString.replaceAll(RegExp(r'[\s\n]'), ''),
           contains('123456789'),
         );
         expect(res.metadata, isNotEmpty, reason: model);
@@ -75,7 +75,10 @@ void main() {
         var content = '';
         var count = 0;
         await for (final res in stream) {
-          content += res.output.content.replaceAll(RegExp(r'[\s\n]'), '');
+          content += res.output.contentAsString.replaceAll(
+            RegExp(r'[\s\n]'),
+            '',
+          );
           count++;
         }
         expect(count, greaterThan(1), reason: model);

--- a/packages/langchain_pinecone/test/vector_stores/pinecone_test.dart
+++ b/packages/langchain_pinecone/test/vector_stores/pinecone_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/packages/langchain_supabase/test/vector_stores/supabase_test.dart
+++ b/packages/langchain_supabase/test/vector_stores/supabase_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Tags(['integration'])
 library; // Uses dart:io
 
 import 'dart:io';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -131,8 +131,8 @@ melos:
         diff: origin/main...HEAD
 
     analyze:
-      description: Run Flutter static analyzer
-      run: melos exec -- "flutter analyze ."
+      description: Analyze the full workspace
+      run: dart analyze .
 
     analyze:diff:
       description: Run Flutter static analyzer
@@ -157,6 +157,32 @@ melos:
       packageFilters:
         flutter: true
         dirExists: test
+
+    test:unit:
+      run: melos run test:unit:dart --no-select && melos run test:unit:firebase --no-select
+      description: Run all non-live tests in this project.
+
+    test:unit:dart:
+      run: melos exec -c 1 --fail-fast -- "dart test test --exclude-tags=integration"
+      description: Run non-live Dart tests for a specific package.
+      packageFilters:
+        flutter: false
+        dirExists: test
+        ignore:
+          - langchain_chroma
+          - langchain_firebase
+          - langchain_supabase
+
+    test:unit:flutter:
+      run: melos exec -c 1 --fail-fast -- "flutter test test --exclude-tags=integration"
+      description: Run non-live Flutter tests for a specific package.
+      packageFilters:
+        flutter: true
+        dirExists: test
+
+    test:unit:firebase:
+      run: melos exec -c 1 --scope=langchain_firebase -- "flutter test test --exclude-tags=integration"
+      description: Run non-live langchain_firebase tests with the Flutter test runner.
 
     test:diff:
       run: melos run test:diff:dart --no-select && melos run test:diff:firebase --no-select

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -132,7 +132,7 @@ melos:
 
     analyze:
       description: Analyze the full workspace
-      run: dart analyze .
+      run: melos exec -c 1 -- "flutter analyze --no-pub ."
 
     analyze:diff:
       description: Run Flutter static analyzer


### PR DESCRIPTION
## Summary

- Makes `AIChatMessage.content` the canonical ordered `List<AIChatMessageContentBlock>` after every supported provider has migrated.
- Updates agents, histories, fakes, serialization, examples, and provider request replay to use block-native AI messages.
- Adds a full-workspace CI gate for analysis and all non-live unit tests while retaining fast diff-filtered jobs.
- Keeps the legacy-map reader for persisted-history compatibility.

## Details

`AIChatMessage.toolCalls` remains available as a derived getter. Canonical map serialization writes ordered content blocks, while `fromMap` continues reading legacy string/tool-call maps.

Streaming concatenation merges blocks only by stable provider identity or explicit stream index. Tool-result messages retain both the opaque call ID and function name, so agents can route parallel same-name calls without conflating their results.

The migration guide documents the new constructors, block access, serialization behavior, reasoning projection, and tool-call identity rules.

The fast diff workflow uses a secret-free `pull_request` event and excludes integration tests, so normal pull requests safely test their own merge ref. The new full-workspace workflow analyzes and tests all packages independently of the diff filter.

This final convergence PR builds on the provider migrations merged through #966.

## Breaking changes

### AI message content is block-native

```dart
// Before
final message = AIChatMessage(content: 'Hello');
final text = message.content;

// After
final message = AIChatMessage.text('Hello');
final blocks = message.content;
final text = message.contentAsString;
```

`AIChatMessage.content` is now a block list. The deprecated string constructor/getter and transitional serialization output are removed; legacy map input remains supported.

### String projections contain visible text only

```dart
final visibleText = message.contentAsString;
final reasoning = message.content
    .whereType<AIChatMessageReasoningBlock>()
    .map((block) => block.reasoning)
    .join();
```

`contentAsString` and `ChatResult.outputAsString` no longer include hidden reasoning.

### Google tool-call IDs are opaque

Code must not assume `toolCall.id == toolCall.name`. IDs use provider values when available or deterministic response/candidate/part coordinates, keeping parallel same-name calls distinct.

## References

- #942
- #945
- #960
- Migration guide: `packages/langchain_core/MIGRATION.md`

## Test plan

- [x] Bootstrap all 27 workspace packages using published dependencies only
- [x] Confirm full-workspace formatting (483 files, 0 changes)
- [x] Run full-workspace `melos analyze` with no diagnostics
- [x] Run every non-live Dart and Firebase/Flutter unit test
- [x] Validate both workflow YAML files
- [x] Run `git diff --check`
