### PR TITLE
docs(langchain_ollama): document using the Ollama wrappers with llmman

### DIFF
--- a/docs/modules/model_io/models/chat_models/integrations/ollama.md
+++ b/docs/modules/model_io/models/chat_models/integrations/ollama.md
@@ -38,6 +38,25 @@ final chatModel = ChatOllama(
 );
 ```
 
+### Using with llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434. `ChatOllama` works with it unchanged; only the base URL differs:
+
+1. Install llmman: `curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh`
+2. Start the server: `llmman serve`
+3. Pull a model, e.g. `llmman pull gemma4` (OCI registries and `hf.co/org/model` are supported)
+
+```dart
+final chatModel = ChatOllama(
+  baseUrl: 'http://localhost:17434',
+  defaultOptions: ChatOllamaOptions(
+    model: 'gemma4',
+  ),
+);
+```
+
+Tool calling, multimodal input and JSON mode work the same way as with Ollama, and `OllamaEmbeddings(baseUrl: 'http://localhost:17434')` works for embeddings.
+
 ## Usage
 
 ```dart

--- a/docs/modules/model_io/models/llms/integrations/ollama.md
+++ b/docs/modules/model_io/models/llms/integrations/ollama.md
@@ -18,6 +18,19 @@ Follow [these instructions](https://github.com/jmorganca/ollama) to set up and r
 2. Fetch a model via `ollama pull <model family>`
   * e.g., for Llama 3: `ollama pull llama3.2`
 
+### Using with llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434. `Ollama` works with it unchanged; only the base URL differs. After `llmman serve` and `llmman pull gemma4`:
+
+```dart
+final llm = Ollama(
+  baseUrl: 'http://localhost:17434',
+  defaultOptions: OllamaOptions(
+    model: 'gemma4',
+  ),
+);
+```
+
 ## Usage
 
 ```dart

--- a/packages/langchain_ollama/README.md
+++ b/packages/langchain_ollama/README.md
@@ -17,6 +17,9 @@
 - Embeddings:
   * `OllamaEmbeddings`: wrapper around Ollama Embeddings API.
 
+These also work with other servers that speak the Ollama API, such as
+[llmman](https://github.com/llmmanorg/llmman) (`baseUrl: 'http://localhost:17434'`).
+
 ## License
 
 LangChain.dart is licensed under the 

--- a/packages/langchain_ollama/lib/src/chat_models/chat_ollama/chat_ollama.dart
+++ b/packages/langchain_ollama/lib/src/chat_models/chat_ollama/chat_ollama.dart
@@ -43,6 +43,10 @@ import 'types.dart';
 /// (default Ollama API URL). But if you are running Ollama on a different
 /// one, you can override it using the [baseUrl] parameter.
 ///
+/// Other servers that speak the Ollama API, such as
+/// [llmman](https://github.com/llmmanorg/llmman), work the same way
+/// (e.g. `baseUrl: 'http://localhost:17434'`).
+///
 /// ### Call options
 ///
 /// You can configure the parameters that will be used when calling the

--- a/packages/langchain_ollama/lib/src/llms/ollama.dart
+++ b/packages/langchain_ollama/lib/src/llms/ollama.dart
@@ -38,6 +38,10 @@ import 'types.dart';
 /// (default Ollama API URL). But if you are running Ollama on a different
 /// one, you can override it using the [baseUrl] parameter.
 ///
+/// Other servers that speak the Ollama API, such as
+/// [llmman](https://github.com/llmmanorg/llmman), work the same way
+/// (e.g. `baseUrl: 'http://localhost:17434'`).
+///
 /// ### Call options
 ///
 /// You can configure the parameters that will be used when calling the


### PR DESCRIPTION
**Description:**

[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434, so `Ollama`, `ChatOllama` and `OllamaEmbeddings` already work with it via `baseUrl`. Docs-only change, no new package or class:

- `docs/.../chat_models/integrations/ollama.md`: "Using with llmman" subsection with install/serve/pull steps and a `ChatOllama(baseUrl: 'http://localhost:17434', ...)` example.
- `docs/.../llms/integrations/ollama.md`: same, shorter, for the `Ollama` LLM wrapper.
- `chat_ollama.dart` / `ollama.dart`: short dartdoc note in the existing "Ollama base URL" section.
- `packages/langchain_ollama/README.md`: one sentence that the wrappers work with other Ollama-API servers such as llmman.
- Examples pass `baseUrl` to the constructor. The pre-existing chat-docs snippet puts it inside `ChatOllamaOptions`, which does not compile; left untouched to keep this focused, happy to fix here if preferred.

**Issue:** N/A

**Dependencies:** none

**Testing:** `dart format --set-exit-if-changed` (0 changed), `dart analyze` in `packages/langchain_ollama` (no issues), `dart test test/chat_models/mappers_content_blocks_test.dart` (3/3). Not run against a live llmman server.

> AI-assisted, reviewed before submitting.
