### PR TITLE
fix(langchain_openai): preserve OpenRouter reasoning through agents

### DIFF
--- a/examples/docs_examples/bin/modules/agents/agent_types/tools_agent.dart
+++ b/examples/docs_examples/bin/modules/agents/agent_types/tools_agent.dart
@@ -113,27 +113,13 @@ Future<void> _toolsAgentLCEL() async {
 
   const outputParser = ToolsAgentOutputParser();
 
-  List<ChatMessage> buildScratchpad(final List<AgentStep> intermediateSteps) {
-    return intermediateSteps
-        .map((s) {
-          return s.action.messageLog +
-              [
-                ChatMessage.tool(
-                  toolCallId: s.action.id,
-                  content: s.observation,
-                  name: s.action.tool,
-                ),
-              ];
-        })
-        .expand((m) => m)
-        .toList(growable: false);
-  }
-
   final agent = Agent.fromRunnable(
     Runnable.mapInput(
       (AgentPlanInput planInput) => <String, dynamic>{
         'input': planInput.inputs['input'],
-        'agent_scratchpad': buildScratchpad(planInput.intermediateSteps),
+        'agent_scratchpad': buildToolAgentScratchpad(
+          planInput.intermediateSteps,
+        ),
       },
     ).pipe(prompt).pipe(model).pipe(outputParser),
     tools: [tool],

--- a/packages/langchain/lib/src/agents/executor.dart
+++ b/packages/langchain/lib/src/agents/executor.dart
@@ -127,10 +127,19 @@ class AgentExecutor extends BaseChain {
       }
 
       if (nextSteps != null) {
-        intermediateSteps.addAll(nextSteps);
+        final stampedSteps = nextSteps
+            .map(
+              (step) => AgentStep(
+                action: step.action,
+                observation: step.observation,
+                iteration: iterations,
+              ),
+            )
+            .toList(growable: false);
+        intermediateSteps.addAll(stampedSteps);
 
-        if (nextSteps.length == 1) {
-          final nextStep = nextSteps.first;
+        if (stampedSteps.length == 1) {
+          final nextStep = stampedSteps.first;
           final tool = nameToToolMap[nextStep.action.tool];
 
           if (tool != null && tool.returnDirect) {

--- a/packages/langchain/lib/src/agents/tools.dart
+++ b/packages/langchain/lib/src/agents/tools.dart
@@ -173,16 +173,21 @@ class ToolsAgent extends BaseSingleActionAgent {
   ) {
     final dynamic agentInput;
 
-    // If there is a memory, we pass the last agent step as a function message.
+    // If there is memory, pass every tool result from the latest iteration.
     // Otherwise, we pass the input as a human message.
     if (llmChain.memory != null && intermediateSteps.isNotEmpty) {
-      final lastStep = intermediateSteps.last;
-      final functionMsg = ChatMessage.tool(
-        toolCallId: lastStep.action.id,
-        content: lastStep.observation,
-        name: lastStep.action.tool,
-      );
-      agentInput = functionMsg;
+      final toolMessages = _latestIterationSteps(intermediateSteps)
+          .map(
+            (step) => ChatMessage.tool(
+              toolCallId: step.action.id,
+              content: step.observation,
+              name: step.action.tool,
+            ),
+          )
+          .toList(growable: false);
+      agentInput = toolMessages.length == 1
+          ? toolMessages.single
+          : toolMessages;
     } else {
       agentInput = switch (inputs[agentInputKey]) {
         final String inputStr => ChatMessage.humanText(inputStr),
@@ -208,22 +213,7 @@ class ToolsAgent extends BaseSingleActionAgent {
 
   List<ChatMessage> _constructScratchPad(
     final List<AgentStep> intermediateSteps,
-  ) {
-    return [
-      ...intermediateSteps
-          .map((final s) {
-            return s.action.messageLog +
-                [
-                  ChatMessage.tool(
-                    toolCallId: s.action.id,
-                    content: s.observation,
-                    name: s.action.tool,
-                  ),
-                ];
-          })
-          .expand((final m) => m),
-    ];
-  }
+  ) => buildToolAgentScratchpad(intermediateSteps);
 
   @override
   String get agentType => 'tool-agent';
@@ -256,6 +246,16 @@ class ToolsAgent extends BaseSingleActionAgent {
         ),
     ]);
   }
+}
+
+List<AgentStep> _latestIterationSteps(final List<AgentStep> steps) {
+  final lastIteration = steps.last.iteration;
+  if (lastIteration == null) return [steps.last];
+  var start = steps.length - 1;
+  while (start > 0 && steps[start - 1].iteration == lastIteration) {
+    start -= 1;
+  }
+  return steps.sublist(start);
 }
 
 /// {@template tools_agent_output_parser}

--- a/packages/langchain/test/agents/executor_test.dart
+++ b/packages/langchain/test/agents/executor_test.dart
@@ -129,6 +129,29 @@ void main() {
       final result = await executor.run('test');
       expect(result, 'mock');
     });
+
+    test('stamps parallel actions with one zero-based iteration', () async {
+      final firstTool = _MockTool(name: 'first');
+      final secondTool = _MockTool(name: 'second');
+      final agent = _MultiActionMockAgent(
+        tools: [firstTool, secondTool],
+        actions: const [
+          AgentAction(id: 'call-1', tool: 'first', toolInput: {'input': 'a'}),
+          AgentAction(id: 'call-2', tool: 'second', toolInput: {'input': 'b'}),
+        ],
+      );
+      final executor = AgentExecutor(
+        agent: agent,
+        maxIterations: 1,
+        returnIntermediateSteps: true,
+      );
+
+      final result = await executor.call('test');
+      final steps =
+          result[AgentExecutor.intermediateStepsOutputKey] as List<AgentStep>;
+
+      expect(steps.map((step) => step.iteration), [0, 0]);
+    });
   });
 
   group('Tool output serialization tests', () {

--- a/packages/langchain/test/agents/tools_agent_test.dart
+++ b/packages/langchain/test/agents/tools_agent_test.dart
@@ -157,19 +157,9 @@ AgentExecutor testLCDLEquivalent({
     Runnable.mapInput(
       (AgentPlanInput planInput) => <String, dynamic>{
         'input': planInput.inputs['input'],
-        'agent_scratchpad': planInput.intermediateSteps
-            .map((s) {
-              return s.action.messageLog +
-                  [
-                    ChatMessage.tool(
-                      toolCallId: s.action.id,
-                      content: s.observation,
-                      name: s.action.tool,
-                    ),
-                  ];
-            })
-            .expand((m) => m)
-            .toList(growable: false),
+        'agent_scratchpad': buildToolAgentScratchpad(
+          planInput.intermediateSteps,
+        ),
       },
     ).pipe(prompt).pipe(llm).pipe(const ToolsAgentOutputParser()),
     tools: [tool],

--- a/packages/langchain/test/memory/buffer_test.dart
+++ b/packages/langchain/test/memory/buffer_test.dart
@@ -55,6 +55,27 @@ void main() {
       expect(result2, {BaseMemory.defaultMemoryKey: expectedResult});
     });
 
+    test('Test ordered chat message lists as input and output', () async {
+      final memory = ConversationBufferMemory(returnMessages: true);
+      final input = <ChatMessage>[
+        ChatMessage.tool(toolCallId: 'call-1', content: 'one'),
+        ChatMessage.tool(toolCallId: 'call-2', content: 'two'),
+      ];
+      final output = <ChatMessage>[
+        ChatMessage.aiText('three'),
+        ChatMessage.aiText('four'),
+      ];
+
+      await memory.saveContext(
+        inputValues: {'input': input},
+        outputValues: {'output': output},
+      );
+
+      expect(await memory.loadMemoryVariables(), {
+        BaseMemory.defaultMemoryKey: [...input, ...output],
+      });
+    });
+
     test('Test buffer memory with pre-loaded history', () async {
       final pastMessages = [
         ChatMessage.humanText("My name's Jonas"),

--- a/packages/langchain_core/lib/src/agents/agents.dart
+++ b/packages/langchain_core/lib/src/agents/agents.dart
@@ -1,2 +1,3 @@
 export 'base.dart';
+export 'scratchpad.dart';
 export 'types.dart';

--- a/packages/langchain_core/lib/src/agents/scratchpad.dart
+++ b/packages/langchain_core/lib/src/agents/scratchpad.dart
@@ -1,0 +1,62 @@
+import 'package:collection/collection.dart';
+
+import '../chat_models/types.dart';
+import 'types.dart';
+
+/// Builds the ordered chat transcript for tool-agent intermediate steps.
+///
+/// Parallel actions from one planning iteration contain the same assistant
+/// [AgentAction.messageLog]. When their logs match, this helper emits that log
+/// once followed by every tool result. Steps without an [AgentStep.iteration],
+/// or custom steps with inconsistent logs, retain the legacy per-step layout.
+List<ChatMessage> buildToolAgentScratchpad(
+  final List<AgentStep> intermediateSteps,
+) {
+  final messages = <ChatMessage>[];
+  var index = 0;
+  while (index < intermediateSteps.length) {
+    final step = intermediateSteps[index];
+    final iteration = step.iteration;
+    if (iteration == null) {
+      _appendLegacyStep(messages, step);
+      index += 1;
+      continue;
+    }
+
+    var end = index + 1;
+    while (end < intermediateSteps.length &&
+        intermediateSteps[end].iteration == iteration) {
+      end += 1;
+    }
+    final group = intermediateSteps.sublist(index, end);
+    const equality = DeepCollectionEquality();
+    final sharedLog = group.first.action.messageLog;
+    final logsMatch = group.every(
+      (candidate) => equality.equals(candidate.action.messageLog, sharedLog),
+    );
+
+    if (logsMatch) {
+      messages
+        ..addAll(sharedLog)
+        ..addAll(group.map(_toolResultMessage));
+    } else {
+      for (final candidate in group) {
+        _appendLegacyStep(messages, candidate);
+      }
+    }
+    index = end;
+  }
+  return messages;
+}
+
+void _appendLegacyStep(final List<ChatMessage> messages, final AgentStep step) {
+  messages
+    ..addAll(step.action.messageLog)
+    ..add(_toolResultMessage(step));
+}
+
+ToolChatMessage _toolResultMessage(final AgentStep step) => ToolChatMessage(
+  toolCallId: step.action.id,
+  content: step.observation,
+  name: step.action.tool,
+);

--- a/packages/langchain_core/lib/src/agents/types.dart
+++ b/packages/langchain_core/lib/src/agents/types.dart
@@ -70,13 +70,23 @@ class AgentFinish extends BaseAgentAction {
 /// {@endtemplate}
 class AgentStep {
   /// {@macro agent_step}
-  const AgentStep({required this.action, required this.observation});
+  const AgentStep({
+    required this.action,
+    required this.observation,
+    this.iteration,
+  });
 
   /// The action taken by the agent.
   final AgentAction action;
 
   /// The observation of the action.
   final String observation;
+
+  /// The zero-based planning iteration that produced this action.
+  ///
+  /// All parallel actions returned by one planning call share the same value.
+  /// Custom executors may leave this unset for legacy per-step behavior.
+  final int? iteration;
 }
 
 /// {@template agent_early_stopping_method}

--- a/packages/langchain_core/lib/src/memory/chat.dart
+++ b/packages/langchain_core/lib/src/memory/chat.dart
@@ -47,16 +47,28 @@ abstract base class BaseChatMemory implements BaseMemory {
     // this is purposefully done in sequence so they're saved in order
     final (input, output) = _getInputOutputValues(inputValues, outputValues);
 
-    if (input is ChatMessage) {
-      await chatHistory.addChatMessage(input);
-    } else {
-      await chatHistory.addHumanChatMessage(input.toString());
-    }
+    await _saveValue(input, isInput: true);
+    await _saveValue(output, isInput: false);
+  }
 
-    if (output is ChatMessage) {
-      await chatHistory.addChatMessage(output);
+  Future<void> _saveValue(
+    final dynamic value, {
+    required final bool isInput,
+  }) async {
+    if (value is ChatMessage) {
+      await chatHistory.addChatMessage(value);
+      return;
+    }
+    if (value is List<ChatMessage>) {
+      for (final message in value) {
+        await chatHistory.addChatMessage(message);
+      }
+      return;
+    }
+    if (isInput) {
+      await chatHistory.addHumanChatMessage(value.toString());
     } else {
-      await chatHistory.addAIChatMessage(output.toString());
+      await chatHistory.addAIChatMessage(value.toString());
     }
   }
 

--- a/packages/langchain_core/lib/src/prompts/chat_prompt.dart
+++ b/packages/langchain_core/lib/src/prompts/chat_prompt.dart
@@ -705,13 +705,11 @@ CustomChatMessagePromptTemplate{
 }
 
 /// {@template message_placeholder}
-/// Prompt template that assumes the variable is a [ChatMessage] ([ChatMessageType.messagePlaceholder]).
+/// Prompt template that accepts one [ChatMessage] or an ordered message list
+/// ([ChatMessageType.messagePlaceholder]).
 ///
-/// This is useful when you want to use a single [ChatMessage] in the prompt.
-/// For example, when you decide the type of message at runtime (e.g.
-/// [HumanChatMessage] or [FunctionChatMessage]).
-///
-/// If you need to add multiple messages, use [MessagesPlaceholder].
+/// This is useful when the value can be either a single runtime-selected
+/// message or a group of messages that must stay at the same prompt position.
 ///
 /// Example:
 /// ```dart
@@ -753,8 +751,17 @@ final class MessagePlaceholder extends ChatMessagePromptTemplate {
   List<ChatMessage> formatMessages([
     final Map<String, dynamic> values = const {},
   ]) {
-    final message = values[variableName] as ChatMessage?;
-    return [if (message != null) message];
+    final value = values[variableName];
+    return switch (value) {
+      null => const [],
+      final ChatMessage message => [message],
+      final List<ChatMessage> messages => messages,
+      _ => throw ArgumentError.value(
+        value,
+        variableName,
+        'Expected a ChatMessage or List<ChatMessage>',
+      ),
+    };
   }
 
   @override

--- a/packages/langchain_core/test/agents/scratchpad_test.dart
+++ b/packages/langchain_core/test/agents/scratchpad_test.dart
@@ -1,0 +1,92 @@
+import 'package:langchain_core/agents.dart';
+import 'package:langchain_core/chat_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const assistant = AIChatMessage(
+    content: [
+      AIChatMessageReasoningBlock(reasoning: 'private reasoning'),
+      AIChatMessageToolCall(
+        id: 'call-1',
+        name: 'first',
+        argumentsRaw: '{}',
+        arguments: {},
+      ),
+      AIChatMessageToolCall(
+        id: 'call-2',
+        name: 'second',
+        argumentsRaw: '{}',
+        arguments: {},
+      ),
+    ],
+  );
+  const firstAction = AgentAction(
+    id: 'call-1',
+    tool: 'first',
+    toolInput: {},
+    messageLog: [assistant],
+  );
+  const secondAction = AgentAction(
+    id: 'call-2',
+    tool: 'second',
+    toolInput: {},
+    messageLog: [assistant],
+  );
+
+  test('emits a shared assistant log once for parallel actions', () {
+    const steps = [
+      AgentStep(action: firstAction, observation: 'one', iteration: 0),
+      AgentStep(action: secondAction, observation: 'two', iteration: 0),
+    ];
+
+    final messages = buildToolAgentScratchpad(steps);
+
+    expect(messages, [
+      assistant,
+      const ToolChatMessage(
+        toolCallId: 'call-1',
+        content: 'one',
+        name: 'first',
+      ),
+      const ToolChatMessage(
+        toolCallId: 'call-2',
+        content: 'two',
+        name: 'second',
+      ),
+    ]);
+  });
+
+  test('keeps legacy per-step behavior without iteration metadata', () {
+    const steps = [
+      AgentStep(action: firstAction, observation: 'one'),
+      AgentStep(action: secondAction, observation: 'two'),
+    ];
+
+    final messages = buildToolAgentScratchpad(steps);
+
+    expect(messages.whereType<AIChatMessage>(), [assistant, assistant]);
+  });
+
+  test('keeps legacy behavior when logs in one iteration differ', () {
+    const otherAssistant = AIChatMessage(
+      content: [AIChatMessageTextBlock(text: 'different')],
+    );
+    const steps = [
+      AgentStep(action: firstAction, observation: 'one', iteration: 0),
+      AgentStep(
+        action: AgentAction(
+          id: 'call-2',
+          tool: 'second',
+          toolInput: {},
+          messageLog: [otherAssistant],
+        ),
+        observation: 'two',
+        iteration: 0,
+      ),
+    ];
+
+    final messages = buildToolAgentScratchpad(steps);
+
+    expect(messages.whereType<AIChatMessage>(), [assistant, otherAssistant]);
+  });
+}

--- a/packages/langchain_core/test/prompts/message_placeholder_test.dart
+++ b/packages/langchain_core/test/prompts/message_placeholder_test.dart
@@ -1,0 +1,29 @@
+import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/prompts.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const placeholder = MessagePlaceholder(variableName: 'input');
+
+  test('accepts a single chat message', () {
+    final message = ChatMessage.humanText('hello');
+
+    expect(placeholder.formatMessages({'input': message}), [message]);
+  });
+
+  test('accepts an ordered list of chat messages', () {
+    final messages = <ChatMessage>[
+      ChatMessage.tool(toolCallId: 'call-1', content: 'one'),
+      ChatMessage.tool(toolCallId: 'call-2', content: 'two'),
+    ];
+
+    expect(placeholder.formatMessages({'input': messages}), messages);
+  });
+
+  test('rejects unrelated values', () {
+    expect(
+      () => placeholder.formatMessages({'input': 'hello'}),
+      throwsArgumentError,
+    );
+  });
+}

--- a/packages/langchain_openai/lib/src/agents/tools.dart
+++ b/packages/langchain_openai/lib/src/agents/tools.dart
@@ -169,16 +169,21 @@ class OpenAIToolsAgent extends BaseSingleActionAgent {
   ) {
     final dynamic agentInput;
 
-    // If there is a memory, we pass the last agent step as a function message.
+    // If there is memory, pass every tool result from the latest iteration.
     // Otherwise, we pass the input as a human message.
     if (llmChain.memory != null && intermediateSteps.isNotEmpty) {
-      final lastStep = intermediateSteps.last;
-      final functionMsg = ChatMessage.tool(
-        toolCallId: lastStep.action.id,
-        content: lastStep.observation,
-        name: lastStep.action.tool,
-      );
-      agentInput = functionMsg;
+      final toolMessages = _latestIterationSteps(intermediateSteps)
+          .map(
+            (step) => ChatMessage.tool(
+              toolCallId: step.action.id,
+              content: step.observation,
+              name: step.action.tool,
+            ),
+          )
+          .toList(growable: false);
+      agentInput = toolMessages.length == 1
+          ? toolMessages.single
+          : toolMessages;
     } else {
       agentInput = switch (inputs[agentInputKey]) {
         final String inputStr => ChatMessage.humanText(inputStr),
@@ -204,22 +209,7 @@ class OpenAIToolsAgent extends BaseSingleActionAgent {
 
   List<ChatMessage> _constructScratchPad(
     final List<AgentStep> intermediateSteps,
-  ) {
-    return [
-      ...intermediateSteps
-          .map((final s) {
-            return s.action.messageLog +
-                [
-                  ChatMessage.tool(
-                    toolCallId: s.action.id,
-                    content: s.observation,
-                    name: s.action.tool,
-                  ),
-                ];
-          })
-          .expand((final m) => m),
-    ];
-  }
+  ) => buildToolAgentScratchpad(intermediateSteps);
 
   @override
   String get agentType => 'openai-tools';
@@ -252,6 +242,16 @@ class OpenAIToolsAgent extends BaseSingleActionAgent {
         ),
     ]);
   }
+}
+
+List<AgentStep> _latestIterationSteps(final List<AgentStep> steps) {
+  final lastIteration = steps.last.iteration;
+  if (lastIteration == null) return [steps.last];
+  var start = steps.length - 1;
+  while (start > 0 && steps[start - 1].iteration == lastIteration) {
+    start -= 1;
+  }
+  return steps.sublist(start);
 }
 
 /// {@template openai_tools_agent_output_parser}

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai.dart
@@ -267,6 +267,9 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
     final PromptValue input, {
     final ChatOpenAIOptions? options,
   }) {
+    final fallbackResponseId = _uuid.v4();
+    String? streamResponseId;
+    var streamSequence = 0;
     return _client.chat.completions
         .createStream(
           createChatCompletionRequest(
@@ -276,10 +279,13 @@ class ChatOpenAI extends BaseChatModel<ChatOpenAIOptions> {
             stream: true,
           ),
         )
-        .map(
-          (final completion) =>
-              completion.toChatResult(completion.id ?? _uuid.v4()),
-        );
+        .map((final completion) {
+          streamResponseId ??= completion.id ?? fallbackResponseId;
+          return completion.toChatResult(
+            streamResponseId!,
+            streamSequence: streamSequence++,
+          );
+        });
   }
 
   /// Tokenizes the given prompt using tiktoken with the encoding used by the

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_mappers.dart
@@ -616,6 +616,12 @@ extension ChatOpenAIResponsesResponseFormatMapper
 extension ChatOpenAIResponsesReasoningEffortMapper
     on ChatOpenAIResponsesReasoningEffort {
   oai.ReasoningConfig toReasoningConfig() => switch (this) {
+    ChatOpenAIResponsesReasoningEffort.none => const oai.ReasoningConfig(
+      effort: oai.ReasoningEffort.none,
+    ),
+    ChatOpenAIResponsesReasoningEffort.minimal => const oai.ReasoningConfig(
+      effort: oai.ReasoningEffort.minimal,
+    ),
     ChatOpenAIResponsesReasoningEffort.low => const oai.ReasoningConfig(
       effort: oai.ReasoningEffort.low,
     ),
@@ -625,6 +631,12 @@ extension ChatOpenAIResponsesReasoningEffortMapper
     ChatOpenAIResponsesReasoningEffort.high => const oai.ReasoningConfig(
       effort: oai.ReasoningEffort.high,
     ),
+    ChatOpenAIResponsesReasoningEffort.xhigh => const oai.ReasoningConfig(
+      effort: oai.ReasoningEffort.xhigh,
+    ),
+    ChatOpenAIResponsesReasoningEffort.max => const oai.ReasoningConfig(
+      effort: oai.ReasoningEffort.max,
+    ),
   };
 }
 
@@ -633,6 +645,7 @@ extension ChatOpenAIResponsesServiceTierMapper
   oai.ServiceTier toServiceTier() => switch (this) {
     ChatOpenAIResponsesServiceTier.auto => oai.ServiceTier.auto,
     ChatOpenAIResponsesServiceTier.vDefault => oai.ServiceTier.defaultTier,
+    ChatOpenAIResponsesServiceTier.fast => oai.ServiceTier.fast,
   };
 }
 

--- a/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_types.dart
+++ b/packages/langchain_openai/lib/src/chat_models/chat_openai_responses_types.dart
@@ -67,7 +67,8 @@ class ChatOpenAIResponsesOptions extends ChatModelOptions {
   final bool? store;
 
   /// Constrains effort on reasoning for reasoning models.
-  /// Supported values are `low`, `medium`, and `high`.
+  /// Supported values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`,
+  /// and `max`, depending on the selected model.
   ///
   /// See https://platform.openai.com/docs/api-reference/responses/create#responses-create-reasoning
   final ChatOpenAIResponsesReasoningEffort? reasoningEffort;
@@ -349,6 +350,12 @@ class ChatOpenAIResponsesResponseFormatJsonSchema
 
 /// Constrains effort on reasoning for reasoning models.
 enum ChatOpenAIResponsesReasoningEffort {
+  /// No effort
+  none,
+
+  /// Minimal effort
+  minimal,
+
   /// Low effort
   low,
 
@@ -357,6 +364,12 @@ enum ChatOpenAIResponsesReasoningEffort {
 
   /// High effort
   high,
+
+  /// Extra-high effort
+  xhigh,
+
+  /// Maximum effort
+  max,
 }
 
 /// Specifies the latency tier to use for processing the request.
@@ -366,6 +379,9 @@ enum ChatOpenAIResponsesServiceTier {
 
   /// The request will be processed using the default service tier.
   vDefault,
+
+  /// The request uses OpenAI Fast mode for lower latency at higher cost.
+  fast,
 }
 
 /// The truncation strategy to use for the model.

--- a/packages/langchain_openai/lib/src/chat_models/mappers.dart
+++ b/packages/langchain_openai/lib/src/chat_models/mappers.dart
@@ -34,6 +34,7 @@ oai.ChatCompletionCreateRequest createChatCompletionRequest(
     reasoningEffort:
         (options?.reasoningEffort ?? defaultOptions.reasoningEffort)
             .toReasoningEffort(),
+    verbosity: (options?.verbosity ?? defaultOptions.verbosity).toVerbosity(),
     metadata: options?.metadata ?? defaultOptions.metadata,
     tools: toolsDtos,
     toolChoice: toolChoice,
@@ -139,13 +140,17 @@ extension ChatMessageListMapper on List<ChatMessage> {
   }
 
   oai.ChatMessage _mapAIMessage(final AIChatMessage aiChatMessage) {
-    return oai.ChatMessage.assistant(
+    final reasoning = _reasoningPayloadForMessage(aiChatMessage);
+    return oai.AssistantMessage(
       content: aiChatMessage.contentAsString,
       toolCalls: aiChatMessage.toolCalls.isNotEmpty
           ? aiChatMessage.toolCalls
                 .map(_mapMessageToolCall)
                 .toList(growable: false)
           : null,
+      reasoningContent: reasoning?['reasoning_content'] as String?,
+      reasoning: reasoning?['reasoning'] as String?,
+      reasoningDetails: _parseReasoningDetails(reasoning),
     );
   }
 
@@ -178,23 +183,20 @@ extension CreateChatCompletionResponseMapper on oai.ChatCompletion {
     if (msg.refusal != null && msg.refusal!.isNotEmpty) {
       throw OpenAIRefusalException(msg.refusal!);
     }
+    final reasoning = _extractReasoningPayload(msg.toJson());
 
     return ChatResult(
       id: id,
       output: AIChatMessage(
         content: [
-          if (msg.hasReasoningContent)
-            AIChatMessageReasoningBlock(
-              reasoning: msg.reasoningContent ?? msg.reasoning ?? '',
+          if (reasoning.isNotEmpty)
+            _reasoningBlock(
+              reasoning,
               id: 'openai-chat:$id:reasoning',
               index: 0,
               providerData: {
                 'openai': {
-                  'chatMessage': msg.toJson(),
-                  if (msg.reasoningDetails != null)
-                    'reasoningDetails': msg.reasoningDetails!
-                        .map((detail) => detail.toJson())
-                        .toList(growable: false),
+                  'chatCompletions': {'reasoning': reasoning},
                 },
               },
             ),
@@ -280,25 +282,32 @@ extension ChatToolChoiceMapper on ChatToolChoice {
 }
 
 extension CreateChatCompletionStreamResponseMapper on oai.ChatStreamEvent {
-  ChatResult toChatResult(final String id) {
+  ChatResult toChatResult(final String id, {final int streamSequence = 0}) {
     final choice = choices?.firstOrNull;
     final delta = choice?.delta;
 
     if (delta?.refusal != null && delta!.refusal!.isNotEmpty) {
       throw OpenAIRefusalException(delta.refusal!);
     }
+    final reasoning = delta == null
+        ? const <String, dynamic>{}
+        : _extractReasoningPayload(delta.toJson());
 
     return ChatResult(
       id: id,
       output: AIChatMessage(
         content: [
-          if (delta?.hasReasoningContent ?? false)
-            AIChatMessageReasoningBlock(
-              reasoning: delta?.reasoningContent ?? delta?.reasoning ?? '',
+          if (reasoning.isNotEmpty)
+            _reasoningBlock(
+              reasoning,
               id: 'openai-chat:$id:reasoning',
               index: 0,
               providerData: {
-                'openai': {'delta': delta?.toJson()},
+                'openai': {
+                  'chatCompletions': {
+                    'reasoningChunks': {'$streamSequence': reasoning},
+                  },
+                },
               },
             ),
           if ((delta?.content ?? '').isNotEmpty)
@@ -350,6 +359,173 @@ extension CreateChatCompletionStreamResponseMapper on oai.ChatStreamEvent {
   }
 }
 
+const _reasoningKeys = {'reasoning_content', 'reasoning', 'reasoning_details'};
+
+Map<String, dynamic> _extractReasoningPayload(
+  final Map<String, dynamic> json,
+) => {
+  for (final key in _reasoningKeys)
+    if (json.containsKey(key)) key: json[key],
+};
+
+AIChatMessageContentBlock _reasoningBlock(
+  final Map<String, dynamic> reasoning, {
+  required final String id,
+  required final int index,
+  required final Map<String, dynamic> providerData,
+}) {
+  if (_hasSubstantiveReasoning(reasoning)) {
+    return AIChatMessageReasoningBlock(
+      reasoning: _readableReasoning(reasoning),
+      id: id,
+      index: index,
+      providerData: providerData,
+    );
+  }
+  return AIChatMessageProviderMetadataBlock(
+    id: id,
+    index: index,
+    providerData: providerData,
+  );
+}
+
+bool _hasSubstantiveReasoning(final Map<String, dynamic> reasoning) {
+  for (final key in const ['reasoning_content', 'reasoning']) {
+    final value = reasoning[key];
+    if (value is String && value.isNotEmpty) return true;
+  }
+  final details = reasoning['reasoning_details'];
+  return details is List && details.isNotEmpty;
+}
+
+String _readableReasoning(final Map<String, dynamic> reasoning) {
+  for (final key in const ['reasoning_content', 'reasoning']) {
+    final value = reasoning[key];
+    if (value is String && value.isNotEmpty) return value;
+  }
+  final details = reasoning['reasoning_details'];
+  if (details is! List) return '';
+  return details
+      .whereType<Map<Object?, Object?>>()
+      .map((detail) => detail.cast<String, dynamic>())
+      .map((detail) => detail['text'] ?? detail['summary'])
+      .whereType<String>()
+      .join();
+}
+
+Map<String, dynamic>? _reasoningPayloadForMessage(final AIChatMessage message) {
+  final chunks = <int, Map<String, dynamic>>{};
+  for (final block in message.content) {
+    final openAI = _asStringMap(block.providerData['openai']);
+    final chatCompletions = _asStringMap(openAI?['chatCompletions']);
+    final complete = _asStringMap(chatCompletions?['reasoning']);
+    if (complete != null) return _extractReasoningPayload(complete);
+    final reasoningChunks = _asStringMap(chatCompletions?['reasoningChunks']);
+    if (reasoningChunks != null) {
+      for (final entry in reasoningChunks.entries) {
+        final sequence = int.tryParse(entry.key);
+        final payload = _asStringMap(entry.value);
+        if (sequence != null && payload != null) chunks[sequence] = payload;
+      }
+    }
+  }
+  if (chunks.isNotEmpty) return _accumulateReasoningChunks(chunks);
+
+  // Compatibility with provider-data shapes emitted before the canonical
+  // chatCompletions namespace was introduced. Complete chat-message payloads
+  // were duplicated across reasoning and text blocks, so use the first one.
+  for (final block in message.content) {
+    final openAI = _asStringMap(block.providerData['openai']);
+    final raw = _asStringMap(openAI?['chatMessage']);
+    if (raw == null) continue;
+    final payload = _extractReasoningPayload(raw);
+    if (!payload.containsKey('reasoning_details') &&
+        openAI!.containsKey('reasoningDetails')) {
+      payload['reasoning_details'] = openAI['reasoningDetails'];
+    }
+    if (payload.isNotEmpty) return payload;
+  }
+
+  final compatibilityChunks = <int, Map<String, dynamic>>{};
+  final seenChunks = <String>{};
+  var sequence = 0;
+  Object? redundantReasoningDetails;
+  var redundantReasoningDetailsPresent = false;
+  for (final block in message.content) {
+    final openAI = _asStringMap(block.providerData['openai']);
+    if (openAI == null) continue;
+    final raw = _asStringMap(openAI['delta']);
+    if (raw != null) {
+      final payload = _extractReasoningPayload(raw);
+      final fingerprint = jsonEncode(payload);
+      if (payload.isNotEmpty && seenChunks.add(fingerprint)) {
+        compatibilityChunks[sequence++] = payload;
+      }
+    }
+    if (openAI.containsKey('reasoningDetails')) {
+      redundantReasoningDetailsPresent = true;
+      redundantReasoningDetails = openAI['reasoningDetails'];
+    }
+  }
+  if (compatibilityChunks.isEmpty && redundantReasoningDetailsPresent) {
+    return {'reasoning_details': redundantReasoningDetails};
+  }
+  return compatibilityChunks.isEmpty
+      ? null
+      : _accumulateReasoningChunks(compatibilityChunks);
+}
+
+Map<String, dynamic> _accumulateReasoningChunks(
+  final Map<int, Map<String, dynamic>> chunks,
+) {
+  final ordered = chunks.entries.toList()
+    ..sort((first, second) => first.key.compareTo(second.key));
+  final result = <String, dynamic>{};
+  for (final key in const ['reasoning_content', 'reasoning']) {
+    var present = false;
+    var stringPresent = false;
+    final value = StringBuffer();
+    for (final chunk in ordered) {
+      if (!chunk.value.containsKey(key)) continue;
+      present = true;
+      final part = chunk.value[key];
+      if (part is String) {
+        stringPresent = true;
+        value.write(part);
+      }
+    }
+    if (present) result[key] = stringPresent ? value.toString() : null;
+  }
+  var detailsPresent = false;
+  final details = <dynamic>[];
+  for (final chunk in ordered) {
+    if (!chunk.value.containsKey('reasoning_details')) continue;
+    detailsPresent = true;
+    final chunkDetails = chunk.value['reasoning_details'];
+    if (chunkDetails is List) details.addAll(chunkDetails);
+  }
+  if (detailsPresent) result['reasoning_details'] = details;
+  return result;
+}
+
+List<oai.ReasoningDetail>? _parseReasoningDetails(
+  final Map<String, dynamic>? reasoning,
+) {
+  if (reasoning == null || !reasoning.containsKey('reasoning_details')) {
+    return null;
+  }
+  final details = reasoning['reasoning_details'];
+  if (details is! List) return null;
+  return details
+      .whereType<Map<Object?, Object?>>()
+      .map((detail) => detail.cast<String, dynamic>())
+      .map(oai.ReasoningDetail.fromJson)
+      .toList(growable: false);
+}
+
+Map<String, dynamic>? _asStringMap(final Object? value) =>
+    value is Map<Object?, Object?> ? value.cast<String, dynamic>() : null;
+
 extension ChatOpenAIResponseFormatMapper on ChatOpenAIResponseFormat {
   oai.ResponseFormat toChatCompletionResponseFormat() {
     return switch (this) {
@@ -368,10 +544,22 @@ extension ChatOpenAIResponseFormatMapper on ChatOpenAIResponseFormat {
 
 extension ChatOpenAIReasoningEffortX on ChatOpenAIReasoningEffort? {
   oai.ReasoningEffort? toReasoningEffort() => switch (this) {
-    ChatOpenAIReasoningEffort.minimal => oai.ReasoningEffort.low, // deprecated
+    ChatOpenAIReasoningEffort.none => oai.ReasoningEffort.none,
+    ChatOpenAIReasoningEffort.minimal => oai.ReasoningEffort.minimal,
     ChatOpenAIReasoningEffort.low => oai.ReasoningEffort.low,
     ChatOpenAIReasoningEffort.medium => oai.ReasoningEffort.medium,
     ChatOpenAIReasoningEffort.high => oai.ReasoningEffort.high,
+    ChatOpenAIReasoningEffort.xhigh => oai.ReasoningEffort.xhigh,
+    ChatOpenAIReasoningEffort.max => oai.ReasoningEffort.max,
+    null => null,
+  };
+}
+
+extension ChatOpenAIVerbosityX on ChatOpenAIVerbosity? {
+  oai.Verbosity? toVerbosity() => switch (this) {
+    ChatOpenAIVerbosity.low => oai.Verbosity.low,
+    ChatOpenAIVerbosity.medium => oai.Verbosity.medium,
+    ChatOpenAIVerbosity.high => oai.Verbosity.high,
     null => null,
   };
 }
@@ -380,6 +568,7 @@ extension ChatOpenAIServiceTierX on ChatOpenAIServiceTier? {
   String? toServiceTierString() => switch (this) {
     ChatOpenAIServiceTier.auto => 'auto',
     ChatOpenAIServiceTier.vDefault => 'default',
+    ChatOpenAIServiceTier.fast => 'fast',
     null => null,
   };
 }
@@ -391,5 +580,6 @@ FinishReason _mapFinishReason(final oai.FinishReason? reason) =>
       oai.FinishReason.toolCalls => FinishReason.toolCalls,
       oai.FinishReason.contentFilter => FinishReason.contentFilter,
       oai.FinishReason.functionCall => FinishReason.toolCalls,
+      oai.FinishReason.unknown => FinishReason.unspecified,
       null => FinishReason.unspecified,
     };

--- a/packages/langchain_openai/lib/src/chat_models/types.dart
+++ b/packages/langchain_openai/lib/src/chat_models/types.dart
@@ -100,7 +100,6 @@ class ChatOpenAIOptions extends ChatModelOptions {
     this.parallelToolCalls,
     this.serviceTier,
     this.user,
-    @Deprecated('verbosity is no longer supported by the OpenAI API')
     this.verbosity,
     super.concurrencyLimit,
   });
@@ -123,7 +122,8 @@ class ChatOpenAIOptions extends ChatModelOptions {
   final bool? store;
 
   /// Constrains effort on reasoning for reasoning models.
-  /// Supported values are `minimal`, `low`, `medium`, and `high`.
+  /// Supported values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`,
+  /// and `max`, depending on the selected model.
   ///
   /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort
   final ChatOpenAIReasoningEffort? reasoningEffort;
@@ -227,7 +227,6 @@ class ChatOpenAIOptions extends ChatModelOptions {
   /// Supported values are `low`, `medium`, and `high`.
   ///
   /// See https://platform.openai.com/docs/api-reference/chat/create#chat-create-verbosity
-  @Deprecated('verbosity is no longer supported by the OpenAI API')
   final ChatOpenAIVerbosity? verbosity;
 
   @override
@@ -484,8 +483,10 @@ class ChatOpenAIJsonSchema {
 
 /// Constrains effort on reasoning for reasoning models.
 enum ChatOpenAIReasoningEffort {
+  /// No reasoning effort
+  none,
+
   /// Minimal effort
-  @Deprecated('The OpenAI API no longer supports minimal. Use low instead.')
   minimal,
 
   /// Low effort
@@ -496,10 +497,15 @@ enum ChatOpenAIReasoningEffort {
 
   /// High effort
   high,
+
+  /// Extra-high effort
+  xhigh,
+
+  /// Maximum effort
+  max,
 }
 
 /// Constrains the verbosity of the model's response.
-@Deprecated('verbosity is no longer supported by the OpenAI API')
 enum ChatOpenAIVerbosity {
   /// More concise responses
   low,
@@ -520,6 +526,9 @@ enum ChatOpenAIServiceTier {
   /// The request will be processed using the default service tier with a lower
   /// uptime SLA and no latency guarantee.
   vDefault,
+
+  /// The request uses OpenAI Fast mode for lower latency at higher cost.
+  fast,
 }
 
 /// {@template openai_refusal_exception}

--- a/packages/langchain_openai/pubspec.yaml
+++ b/packages/langchain_openai/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   langchain_core: 0.4.1
   langchain_tiktoken: ^1.0.1
   meta: ^1.16.0
-  openai_dart: ^1.4.0
+  openai_dart: ^8.1.0
   uuid: ^4.5.1
 
 dev_dependencies:

--- a/packages/langchain_openai/test/agents/reasoning_replay_test.dart
+++ b/packages/langchain_openai/test/agents/reasoning_replay_test.dart
@@ -1,0 +1,193 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:langchain/langchain.dart';
+import 'package:langchain_openai/langchain_openai.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('one stream invocation uses one fallback reasoning identity', () async {
+    final client = MockClient((request) async {
+      const body = '''
+data: {"choices":[{"delta":{"reasoning_content":"first "}}]}
+
+data: {"id":"late-provider-id","choices":[{"delta":{"reasoning_content":"second"}}]}
+
+data: [DONE]
+
+''';
+      return http.Response(
+        body,
+        200,
+        headers: {'content-type': 'text/event-stream'},
+      );
+    });
+    final model = ChatOpenAI(
+      apiKey: 'test-key',
+      baseUrl: 'https://example.test/v1',
+      client: client,
+    );
+
+    final chunks = await model.stream(PromptValue.string('hello')).toList();
+    final merged = chunks.reduce((first, second) => first.concat(second));
+
+    expect(chunks.map((chunk) => chunk.id).toSet(), hasLength(1));
+    expect(
+      merged.output.content.whereType<AIChatMessageReasoningBlock>().single,
+      isA<AIChatMessageReasoningBlock>().having(
+        (block) => block.reasoning,
+        'reasoning',
+        'first second',
+      ),
+    );
+  });
+
+  for (final withMemory in [false, true]) {
+    test('replays reasoning and parallel results '
+        '${withMemory ? 'with' : 'without'} memory', () async {
+      final requests = <Map<String, dynamic>>[];
+      final executedTools = <String>[];
+      final reasoningDetails = <Map<String, dynamic>>[
+        {
+          'type': 'reasoning.text',
+          'id': 'reasoning-1',
+          'format': 'anthropic-claude-v1',
+          'index': 0,
+          'text': 'I should call both tools.',
+          'signature': 'opaque-signature',
+          'future': {
+            'nested': [true, null],
+          },
+        },
+      ];
+      final client = MockClient((request) async {
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        requests.add(body);
+        final response = requests.length == 1
+            ? {
+                'id': 'completion-1',
+                'object': 'chat.completion',
+                'created': 1,
+                'model': 'openrouter/model',
+                'choices': [
+                  {
+                    'index': 0,
+                    'message': {
+                      'role': 'assistant',
+                      'reasoning_content': 'primary reasoning',
+                      'reasoning': 'secondary reasoning',
+                      'reasoning_details': reasoningDetails,
+                      'tool_calls': [
+                        {
+                          'id': 'call-1',
+                          'type': 'function',
+                          'function': {
+                            'name': 'first_tool',
+                            'arguments': '{"input":"one"}',
+                          },
+                        },
+                        {
+                          'id': 'call-2',
+                          'type': 'function',
+                          'function': {
+                            'name': 'second_tool',
+                            'arguments': '{"input":"two"}',
+                          },
+                        },
+                      ],
+                    },
+                    'finish_reason': 'tool_calls',
+                  },
+                ],
+              }
+            : {
+                'id': 'completion-2',
+                'object': 'chat.completion',
+                'created': 2,
+                'model': 'openrouter/model',
+                'choices': [
+                  {
+                    'index': 0,
+                    'message': {'role': 'assistant', 'content': 'done'},
+                    'finish_reason': 'stop',
+                  },
+                ],
+              };
+        return http.Response(
+          jsonEncode(response),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final firstTool = StringTool.fromFunction<ToolOptions>(
+        name: 'first_tool',
+        description: 'Returns the first result.',
+        func: (input) {
+          executedTools.add('first_tool:$input');
+          return 'first result';
+        },
+      );
+      final secondTool = StringTool.fromFunction<ToolOptions>(
+        name: 'second_tool',
+        description: 'Returns the second result.',
+        func: (input) {
+          executedTools.add('second_tool:$input');
+          return 'second result';
+        },
+      );
+      final memory = withMemory
+          ? ConversationBufferMemory(returnMessages: true)
+          : null;
+      final model = ChatOpenAI(
+        apiKey: 'test-key',
+        baseUrl: 'https://example.test/v1',
+        client: client,
+        defaultOptions: const ChatOpenAIOptions(model: 'openrouter/model'),
+      );
+      final agent = ToolsAgent.fromLLMAndTools(
+        llm: model,
+        tools: [firstTool, secondTool],
+        memory: memory,
+      );
+      final executor = AgentExecutor(agent: agent);
+
+      final result = await executor.run('Use both tools.');
+
+      expect(result, 'done');
+      expect(executedTools, ['first_tool:one', 'second_tool:two']);
+      expect(requests, hasLength(2));
+      final messages = requests.last['messages'] as List<dynamic>;
+      final assistantMessages = messages
+          .whereType<Map<String, dynamic>>()
+          .where((message) => message['role'] == 'assistant')
+          .toList(growable: false);
+      final toolMessages = messages
+          .whereType<Map<String, dynamic>>()
+          .where((message) => message['role'] == 'tool')
+          .toList(growable: false);
+
+      expect(assistantMessages, hasLength(1));
+      expect(
+        assistantMessages.single['reasoning_content'],
+        'primary reasoning',
+      );
+      expect(assistantMessages.single['reasoning'], 'secondary reasoning');
+      expect(assistantMessages.single['reasoning_details'], reasoningDetails);
+      expect(
+        (assistantMessages.single['tool_calls'] as List<dynamic>).map(
+          (call) => (call as Map<String, dynamic>)['id'],
+        ),
+        ['call-1', 'call-2'],
+      );
+      expect(toolMessages.map((message) => message['tool_call_id']), [
+        'call-1',
+        'call-2',
+      ]);
+      expect(toolMessages.map((message) => message['content']), [
+        'first result',
+        'second result',
+      ]);
+    });
+  }
+}

--- a/packages/langchain_openai/test/agents/tools_test.dart
+++ b/packages/langchain_openai/test/agents/tools_test.dart
@@ -9,7 +9,6 @@ import 'package:langchain/langchain.dart'
     show AgentExecutor, ConversationBufferMemory;
 import 'package:langchain_community/langchain_community.dart';
 import 'package:langchain_core/agents.dart';
-import 'package:langchain_core/chat_models.dart';
 import 'package:langchain_core/prompts.dart';
 import 'package:langchain_core/runnables.dart';
 import 'package:langchain_core/tools.dart';
@@ -137,19 +136,9 @@ void main() {
       Runnable.mapInput(
         (final AgentPlanInput planInput) => <String, dynamic>{
           'input': planInput.inputs['input'],
-          'agent_scratchpad': planInput.intermediateSteps
-              .map((final s) {
-                return s.action.messageLog +
-                    [
-                      ChatMessage.tool(
-                        toolCallId: s.action.id,
-                        content: s.observation,
-                        name: s.action.tool,
-                      ),
-                    ];
-              })
-              .expand((final m) => m)
-              .toList(growable: false),
+          'agent_scratchpad': buildToolAgentScratchpad(
+            planInput.intermediateSteps,
+          ),
         },
       ).pipe(prompt).pipe(model).pipe(const OpenAIToolsAgentOutputParser()),
       tools: [tool],

--- a/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
+++ b/packages/langchain_openai/test/chat_models/chat_openai_responses_mappers_test.dart
@@ -345,6 +345,21 @@ void main() {
 
         expect(request.metadata, {'key': 'value'});
       });
+
+      test('maps current reasoning efforts and fast service tier', () {
+        final messages = [ChatMessage.humanText('Hello')];
+        final request = createResponseRequest(
+          messages,
+          options: const ChatOpenAIResponsesOptions(
+            reasoningEffort: ChatOpenAIResponsesReasoningEffort.max,
+            serviceTier: ChatOpenAIResponsesServiceTier.fast,
+          ),
+          defaultOptions: const ChatOpenAIResponsesOptions(model: 'gpt-5'),
+        );
+
+        expect(request.reasoning?.effort, oai.ReasoningEffort.max);
+        expect(request.serviceTier, oai.ServiceTier.fast);
+      });
     });
 
     group('ordered output blocks', () {

--- a/packages/langchain_openai/test/chat_models/mappers_content_blocks_test.dart
+++ b/packages/langchain_openai/test/chat_models/mappers_content_blocks_test.dart
@@ -1,4 +1,6 @@
 import 'package:langchain_core/chat_models.dart';
+import 'package:langchain_core/language_models.dart';
+import 'package:langchain_openai/langchain_openai.dart';
 import 'package:langchain_openai/src/chat_models/mappers.dart';
 import 'package:openai_dart/openai_dart.dart' as oai;
 import 'package:test/test.dart';
@@ -76,4 +78,262 @@ void main() {
     expect(calls.map((call) => call.id), ['call-madrid', 'call-paris']);
     expect(calls.map((call) => call.arguments['city']), ['Madrid', 'Paris']);
   });
+
+  test(
+    'replays complete OpenRouter reasoning exactly after map round-trip',
+    () {
+      final reasoningDetails = <Map<String, dynamic>>[
+        {
+          'type': 'reasoning.text',
+          'id': 'reasoning-1',
+          'format': 'anthropic-claude-v1',
+          'index': 0,
+          'text': 'detail text',
+          'signature': null,
+          'future': {
+            'nested': [true, null],
+          },
+        },
+      ];
+      final completion = oai.ChatCompletion.fromJson({
+        'id': 'completion-1',
+        'model': 'openrouter/model',
+        'choices': [
+          {
+            'message': {
+              'role': 'assistant',
+              'content': 'answer',
+              'reasoning_content': 'primary reasoning',
+              'reasoning': 'secondary reasoning',
+              'reasoning_details': reasoningDetails,
+              'tool_calls': const [
+                {
+                  'id': 'call-1',
+                  'type': 'function',
+                  'function': {
+                    'name': 'weather',
+                    'arguments': '{"city":"Madrid"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      final mapped = completion.toChatResult('completion-1').output;
+      final restored = AIChatMessage.fromMap(mapped.toMap());
+      final outbound = [restored].toChatCompletionMessages().single.toJson();
+
+      expect(mapped.contentAsString, 'answer');
+      expect(
+        mapped.content
+            .whereType<AIChatMessageReasoningBlock>()
+            .single
+            .reasoning,
+        'primary reasoning',
+      );
+      expect(outbound['reasoning_content'], 'primary reasoning');
+      expect(outbound['reasoning'], 'secondary reasoning');
+      expect(outbound['reasoning_details'], reasoningDetails);
+      expect(outbound['tool_calls'], [
+        {
+          'id': 'call-1',
+          'type': 'function',
+          'function': {'name': 'weather', 'arguments': '{"city":"Madrid"}'},
+        },
+      ]);
+    },
+  );
+
+  test('retains empty reasoning details as provider metadata', () {
+    final completion = oai.ChatCompletion.fromJson(const {
+      'id': 'completion-1',
+      'model': 'openrouter/model',
+      'choices': [
+        {
+          'message': {'role': 'assistant', 'reasoning_details': <dynamic>[]},
+        },
+      ],
+    });
+
+    final message = completion.toChatResult('completion-1').output;
+    final outbound = [message].toChatCompletionMessages().single.toJson();
+
+    expect(message.content.single, isA<AIChatMessageProviderMetadataBlock>());
+    expect(outbound, containsPair('reasoning_details', <dynamic>[]));
+  });
+
+  test('retains signature-only reasoning as an opaque reasoning block', () {
+    final detail = <String, dynamic>{
+      'type': 'reasoning.text',
+      'id': 'reasoning-1',
+      'format': 'anthropic-claude-v1',
+      'index': 0,
+      'signature': 'opaque-signature',
+    };
+    final completion = oai.ChatCompletion.fromJson({
+      'id': 'completion-1',
+      'model': 'openrouter/model',
+      'choices': [
+        {
+          'message': {
+            'role': 'assistant',
+            'reasoning_details': [detail],
+          },
+        },
+      ],
+    });
+
+    final message = completion.toChatResult('completion-1').output;
+    final reasoning = message.content
+        .whereType<AIChatMessageReasoningBlock>()
+        .single;
+    final outbound = [message].toChatCompletionMessages().single.toJson();
+
+    expect(reasoning.reasoning, isEmpty);
+    expect(outbound['reasoning_details'], [detail]);
+  });
+
+  test('streamed reasoning chunks retain aliases and detail order', () {
+    oai.ChatStreamEvent chunk(final Map<String, dynamic> delta) =>
+        oai.ChatStreamEvent.fromJson({
+          'choices': [
+            {'delta': delta},
+          ],
+        });
+
+    final firstDetail = <String, dynamic>{
+      'type': 'reasoning.text',
+      'text': 'first',
+      'signature': 'sig-1',
+    };
+    final secondDetail = <String, dynamic>{
+      'type': 'reasoning.encrypted',
+      'data': 'second',
+      'future': {'keep': true},
+    };
+    final first = chunk({
+      'reasoning_content': 'primary ',
+      'reasoning': 'secondary ',
+      'reasoning_details': [firstDetail],
+    }).toChatResult('fallback-id', streamSequence: 0).output;
+    final second = chunk({
+      'reasoning_content': 'reasoning',
+      'reasoning': 'summary',
+      'reasoning_details': [secondDetail],
+    }).toChatResult('fallback-id', streamSequence: 1).output;
+
+    final merged = first.concat(second);
+    final reasoning = merged.content
+        .whereType<AIChatMessageReasoningBlock>()
+        .single;
+    final outbound = [merged].toChatCompletionMessages().single.toJson();
+    final openAI = reasoning.providerData['openai'] as Map<String, dynamic>;
+    final chatCompletions = openAI['chatCompletions'] as Map<String, dynamic>;
+
+    expect((chatCompletions['reasoningChunks'] as Map<String, dynamic>).keys, [
+      '0',
+      '1',
+    ]);
+    expect(outbound['reasoning_content'], 'primary reasoning');
+    expect(outbound['reasoning'], 'secondary summary');
+    expect(outbound['reasoning_details'], [firstDetail, secondDetail]);
+  });
+
+  test('does not synthesize provider reasoning from a generic block', () {
+    const message = AIChatMessage(
+      content: [AIChatMessageReasoningBlock(reasoning: 'private thought')],
+    );
+
+    final outbound = [message].toChatCompletionMessages().single.toJson();
+
+    expect(outbound, isNot(contains('reasoning_content')));
+    expect(outbound, isNot(contains('reasoning')));
+    expect(outbound, isNot(contains('reasoning_details')));
+  });
+
+  test('reads the previous chatMessage provider-data shape', () {
+    const details = [
+      {'type': 'reasoning.text', 'text': 'legacy', 'signature': 'sig'},
+    ];
+    const message = AIChatMessage(
+      content: [
+        AIChatMessageReasoningBlock(
+          reasoning: 'legacy',
+          providerData: {
+            'openai': {
+              'chatMessage': {
+                'reasoning_content': 'legacy',
+                'reasoning_details': details,
+              },
+              'reasoningDetails': details,
+            },
+          },
+        ),
+        AIChatMessageTextBlock(
+          text: 'answer',
+          providerData: {
+            'openai': {
+              'chatMessage': {
+                'reasoning_content': 'legacy',
+                'reasoning_details': details,
+              },
+            },
+          },
+        ),
+      ],
+    );
+
+    final outbound = [message].toChatCompletionMessages().single.toJson();
+
+    expect(outbound['reasoning_details'], details);
+    expect(outbound['reasoning_content'], 'legacy');
+  });
+
+  test(
+    'maps current reasoning, verbosity, tier, and unknown finish values',
+    () {
+      final request = createChatCompletionRequest(
+        [ChatMessage.humanText('hello')],
+        options: const ChatOpenAIOptions(
+          reasoningEffort: ChatOpenAIReasoningEffort.minimal,
+          verbosity: ChatOpenAIVerbosity.high,
+          serviceTier: ChatOpenAIServiceTier.fast,
+        ),
+        defaultOptions: const ChatOpenAIOptions(),
+      );
+      const completion = oai.ChatCompletion(
+        id: 'completion-1',
+        object: 'chat.completion',
+        model: 'openrouter/model',
+        choices: [
+          oai.ChatChoice(
+            message: oai.AssistantMessage(content: 'answer'),
+            finishReason: oai.FinishReason.unknown,
+          ),
+        ],
+      );
+
+      expect(request.reasoningEffort, oai.ReasoningEffort.minimal);
+      expect(request.verbosity, oai.Verbosity.high);
+      expect(request.serviceTier, 'fast');
+      expect(
+        completion.toChatResult('completion-1').finishReason,
+        FinishReason.unspecified,
+      );
+      for (final entry in const {
+        ChatOpenAIReasoningEffort.none: oai.ReasoningEffort.none,
+        ChatOpenAIReasoningEffort.xhigh: oai.ReasoningEffort.xhigh,
+        ChatOpenAIReasoningEffort.max: oai.ReasoningEffort.max,
+      }.entries) {
+        final currentRequest = createChatCompletionRequest(
+          [ChatMessage.humanText('hello')],
+          options: ChatOpenAIOptions(reasoningEffort: entry.key),
+          defaultOptions: const ChatOpenAIOptions(),
+        );
+        expect(currentRequest.reasoningEffort, entry.value);
+      }
+    },
+  );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,7 +88,7 @@ melos:
         mistralai_dart: ^6.1.0
         objectbox: ^5.1.0
         ollama_dart: ^2.6.0
-        openai_dart: ^1.4.0
+        openai_dart: ^8.1.0
         path: ^1.9.1
         pinecone: ^0.7.2
         rxdart: ">=0.27.7 <0.29.0"


### PR DESCRIPTION
## Summary

- Upgrades `langchain_openai` from `openai_dart` 1.4.0 to the published 8.1.0 release.
- Preserves OpenRouter Chat Completions reasoning losslessly through complete responses, streaming, map serialization, and outbound agent replay.
- Fixes parallel-tool agent transcripts so one assistant turn is followed by every ordered tool result, both with and without conversation memory.

## Details

### Exact reasoning replay

Provider-native reasoning is stored under namespaced provider data:

- Complete responses: `providerData['openai']['chatCompletions']['reasoning']`
- Streamed deltas: `providerData['openai']['chatCompletions']['reasoningChunks'][sequence]`

The mapper retains `reasoning`, `reasoning_content`, and `reasoning_details` independently, including explicit nulls, empty arrays, signature-only details, and future nested fields. Empty reasoning metadata is represented as a provider-metadata block; actual or signature-bearing reasoning uses a reasoning block.

Outbound requests are reconstructed only from preserved OpenAI provider data. Manually created generic reasoning blocks never synthesize provider-specific request fields. The mapper also reads the previous `chatMessage`, `delta`, and `reasoningDetails` shapes as compatibility fallbacks.

Stream invocations use one stable fallback response identity and monotonic chunk sequence, including when provider events omit or introduce response IDs partway through the stream.

### Complete parallel-tool transcripts

- Adds an optional zero-based `iteration` to `AgentStep` and stamps actions from the same planning call together.
- Adds and exports `buildToolAgentScratchpad`, which emits one shared assistant message followed by every tool result for an iteration.
- Uses the helper in `ToolsAgent`, the deprecated OpenAI tools agent, and the LCEL agent example.
- Allows `MessagePlaceholder` and chat memory to accept ordered message lists.
- Stores every tool result from the latest iteration when memory is enabled.

The resulting replay is:

```text
assistant(reasoning + tool calls)
tool(result 1)
tool(result 2)
```

### Client API migration

- Maps `FinishReason.unknown` to `FinishReason.unspecified`.
- Adds `none`, `xhigh`, and `max` reasoning efforts while retaining true `minimal` semantics.
- Adds the `fast` service tier.
- Restores request mapping for the existing verbosity option.

## References

- Closes #945.
- Uses the lossless `ReasoningDetail` support released by [davidmigloz/ai_clients_dart#299](https://github.com/davidmigloz/ai_clients_dart/pull/299).
- Follows [OpenRouter's reasoning-token preservation requirements](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens).

## Test plan

- [x] Resolve `openai_dart` 8.1.0 from pub.dev with no path or Git override.
- [x] Run formatting checks.
- [x] Run full-workspace analysis across 27 packages.
- [x] Run all non-live workspace unit tests, including Firebase.
- [x] Verify exact complete and streamed reasoning round trips, aliases, empty arrays, signature-only details, and compatibility data.
- [x] Run untagged no-network `ChatOpenAI` → `ToolsAgent` → `AgentExecutor` tests with two parallel tools, both with and without `ConversationBufferMemory`.

No live API credentials are required by the added acceptance tests.
